### PR TITLE
Fix a syntax error in the generated routes file with multiple routes

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -174,7 +174,7 @@ module.exports = {
 		}
 		routesOutput.push(`
 			},
-		}`);
+		},`);
 	}
 	routesOutput.push(`
 	}


### PR DESCRIPTION
I made a mistake in the code generation when I refactored for allowing multiple entries for `page`. Missed a comma, and any site with multiple routes breaks. Didn't see it because I was only testing with one route. Sorry!