### PR TITLE
Fix for #34, compatibility with npm 2

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -39,5 +39,9 @@
     "gulp-babel": "~6.1.2",
     "gulp-eslint": "0.15.0",
     "react-server-gulp-module-tagger": "0.0.8"
+  },
+  "peerDependencies": {
+    "babel-loader": "~6.2",
+    "babel-runtime": "~6.3"
   }
 }

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -39,9 +39,5 @@
     "gulp-babel": "~6.1.2",
     "gulp-eslint": "0.15.0",
     "react-server-gulp-module-tagger": "0.0.8"
-  },
-  "peerDependencies": {
-    "babel-loader": "~6.2",
-    "babel-runtime": "~6.3"
   }
 }

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -82,6 +82,16 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify) =
 				},
 			],
 		},
+		resolve: {
+			root: [
+				path.resolve("./node_modules/react-server-cli/node_modules"),
+			],
+		},
+		resolveLoader: {
+			root: [
+				path.resolve("./node_modules/react-server-cli/node_modules"),
+			],
+		},
 		plugins: [
 			new ExtractTextPlugin("[name].css"),
 		],


### PR DESCRIPTION
This PR should fix issue #34, react-server-cli not working with npm 2. It turns out that you can tell webpack where to look for modules using the `resolve` and `resolveLoader` keys (in addition to the current directory). This change means that webpack compilation will look in `react-server-cli/node_modules` as well as the normal paths.

I've tested this in both npm 2 and 3 in both hot and not hot modes with `example-reactserver` (after applying [example-reactserver pull request #2](https://github.com/doug-wade/example-reactserver/pull/2)).

Sorry this didn't just work out of the box; npm 3 can let you be a lot looser with dependencies in this case, which is why I didn't see that it didn't work with npm 2.