### PR TITLE
Support page rendering with non-2xx responses

### DIFF
--- a/packages/react-server/core/__tests__/integration/internalServerError/InternalServerErrorSpec.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/InternalServerErrorSpec.js
@@ -1,0 +1,43 @@
+var helper = require("../../../test/specRuntime/testHelper");
+var Browser = require("zombie");
+
+describe("A 500 internal server error page", () => {
+
+	a500("has no body by default", '/internalServerErrorNoDocument', txt => {
+		// Yikes... not good default behavior.
+		expect(txt).toBe('[object Object]\n')
+	});
+
+	a500("has a body with `haveDocument(true)`", '/internalServerErrorWithDocument', txt => {
+		expect(txt).not.toMatch('Cannot GET /internalServerErrorNoDocument')
+		expect(txt).toMatch('foo</title>')
+		expect(txt).toMatch('foo</div>')
+	});
+
+	a500("can result from an exception during `handleRoute()`", '/internalServerErrorException', txt => {
+		expect(txt).toBe('[object Object]\n')
+	}, xit); // Pending... why doesn't this work?
+
+	a500("can result from a rejection from `handleRoute()`", '/internalServerErrorRejection', txt => {
+		expect(txt).toBe('[object Object]\n')
+	});
+
+	// Pass `xit` for `the500` to mark a test as pending.
+	function a500(spec, url, callback, the500=it) {
+		the500(spec, done => new Browser()
+			.fetch(`http://localhost:${helper.getPort()}${url}`)
+			.then(res => (expect(res.status).toBe(500), res.text()))
+			.then(callback)
+			.then(done)
+		);
+	}
+
+	helper.startServerBeforeAll(__filename, [
+		"./pages/InternalServerErrorNoDocument",
+		"./pages/InternalServerErrorWithDocument",
+		"./pages/InternalServerErrorException",
+		"./pages/InternalServerErrorRejection",
+	]);
+
+	helper.stopServerAfterAll();
+});

--- a/packages/react-server/core/__tests__/integration/internalServerError/InternalServerErrorSpec.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/InternalServerErrorSpec.js
@@ -8,7 +8,7 @@ describe("A 500 internal server error page", () => {
 		expect(txt).toBe('[object Object]\n')
 	});
 
