### PR TITLE
When TRITON_CONFIGS is not defined, default to a null configuration.

### DIFF
--- a/packages/react-server/core/config.js
+++ b/packages/react-server/core/config.js
@@ -8,22 +8,19 @@
 if (SERVER_SIDE) {
 
 	module.exports = function () {
-
 		// only read out the config once, and then cache it. -sra.
 		if (null === config) {
 			/*eslint-disable no-process-env */
-			if (!process.env.TRITON_CONFIGS) {
-				/*eslint-enable no-process-env */
-				throw new Error('TRITON_CONFIGS environment variable required to start server.');
+			if (process.env.TRITON_CONFIGS) {
+				var fs = require("fs");
+				/*eslint-disable no-process-env */
+				var configFile = fs.readFileSync(process.env.TRITON_CONFIGS + "/config.json");
+				/*eslint-disable no-process-env */
+				config = Object.freeze(JSON.parse(configFile));
+			} else {
+				config = Object.freeze({});
 			}
-
-			var fs = require("fs");
-			/*eslint-disable no-process-env */
-			var configFile = fs.readFileSync(process.env.TRITON_CONFIGS + "/config.json");
-			/*eslint-disable no-process-env */
-			config = Object.freeze(JSON.parse(configFile));
 		}
-
 		return config;
 	};
 


### PR DESCRIPTION
This is a PR to address some of the errors I've had in making example sites. If you don't define TRITON_CONFIGS as an env variable, you get an error like: 

```
2016-02-11T16:54:46.959Z - error: [react-server.core.renderMiddleware] Error rendering element 0 message=TRITON_CONFIGS environment variable required to start server., stack=Error: TRITON_CONFIGS environment variable required to start server.
    at module.exports (/Users/sashaaickin/code/react-server-test-2/node_modules/react-server/target/server/config.js:17:11)
    at getNonInternalConfigs (/Users/sashaaickin/code/react-server-test-2/node_modules/react-server/target/server/renderMiddleware.js:904:19)
    at bootstrapClient (/Users/sashaaickin/code/react-server-test-2/node_modules/react-server/target/server/renderMiddleware.js:809:13)
    at writeElements (/Users/sashaaickin/code/react-server-test-2/node_modules/react-server/target/server/renderMiddleware.js:773:4)
    at doElement (/Users/sashaaickin/code/react-server-test-2/node_modules/react-server/target/server/renderMiddleware.js:601:3)
    at /Users/sashaaickin/code/react-server-test-2/node_modules/react-server/target/server/renderMiddleware.js:609:11
    at /Users/sashaaickin/code/react-server-test-2/node_modules/continuation-local-storage/context.js:74:17
    at _fulfilled (/Users/sashaaickin/code/react-server-test-2/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/Users/sashaaickin/code/react-server-test-2/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/Users/sashaaickin/code/react-server-test-2/node_modules/q/q.js:796:13)
```

If you do define `TRITON_CONFIGS` but there's no `config.json` in that directory, then you get another, similar error about the file not existing. In either case, the render messes up and doesn't send down `window.__tritonState`, so the client code never reconnects.

I'm not entirely sure if an empty `config.json` is valid, although it seems to work in my limited testing.

Longer term, I think it may be best to follow the `eslint`/`babel` convention of having a `.reactserverrc` file and/or a section in `package.json`, but for now, this makes it so you don't have to make a dummy `config.json` just to get things running.

Note that this code still throws an error if `TRITON_CONFIGS` is defined but there's no `config.json` in the directory. That's by design, as it seems like an error to me if you deliberately set the variable but don't have a config file there.