### PR TITLE
Partial fix for #34. npm v2 now works as long as hot mode is disabled.

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -39,5 +39,9 @@
     "gulp-babel": "~6.1.2",
     "gulp-eslint": "0.15.0",
     "react-server-gulp-module-tagger": "0.0.8"
+  },
+  "peerDependencies": {
+    "babel-loader": "~6.2",
+    "babel-runtime": "~6.3"
   }
 }

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -39,9 +39,5 @@
     "gulp-babel": "~6.1.2",
     "gulp-eslint": "0.15.0",
     "react-server-gulp-module-tagger": "0.0.8"
-  },
-  "peerDependencies": {
-    "babel-loader": "~6.2",
-    "babel-runtime": "~6.3"
   }
 }

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -82,6 +82,16 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify) =
 				},
 			],
 		},
+		resolve: {
+			root: [
+				path.resolve("./node_modules/react-server-cli/node_modules"),
+			],
+		},
+		resolveLoader: {
+			root: [
+				path.resolve("./node_modules/react-server-cli/node_modules"),
+			],
+		},
 		plugins: [
 			new ExtractTextPlugin("[name].css"),
 		],


### PR DESCRIPTION
This is a simple partial fix for #34, adding two libraries as peer dependencies for `react-server-cli`. In both npm 2 and npm 3, I was able to do the following:

1. clone `example-reactserver`
1. `npm install`
1. (for npm 3 only) `npm install` any uninstalled peer dependencies.
1. `./node_modules/react-server-cli/bin/react-server-cli --hot=false`
1. open `localhost:3000`

And things worked. Huzzah.

I still have dependency work to do to make hot reload mode work with npm v2, so #34 should stay open.

~~(Also, note that in order to get `example-reactserver` to serve up its page correctly, [this bug fix PR](https://github.com/doug-wade/example-reactserver/pull/1) needs to be pulled.)~~ (PR was merged.)