### PR TITLE
Request JS scripts with <link rel=preload...>

### DIFF
--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -157,6 +157,7 @@ class Navigator extends EventEmitter {
 		PageUtil.PageConfig.initFromPageWithDefaults(page, {
 			isFragment    : false,
 			isRawResponse : false,
+			preloadJS     : false,
 		});
 
 		// call page.handleRoute(), and use the resulting code to decide how to

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -421,6 +421,15 @@ function renderBaseTag(pageObject, res) {
 	});
 }
 
+function renderPreloadScripts(scripts, res) {
+	if (!scripts.length) return;
+	scripts
+		.filter(script => script && script.href)
+		.forEach(script => {
+			res.write(`<link rel="preload" href="${script.href.src || script.href}" as="script" ${script.crossOrigin ? "crossorigin" : ""} />`);
+		});
+}
+
 function renderScriptsSync(scripts, res) {
 
 	// right now, the getXXXScriptFiles methods return synchronously, no promises, so we can render
@@ -552,6 +561,10 @@ function renderScripts(pageObject, res) {
 	// Want to gather these into one list of scripts, because we care if
 	// there are any non-JS scripts in the whole bunch.
 	var scripts = pageObject.getSystemScripts().concat(pageObject.getScripts());
+
+	if (PageUtil.PageConfig.get('preloadJS')) {
+		renderPreloadScripts(scripts, res);
+	}
 
 	var thereIsAtLeastOneNonJSScript = scripts.filter(
 		script => script.type && script.type !== "text/javascript"


### PR DESCRIPTION
Something has been bugging me about [our homepage's waterfall](http://www.webpagetest.org/result/160311_WH_75c9794b7b2582da0f20fcf8dfdf087f/). Even though we use [LAB.js](http://labjs.com/) to download our JS in parallel, sometimes the requests are delayed and/or serialized. I'm not sure it's a too-many-requests-to-our-CDN problem, and I'm not sure domain-sharding would fix it.

Here's a _decent_ waterfall. The JS is downloading in parallel with the CSS, although, on connection 8, you can see that one JS file delays another. If you _squint_, you can see a delay between when connections 3 and 6 open up, and when the second JS file is requested on 8. But maybe that's just my imagination.

<img width="938" alt="waterfall1" src="https://cloud.githubusercontent.com/assets/1145262/13719742/355953cc-e7af-11e5-8c18-7e021d0ed128.png">

Waterfalls 2 is worse. There is an _obvious_ missed opportunity to download JS files, and _plenty_ of open connections.

<img width="940" alt="waterfall2" src="https://cloud.githubusercontent.com/assets/1145262/13719749/5581ae24-e7af-11e5-9a42-c36d142f5630.png">

Waterfall 3 is the worst. JS isn't _requested_ until the CSS is nearly 100% completely downloaded.
<img width="939" alt="waterfall3" src="https://cloud.githubusercontent.com/assets/1145262/13719752/5e939978-e7af-11e5-9af5-6580ffb3a26b.png">

I don't know what's causing this. Maybe I'm way wrong and this is solvable with domain-sharding. But maybe not. So why not try using [`<link rel=preload>`](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/)? Maybe it'll magically make browsers smarter and eagerly request stuff sooner.

In the long run, maybe this can _replace_ LAB.js; LAB is a _lot_ of bytes in every request, bytes that could instead be HTML or inline styles or something more valuable.

I made it a config thing in React-Server, so pages can opt in, and we can individually measure any perf boosts (or lack thereof).
