### PR TITLE
Add guards in server-side logger setters

### DIFF
--- a/packages/react-server/core/logging/server.js
+++ b/packages/react-server/core/logging/server.js
@@ -131,7 +131,11 @@ var setTimestamp = function(bool){
 	global.TIMESTAMP_TRITON_LOG_OUTPUT = bool;
 
 	// Update any loggers that are alredy set up.
-	common.forEachLogger(logger => logger.transports.file.timestamp = bool);
+	common.forEachLogger(logger => {
+		if (logger.transports.file) {
+			logger.transports.file.timestamp = bool;
+		}
+	});
 }
 
 var setColorize = function(bool){
@@ -139,7 +143,11 @@ var setColorize = function(bool){
 	global.COLORIZE_TRITON_LOG_OUTPUT = bool;
 
 	// Update any loggers that are alredy set up.
-	common.forEachLogger(logger => logger.updateColorize());
+	common.forEachLogger(logger => {
+		if (logger.updateColorize) {
+			logger.updateColorize();
+		}
+	});
 }
 
 // Default is only if we're directly attached to a terminal.


### PR DESCRIPTION
These were somehow failing during corvair client tests.  The failure is at
`require` time when `setColorize` and `setTimestamp` are both set.  Maybe
loggers leaking between client/server tests?  Not sure why this just cropped
up now, but it's easy to guard against.