### PR TITLE
Move common code out into a common chunk so that it can be separately cached

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -84,6 +84,10 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify) =
 		},
 		plugins: [
 			new ExtractTextPlugin("[name].css"),
+			new webpack.optimize.CommonsChunkPlugin({
+				name:"common",
+				filename: "common.js",
+			}),
 		],
 	};
 

--- a/packages/react-server-cli/src/coreJsMiddleware.js
+++ b/packages/react-server-cli/src/coreJsMiddleware.js
@@ -4,6 +4,7 @@ export default (pathToStatic) => {
 			const routeName = this.getRequest().getRouteName();
 			const baseUrl = pathToStatic || "/";
 			return [
+				`${baseUrl}common.js`,
 				`${baseUrl}${routeName}.bundle.js`,
 				{
 					type: "text/javascript",


### PR DESCRIPTION
Trying to standardize best practices for JavaScript caching. I think the steps are:

1. Pull common code (mostly `react-server` but potentially app code too) out into a common chunk that can be cached long term.
1. Add hashes to the files [according to these instructions](https://medium.com/@okonetchnikov/long-term-caching-of-static-assets-with-webpack-1ecb139adb95).
1. Make the runtime JavaScript server serve up the JavaScript with far-future expires.

This PR is just for the first step; I've tested it with the simple example, and it seems to work. If there's only one route, the `common.js` file does not contain anything, but I think that's probably ok.