### PR TITLE
Bumping the react peer dependencies

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -35,8 +35,8 @@
     "winston": "0.8.3"
   },
   "peerDependencies": {
-    "react": "0.14.2",
-    "react-dom": "0.14.2",
+    "react": "~0.14.2",
+    "react-dom": "~0.14.2",
     "superagent": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`react-server` currently has a peer dependency of a specific version of `react` and `react-dom` (0.14.2), which makes it incompatible with the most recent bug fix release of those packages. (Well, it makes npm claim it's incompatible, but the code works just fine if you install the latest `react(-dom)`.)

This PR allows `react-server` to be installed with any of the 0.14.x releases of `react(-dom)`, for x >= 2. It doesn't allow 0.15 (which may be overly conservative?).

I think this should also be done for `superagent`, but I wasn't as familiar with its versions and potential upgrade headaches, so I left it be for now. Thanks!