### PR TITLE
Upgrade to react-dom; eliminated deprecated calls into react

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -1,5 +1,6 @@
 
 var React = require('react'),
+	ReactDOM = require('react-dom'),
 	MobileDetect = require('mobile-detect'),
 	logger = require('./logging').getLogger(__LOGGER__),
 	RequestContext = require('./context/RequestContext'),
@@ -384,7 +385,7 @@ class ClientController extends EventEmitter {
 			,   timer = logger.timer(`renderElement.individual.${name}`)
 
 			element = React.cloneElement(element, { context: this.context });
-			React.render(element, root);
+			ReactDOM.render(element, root);
 
 			totalRenderTime += timer.stop();
 
@@ -616,4 +617,3 @@ function buildContext(routes) {
 }
 
 module.exports = ClientController;
-

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -1,6 +1,7 @@
 
 var logger = require('./logging').getLogger(__LOGGER__),
 	React = require('react'),
+	ReactDOMServer = require('react-dom/server'),
 	MobileDetect = require('mobile-detect'),
 	RequestContext = require('./context/RequestContext'),
 	RequestLocalStorage = require('./util/RequestLocalStorage'),
@@ -735,7 +736,7 @@ function renderElement(res, element, context) {
 
 	try {
 		if (element !== null) {
-			html = React.renderToString(
+			html = ReactDOMServer.renderToString(
 				React.cloneElement(element, { context: context })
 			);
 		}

--- a/packages/react-server/core/test/components/FragmentDataCacheSpec.js
+++ b/packages/react-server/core/test/components/FragmentDataCacheSpec.js
@@ -3,6 +3,7 @@ var TritonAgent = require("../../TritonAgent")
 ,	superagent = require("superagent")
 ,	cheerio = require("cheerio")
 ,	React = require("react")
+,	ReactDOMServer = require("react-dom/server")
 ,	FragmentDataCache = require("../../components/FragmentDataCache")
 ,	isArray = require("lodash/lang/isArray")
 ;
@@ -35,7 +36,7 @@ describe("FragmentDataCache", () => {
 
 			TritonAgent.get(URL)
 				.then(res => {
-					var $ = cheerio.load(React.renderToStaticMarkup(<FragmentDataCache />));
+					var $ = cheerio.load(ReactDOMServer.renderToStaticMarkup(<FragmentDataCache />));
 
 					var dataStr = $("#triton-fragment-data-cache").attr("data-triton-data-cache");
 					var parsedData = JSON.parse(dataStr);
@@ -65,7 +66,7 @@ describe("FragmentDataCache", () => {
 
 			TritonAgent.get(URL)
 				.then(res => {
-					var htmlStr = React.renderToStaticMarkup(<FragmentDataCache cacheNodeId="fooBarBaz" />);
+					var htmlStr = ReactDOMServer.renderToStaticMarkup(<FragmentDataCache cacheNodeId="fooBarBaz" />);
 					var $ = cheerio.load(htmlStr);
 
 					var node
@@ -102,19 +103,19 @@ describe("FragmentDataCache", () => {
 	});
 
 	describe("FragmentDataCache.createWhenReady", () => {
-		
+
 		it("resolves with a FragmentDataCache when TritonAgent resolves", withRlsContext(done => {
 			var URL = "/describe";
 
 			TritonAgent.get(URL)
 				.then(res => {
-					// do nothing here	
+					// do nothing here
 				});
 
 			FragmentDataCache.createWhenReady().then(fragmentComponent => {
 				expect(fragmentComponent).toBeDefined();
 
-				var htmlStr = React.renderToStaticMarkup(fragmentComponent);
+				var htmlStr = ReactDOMServer.renderToStaticMarkup(fragmentComponent);
 				var $ = cheerio.load(htmlStr);
 
 				var node
@@ -150,13 +151,13 @@ describe("FragmentDataCache", () => {
 
 			TritonAgent.get(URL)
 				.then(res => {
-					// do nothing here	
+					// do nothing here
 				});
 
 			FragmentDataCache.createWhenReady({cacheNodeId: 'fooBarBaz'}).then(fragmentComponent => {
 				expect(fragmentComponent).toBeDefined();
 
-				var htmlStr = React.renderToStaticMarkup(fragmentComponent);
+				var htmlStr = ReactDOMServer.renderToStaticMarkup(fragmentComponent);
 				var $ = cheerio.load(htmlStr);
 
 				var node
@@ -196,10 +197,10 @@ describe("FragmentDataCache", () => {
 			TritonAgent.get("/error").then(res => {});
 
 			FragmentDataCache.createWhenReady().then(fragmentComponent => {
-				
+
 				expect(fragmentComponent).toBeDefined();
 
-				var htmlStr = React.renderToStaticMarkup(fragmentComponent);
+				var htmlStr = ReactDOMServer.renderToStaticMarkup(fragmentComponent);
 				var $ = cheerio.load(htmlStr);
 
 				var node
@@ -222,7 +223,7 @@ describe("FragmentDataCache", () => {
 				expect(getSingleEntry(parsedData, "/error").err).toBeDefined();
 				expect(getSingleEntry(parsedData, "/error").err.response).toBeDefined();
 				expect(getSingleEntry(parsedData, "/error").err.response.body).toBeDefined();
-				
+
 				// it should include the res.body prop only
 				expect(Object.keys(getSingleEntry(parsedData, "/describe").res).length).toBe(1);
 				expect(Object.keys(getSingleEntry(parsedData, "/error").err.response).length).toBe(1);
@@ -250,7 +251,7 @@ describe("FragmentDataCache", () => {
 
 				expect(fragmentComponent).toBeDefined();
 
-				var htmlStr = React.renderToStaticMarkup(fragmentComponent);
+				var htmlStr = ReactDOMServer.renderToStaticMarkup(fragmentComponent);
 				var $ = cheerio.load(htmlStr);
 
 				var node
@@ -294,7 +295,7 @@ describe("FragmentDataCache", () => {
 
 				expect(fragmentComponent).toBeDefined();
 
-				var htmlStr = React.renderToStaticMarkup(fragmentComponent);
+				var htmlStr = ReactDOMServer.renderToStaticMarkup(fragmentComponent);
 				var $ = cheerio.load(htmlStr);
 
 				var node


### PR DESCRIPTION
In 0.14.0, React deprecated `render`, `renderToString`, and `renderToStaticMarkup` in the `react` package and moved them to `react-dom` and `react-dom/server`.

This tiny PR upgrades all the calls I could find to the old functions, making the code forward-compatible, and it eliminates console deprecation warnings I was seeing both on server and client. Cheers!