### PR TITLE
Add babel preset to share babel settings

### DIFF
--- a/packages/babel-preset-react-server/.gitignore
+++ b/packages/babel-preset-react-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/packages/babel-preset-react-server/.npmignore
+++ b/packages/babel-preset-react-server/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/packages/babel-preset-react-server/README.md
+++ b/packages/babel-preset-react-server/README.md
@@ -1,0 +1,13 @@
+# babel-preset-react-server
+
+A babel preset for working with react-server
+
+# Usage
+
+    npm install --save-dev babel-preset-react-server
+
+Then, in your .babelrc
+
+    {
+      "presets": ["babel-preset-react-server"]
+    }

--- a/packages/babel-preset-react-server/index.js
+++ b/packages/babel-preset-react-server/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  plugins: [
+    require('babel-plugin-transform-es2015-arrow-functions'),
+    require('babel-plugin-transform-es2015-block-scoping'),
+    require('babel-plugin-transform-es2015-classes'),
+    require('babel-plugin-transform-es2015-computed-properties'),
+    require('babel-plugin-transform-es2015-constants'),
+    require('babel-plugin-transform-es2015-destructuring'),
+    require('babel-plugin-transform-es2015-modules-commonjs'),
+    require('babel-plugin-transform-es2015-parameters'),
+    require('babel-plugin-transform-es2015-shorthand-properties'),
+    require('babel-plugin-transform-es2015-spread'),
+    require('babel-plugin-transform-es2015-template-literals'),
+    require('babel-plugin-transform-object-rest-spread'),
+  ],
+  presets: [
+    require('babel-preset-react'),
+  ],
+}

--- a/packages/babel-preset-react-server/package.json
+++ b/packages/babel-preset-react-server/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "babel-preset-react-server",
+  "version": "0.1.0",
+  "description": "A recommended Babel config for working with react-server",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "redfin/react-server",
+  "keywords": [
+    "babel",
+    "react-server",
+    "react",
+    "preset"
+  ],
+  "author": "Doug Wade <doug.wade@redfin.com>",
+  "license": "Apache License 2.0",
+  "publishConfig": {
+    "registry": "http://qa-compile-1.redfintest.com:4873"
+  },
+  "dependencies": {
+    "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+    "babel-plugin-transform-es2015-block-scoping": "^6.3.13",
+    "babel-plugin-transform-es2015-classes": "^6.3.13",
+    "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-constants": "^6.1.4",
+    "babel-plugin-transform-es2015-destructuring": "^6.3.13",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.3.13",
+    "babel-plugin-transform-es2015-parameters": "^6.3.13",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-spread": "^6.3.13",
+    "babel-plugin-transform-es2015-template-literals": "^6.3.13",
+    "babel-plugin-transform-object-rest-spread": "^6.3.13",
+    "babel-preset-react": "^6.5.0"
+  }
+}


### PR DESCRIPTION
Eventually intended to replace react-server/buildutils/gulp-common.js in a more reusable way (for example, with use with a command-line babel).  Should make migration to Babel 6 easier.