### PR TITLE
Kill the requestLocalStorageNamespaces gauge

### DIFF
--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -63,9 +63,6 @@ module.exports = function(server, routes) {
 
 		initResponseCompletePromise(res);
 
-		// Just to keep an eye out for leaks.
-		logger.gauge("requestLocalStorageNamespaces", RequestLocalStorage.getCountNamespaces());
-
 		// monkey-patch `res.write` so that we don't try to write to the stream if it's
 		// already closed
 		var origWrite = res.write;


### PR DESCRIPTION
This isn't something that needs to be logged per request.

The module is exported, so users can track this themselves if necessary.