### PR TITLE
Expose `getRequest()` on the page chain

### DIFF
--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -92,6 +92,7 @@ var PAGE_CHAIN_PROTOTYPE = {
 	setExpressRequest  : makeSetter('expressRequest'),
 	setExpressResponse : makeSetter('expressResponse'),
 	setRequest         : makeSetter('request'),
+	getRequest         : makeGetter('request'),
 
 	// TODO: Kill these?  They're only used to patch values
 	// through from navigator to renderMiddleware within triton itself.


### PR DESCRIPTION
I want to be able to get at query string parameters without re-parsing.

This seems like the shortest path:

```javascript
import {getCurrentRequestContext} from "react-server";
...
const foo = getCurrentRequestContext().page.getRequest().getQuery().foo;
```