### PR TITLE
Not all browsers implement all console methods

### DIFF
--- a/packages/react-server/core/logging/client.js
+++ b/packages/react-server/core/logging/client.js
@@ -15,7 +15,7 @@ var _console = ['log','error','warn','debug','info'].reduce((m,v) => {
 	// IE9 also needs a real function for `apply` to work.
 	m[v] = (typeof console === 'undefined')
 		?() => {}
-		:Function.prototype.bind.call(console[v], console)
+		:Function.prototype.bind.call(console[v]||console.log, console)
 	return m;
 }, {});
 


### PR DESCRIPTION
Fall back to `console.log`.