### PR TITLE
Exclude tests and test code from published package

### DIFF
--- a/packages/react-server/.npmignore
+++ b/packages/react-server/.npmignore
@@ -1,3 +1,16 @@
+# Goal: include everything in target/, buildutils/, _except_ for __tests__ dirs
 
-**/__tests__/**
+# test-specific dirs
+**/__tests__/
+/target/test-temp
+/target/*/test/
 
+# source/docs dirs
+/core
+/docs
+
+# individual files
+gulpfile.js
+
+# .eslintrc, .npmignore
+.*

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -11,10 +11,6 @@
     "prepublish": "gulp build",
     "test": "gulp test"
   },
-  "files": [
-    "buildutils",
-    "target"
-  ],
   "dependencies": {
     "body-parser": "1.9.2",
     "bundle-loader": "0.5.2",


### PR DESCRIPTION
Fixing up our package.json and .npmignore so that we're not publishing tests + test helpers anymore.

I published a gist with the [diff between the old and new packages](https://gist.github.com/roblg/ac37b61e212483c60f85).

I also noticed while doing this that we were still accidentally publishing a bunch of test files. I filed #44 to address cleaning before publishing.

