### PR TITLE
Handleroute exceptions

### DIFF
--- a/packages/react-server/core/__tests__/integration/internalServerError/InternalServerErrorSpec.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/InternalServerErrorSpec.js
@@ -16,7 +16,7 @@ describe("A 500 internal server error page", () => {
 
 	a500("can result from an exception during `handleRoute()`", '/internalServerErrorException', txt => {
 		expect(txt).toBe('[object Object]\n')
-	}, xit); // Pending... why doesn't this work?
+	});
 
 	a500("can result from a rejection from `handleRoute()`", '/internalServerErrorRejection', txt => {
 		expect(txt).toBe('[object Object]\n')

--- a/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorException.js
+++ b/packages/react-server/core/__tests__/integration/internalServerError/pages/InternalServerErrorException.js
@@ -3,8 +3,9 @@ import React from "react"
 export default class InternalServerErrorException {
 	handleRoute() {
 
-		// Not throwing an `Error` since this is easier to match.
-		throw "died";
+		// Need to throw a real error here, since CLS is going to
+		// assign a property to the error to track its source context.
+		throw new Error("died");
 
 		return {code: 200};
 	}

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -161,7 +161,10 @@ class Navigator extends EventEmitter {
 
 		// call page.handleRoute(), and use the resulting code to decide how to
 		// respond.
-		page.handleRoute().then(handleRouteResult => {
+		// We call it in a promise handler so any exception that
+		// arises will get converted to a rejection that we can handle
+		// below.
+		Q().then(page.handleRoute).then(handleRouteResult => {
 
 			page.setStatus(handleRouteResult.code);
 


### PR DESCRIPTION
Pretty simple.  Funnel exceptions arising during `handleRoute()` through the navigator's `catch()`.