-	a500("has a body with `haveDocument(true)`", '/internalServerErrorWithDocument', txt => {
+	a500("has a body with `hasDocument: true`", '/internalServerErrorWithDocument', txt => {
 		expect(txt).not.toMatch('Cannot GET /internalServerErrorNoDocument')
 		expect(txt).toMatch('foo</title>')
 		expect(txt).toMatch('foo</div>')

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorException.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorException.js
@@ -2,9 +2,6 @@ import React from "react"
 
 export default class InternalServerErrorException {
 	handleRoute() {
-		// This is just to verify that we don't render after a real
-		// exception even if we claim that we can.
-		this.setHaveDocument(true);
 
 		// Not throwing an `Error` since this is easier to match.
 		throw "died";

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorException.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorException.js
@@ -1,0 +1,24 @@
+import React from "react"
+
+export default class InternalServerErrorException {
+	handleRoute() {
+		// This is just to verify that we don't render after a real
+		// exception even if we claim that we can.
+		this.setHaveDocument(true);
+
+		// Not throwing an `Error` since this is easier to match.
+		throw "died";
+
+		return {code: 200};
+	}
+
+	// Should never get called.
+	getTitle() {
+		return "foo";
+	}
+
+	// Should never get called.
+	getElements() {
+		return <div>foo</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorNoDocument.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorNoDocument.js
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default class InternalServerErrorException {
+	handleRoute() {
+		return {code: 500};
+	}
+
+	// Should never get called.
+	getTitle() {
+		return "foo";
+	}
+
+	// Should never get called.
+	getElements() {
+		return <div>foo</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorRejection.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorRejection.js
@@ -3,9 +3,6 @@ import Q from "q"
 
 export default class InternalServerErrorException {
 	handleRoute() {
-		// This is just to verify that we don't render after a real
-		// exception even if we claim that we can.
-		this.setHaveDocument(true);
 
 		var dfd = Q.defer();
 		dfd.reject("rejected");

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorRejection.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorRejection.js
@@ -1,0 +1,25 @@
+import React from "react"
+import Q from "q"
+
+export default class InternalServerErrorException {
+	handleRoute() {
+		// This is just to verify that we don't render after a real
+		// exception even if we claim that we can.
+		this.setHaveDocument(true);
+
+		var dfd = Q.defer();
+		dfd.reject("rejected");
+
+		return dfd.promise;
+	}
+
+	// Should never get called.
+	getTitle() {
+		return "foo";
+	}
+
+	// Should never get called.
+	getElements() {
+		return <div>foo</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorWithDocument.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorWithDocument.js
@@ -1,0 +1,16 @@
+import React from "react"
+
+export default class InternalServerErrorWithDocumentPage {
+	handleRoute() {
+		this.setHaveDocument(true);
+		return {code: 500};
+	}
+
+	getTitle() {
+		return "foo";
+	}
+
+	getElements() {
+		return <div>foo</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorWithDocument.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorWithDocument.js
@@ -2,8 +2,10 @@ import React from "react"
 
 export default class InternalServerErrorWithDocumentPage {
 	handleRoute() {
-		this.setHaveDocument(true);
-		return {code: 500};
+		return {
+			code        : 500,
+			hasDocument : true,
+		};
 	}
 
 	getTitle() {

--- a/packages/react-server/core/__tests__/integration/notFound/NotFoundSpec.js
+++ b/packages/react-server/core/__tests__/integration/notFound/NotFoundSpec.js
@@ -1,0 +1,35 @@
+var helper = require("../../../test/specRuntime/testHelper");
+var Browser = require("zombie");
+
+describe("A 404 not found page", () => {
+
+	a404("can result from no route", '/notFoundDoesNotExist', txt => {
+		expect(txt).toBe('Cannot GET /notFoundDoesNotExist\n')
+	});
+
+	a404("has no body by default", '/notFoundNoDocument', txt => {
+		expect(txt).toBe('Cannot GET /notFoundNoDocument\n')
+	});
+
+	a404("has a body with `haveDocument(true)`", '/notFoundWithDocument', txt => {
+		expect(txt).not.toMatch('Cannot GET /notFoundNoDocument')
+		expect(txt).toMatch('foo</title>')
+		expect(txt).toMatch('foo</div>')
+	});
+
+	function a404(spec, url, callback) {
+		it(spec, done => new Browser()
+			.fetch(`http://localhost:${helper.getPort()}${url}`)
+			.then(res => (expect(res.status).toBe(404), res.text()))
+			.then(callback)
+			.then(done)
+		);
+	}
+
+	helper.startServerBeforeAll(__filename, [
+		"./pages/NotFoundNoDocument",
+		"./pages/NotFoundWithDocument",
+	]);
+
+	helper.stopServerAfterAll();
+});

--- a/packages/react-server/core/__tests__/integration/notFound/NotFoundSpec.js
+++ b/packages/react-server/core/__tests__/integration/notFound/NotFoundSpec.js
@@ -11,7 +11,7 @@ describe("A 404 not found page", () => {
 		expect(txt).toBe('Cannot GET /notFoundNoDocument\n')
 	});
 
-	a404("has a body with `haveDocument(true)`", '/notFoundWithDocument', txt => {
+	a404("has a body with `hasDocument: true`", '/notFoundWithDocument', txt => {
 		expect(txt).not.toMatch('Cannot GET /notFoundNoDocument')
 		expect(txt).toMatch('foo</title>')
 		expect(txt).toMatch('foo</div>')

--- a/packages/react-server/core/__tests__/integration/notFound/pages/NotFoundNoDocument.js
+++ b/packages/react-server/core/__tests__/integration/notFound/pages/NotFoundNoDocument.js
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default class NotFoundNoDocumentPage {
+	handleRoute() {
+		return {code: 404};
+	}
+
+	// Should never get called.
+	getTitle() {
+		return "foo";
+	}
+
+	// Should never get called.
+	getElements() {
+		return <div>foo</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/integration/notFound/pages/NotFoundWithDocument.js
+++ b/packages/react-server/core/__tests__/integration/notFound/pages/NotFoundWithDocument.js
@@ -1,0 +1,16 @@
+import React from "react"
+
+export default class NotFoundWithDocumentPage {
+	handleRoute() {
+		this.setHaveDocument(true);
+		return {code: 404};
+	}
+
+	getTitle() {
+		return "foo";
+	}
+
+	getElements() {
+		return <div>foo</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/integration/notFound/pages/NotFoundWithDocument.js
+++ b/packages/react-server/core/__tests__/integration/notFound/pages/NotFoundWithDocument.js
@@ -2,8 +2,10 @@ import React from "react"
 
 export default class NotFoundWithDocumentPage {
 	handleRoute() {
-		this.setHaveDocument(true);
-		return {code: 404};
+		return {
+			code        : 404,
+			hasDocument : true,
+		};
 	}
 
 	getTitle() {

--- a/packages/react-server/core/__tests__/integration/redirectForward/PermanentRedirectWithDocumentPage.js
+++ b/packages/react-server/core/__tests__/integration/redirectForward/PermanentRedirectWithDocumentPage.js
@@ -1,0 +1,11 @@
+import React from "react"
+
+export default class PermanentRedirectWithDocumentPage {
+	handleRoute() {
+		return {code: 301, location: "/final", hasDocument: true};
+	}
+
+	getElements() {
+		return <div id="main">PermanentRedirectWithDocumentPage</div>
+	}
+}

--- a/packages/react-server/core/__tests__/integration/redirectForward/RedirectForwardSpec.js
+++ b/packages/react-server/core/__tests__/integration/redirectForward/RedirectForwardSpec.js
@@ -5,7 +5,9 @@ describe("A redirect page", () => {
 
 	helper.startServerBeforeAll(__filename, [
 		"./TemporaryRedirectPage",
+		"./TemporaryRedirectWithDocumentPage",
 		"./PermanentRedirectPage",
+		"./PermanentRedirectWithDocumentPage",
 		"./FinalPage",
 	]);
 
@@ -34,6 +36,34 @@ describe("A redirect page", () => {
 		browser.visit(`http://localhost:${helper.getPort()}/temporaryRedirect`);
 	});
 
+	it("gets the right body for a temp redirect", done => {
+		(new Browser).on("redirect", (req, res) => {
+			res.text().then(text => {
+				expect(text).toMatch('<p>Found. Redirecting to <a href="/final">/final</a></p>');
+				expect(text).not.toMatch('TemporaryRedirectPage');
+				done();
+			});
+		})
+		.visit(`http://localhost:${helper.getPort()}/temporaryRedirect`);
+	});
+
+	it("gets the right body for a temp redirect with document", done => {
+		(new Browser).on("redirect", (req, res) => {
+			res.text().then(text => {
+				expect(text).not.toMatch('<p>Found. Redirecting to <a href="/final">/final</a></p>');
+				expect(text).toMatch('TemporaryRedirectWithDocumentPage');
+				done();
+			});
+		})
+		.visit(`http://localhost:${helper.getPort()}/temporaryRedirectWithDocument`);
+	});
+
+	describe("redirects temporarily to the right page with document", () => {
+		helper.testWithDocument("/temporaryRedirectWithDocument", (document) => {
+			expect(document.location.pathname).toMatch("/final");
+		});
+	});
+
 	describe("redirects permanently to the right page", () => {
 		helper.testWithDocument("/permanentRedirect", (document) => {
 			expect(document.location.pathname).toMatch("/final");
@@ -56,6 +86,36 @@ describe("A redirect page", () => {
 		});
 		browser.visit(`http://localhost:${helper.getPort()}/permanentRedirect`);
 	});
+
+	it("gets the right body for a permanent redirect", done => {
+		(new Browser).on("redirect", (req, res) => {
+			res.text().then(text => {
+				expect(text).toMatch('<p>Moved Permanently. Redirecting to <a href="/final">/final</a></p>');
+				expect(text).not.toMatch('PermanentRedirectPage');
+				done();
+			});
+		})
+		.visit(`http://localhost:${helper.getPort()}/permanentRedirect`);
+	});
+
+	it("gets the right body for a permanent redirect with document", done => {
+		(new Browser).on("redirect", (req, res) => {
+			res.text().then(text => {
+				expect(text).not.toMatch('<p>Moved Permanently. Redirecting to <a href="/final">/final</a></p>');
+				expect(text).toMatch('PermanentRedirectWithDocumentPage');
+				done();
+			});
+		})
+		.visit(`http://localhost:${helper.getPort()}/permanentRedirectWithDocument`);
+	});
+
+	describe("redirects permanently to the right page with document", () => {
+		helper.testWithDocument("/permanentRedirectWithDocument", (document) => {
+			expect(document.location.pathname).toMatch("/final");
+		});
+	});
+
+
 });
 
 describe("A forward page", () => {

--- a/packages/react-server/core/__tests__/integration/redirectForward/TemporaryRedirectWithDocumentPage.js
+++ b/packages/react-server/core/__tests__/integration/redirectForward/TemporaryRedirectWithDocumentPage.js
@@ -1,0 +1,11 @@
+import React from "react"
+
+export default class TemporaryRedirectWithDocumentPage {
+	handleRoute() {
+		return {code: 302, location: "/final", hasDocument: true};
+	}
+
+	getElements() {
+		return <div id="main">TemporaryRedirectWithDocumentPage</div>
+	}
+}

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -168,7 +168,7 @@ class Navigator extends EventEmitter {
 			// TODO: I think that 3xx/4xx/5xx shouldn't be considered "errors" in navigateDone, but that's
 			// how the code is structured right now, and I'm changing too many things at once at the moment. -sra.
 			if (handleRouteResult.code && ((handleRouteResult.code / 100)|0) !== 2) {
-				this.emit("navigateDone", {status: handleRouteResult.code, redirectUrl: handleRouteResult.location}, null, request.getUrl(), type);
+				this.emit("navigateDone", {status: handleRouteResult.code, redirectUrl: handleRouteResult.location}, page, request.getUrl(), type);
 				return;
 			}
 			if (handleRouteResult.page) {
@@ -182,6 +182,11 @@ class Navigator extends EventEmitter {
 			this.emit('navigateDone', null, page, request.getUrl(), type);
 		}).catch(err => {
 			logger.error("Error while handling route", err);
+
+			// This was a real error.  Even if the page claims it
+			// has a document, we can't trust it at this point.
+			page.setHaveDocument(false);
+
 			this.emit('navigateDone', {status: 500}, page, request.getUrl(), type);
 		});
 

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -165,6 +165,8 @@ class Navigator extends EventEmitter {
 
 			page.setStatus(handleRouteResult.code);
 
+			page.setHasDocument(handleRouteResult.hasDocument);
+
 			// TODO: I think that 3xx/4xx/5xx shouldn't be considered "errors" in navigateDone, but that's
 			// how the code is structured right now, and I'm changing too many things at once at the moment. -sra.
 			if (handleRouteResult.code && ((handleRouteResult.code / 100)|0) !== 2) {
@@ -182,10 +184,6 @@ class Navigator extends EventEmitter {
 			this.emit('navigateDone', null, page, request.getUrl(), type);
 		}).catch(err => {
 			logger.error("Error while handling route", err);
-
-			// This was a real error.  Even if the page claims it
-			// has a document, we can't trust it at this point.
-			page.setHaveDocument(false);
 
 			this.emit('navigateDone', {status: 500}, page, request.getUrl(), type);
 		});

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -108,7 +108,7 @@ module.exports = function(server, routes) {
 				// The page can elect to proceed to render
 				// even with a non-2xx response.  If it
 				// _doesn't_ do so then we're done.
-				var done = !(page && page.getHaveDocument());
+				var done = !(page && page.getHasDocument());
 
 				if (err.status === 301 || err.status === 302 || err.status === 307) {
 					res.redirect(err.status, err.redirectUrl);

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -111,7 +111,15 @@ module.exports = function(server, routes) {
 				var done = !(page && page.getHasDocument());
 
 				if (err.status === 301 || err.status === 302 || err.status === 307) {
-					res.redirect(err.status, err.redirectUrl);
+					if (done){
+						// This adds a boilerplate body.
+						res.redirect(err.status, err.redirectUrl);
+					} else {
+						// This expects our page to
+						// render a body.  Hope they
+						// know what they're doing.
+						res.set('Location', err.redirectUrl);
+					}
 				} else if (done) {
 					if (err.status === 404) {
 						next();

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -27,7 +27,6 @@ var PAGE_MIXIN = {
 	getExpressResponse : makeGetter('expressResponse'), // Only available with `isRawResponse`.
 	getRequest         : makeGetter('request'),
 	getConfig          : key => PageConfig.get(key),
-	setHaveDocument    : makeSetter('haveDocument'), // Proceed to render with non-200 code.
 };
 
 // Each item here represents a method that page/middleware objects may override.
@@ -93,18 +92,22 @@ var PAGE_CHAIN_PROTOTYPE = {
 	setExpressRequest  : makeSetter('expressRequest'),
 	setExpressResponse : makeSetter('expressResponse'),
 	setRequest         : makeSetter('request'),
-	getHaveDocument    : makeGetter('haveDocument'),
-	setHaveDocument    : makeSetter('haveDocument'),
 
-	// TODO: Kill these.  They're only used to patch the status code
+	// TODO: Kill these?  They're only used to patch values
 	// through from navigator to renderMiddleware within triton itself.
 	// They don't need to be exposed publicly.
 	//
 	// The way to set a response code for your page is to return it from
 	// `handleRoute()` as e.g. `{code: 200}`.
 	//
+	// The way to opt-in to rendering a document for a non-2xx response
+	// code is to include `hasDocument: true` in your `handleRoute()`
+	// response object.
+	//
 	getStatus          : makeGetter('status'),
 	setStatus          : makeSetter('status'),
+	getHasDocument     : makeGetter('hasDocument'),
+	setHasDocument     : makeSetter('hasDocument'),
 };
 
 // We log all method calls on the page chain for debugging purposes.

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -27,6 +27,7 @@ var PAGE_MIXIN = {
 	getExpressResponse : makeGetter('expressResponse'), // Only available with `isRawResponse`.
 	getRequest         : makeGetter('request'),
 	getConfig          : key => PageConfig.get(key),
+	setHaveDocument    : makeSetter('haveDocument'), // Proceed to render with non-200 code.
 };
 
 // Each item here represents a method that page/middleware objects may override.
@@ -92,6 +93,8 @@ var PAGE_CHAIN_PROTOTYPE = {
 	setExpressRequest  : makeSetter('expressRequest'),
 	setExpressResponse : makeSetter('expressResponse'),
 	setRequest         : makeSetter('request'),
+	getHaveDocument    : makeGetter('haveDocument'),
+	setHaveDocument    : makeSetter('haveDocument'),
 
 	// TODO: Kill these.  They're only used to patch the status code
 	// through from navigator to renderMiddleware within triton itself.


### PR DESCRIPTION
Default behavior is unchanged.

Page may elect to proceed with ordinary rendering via `setHaveDocument()`.

Response is still be set by `handleRoute()` return value.

Example:

```javascript
handleRoute() {
    this.setHaveDocument(true);
    return { code: 404 };
}

getTitle() {
    return "404 Not Found";
}

getElements() {
    ...
}
```