### PR TITLE
No `gulp test` in prepublish

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -8,7 +8,7 @@
   "author": "Navtej",
   "license": "Apache License 2.0",
   "scripts": {
-    "prepublish": "gulp build && gulp test",
+    "prepublish": "gulp build",
     "test": "gulp test"
   },
   "files": [


### PR DESCRIPTION
Fixes https://github.com/redfin/react-server/issues/6.

Currently redundantly testing during `npm install` in Travis.

Our actual publishing to npm also frequently times out and has to retry.

Can we just publish when travis is green or we've manually run `gulp test` ourselves?

Do we need a `publish` script that wraps testing and publishing as recommended
in https://github.com/npm/npm/issues/3059#issuecomment-12282746?