### PR TITLE
ClientController bug

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -563,7 +563,7 @@ class ClientController extends EventEmitter {
 		if (window.__reactServerDisableClientNavigation) return;
 
 		this._historyListener = ({state}) => {
-			var frame = state.reactServerFrame;
+			var frame = state ? state.reactServerFrame : null;
 
 			// Not our frame.
 			if (!frame) return;


### PR DESCRIPTION
There was a derefencing of state inside of the historyListener when state could be null.  This fixes that.