### PR TITLE
Don't omit roots for empty elements

### DIFF
--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -829,6 +829,15 @@ function writeElement(res, element, i){
 	} else if (element.containerClose) {
 		res.write('</div>');
 	} else {
+		if (!element) {
+			// A falsy element was a render error.  We've gotta
+			// emit a root for it, so we'll cook up an empty
+			// element object.
+			element = {
+				attrs : {},
+				html  : '',
+			}
+		}
 		res.write(`<div data-react-server-root-id=${
 			i
 		} data-react-server-timing-offset="${

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -822,6 +822,15 @@ function writeElements(res, elements) {
 }
 
 function writeElement(res, element, i){
+	if (!element) {
+		// A falsy element was a render error.  We've gotta
+		// emit a root for it, so we'll cook up an empty
+		// element object.
+		element = {
+			attrs : {},
+			html  : '',
+		}
+	}
 	if (element.containerOpen) {
 		res.write(`<div ${PAGE_CONTAINER_NODE_ID}=${i}${
 			_.map(element.containerOpen, (v, k) => ` ${k}="${attrfy(v)}"`)
@@ -829,15 +838,6 @@ function writeElement(res, element, i){
 	} else if (element.containerClose) {
 		res.write('</div>');
 	} else {
-		if (!element) {
-			// A falsy element was a render error.  We've gotta
-			// emit a root for it, so we'll cook up an empty
-			// element object.
-			element = {
-				attrs : {},
-				html  : '',
-			}
-		}
 		res.write(`<div data-react-server-root-id=${
 			i
 		} data-react-server-timing-offset="${


### PR DESCRIPTION
Some error cases put empty strings into the elements array in
`renderMiddleware`.  Those originally turned into empty roots, but started
erroring out when root element attributes came online.  This restores original
behavior.