### PR TITLE
Add a .gitignore for node_modules at the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
When you `npm install` from the root directory, git thinks `node_modules` need to be checked in. This fixes that. Cheers.