### PR TITLE
Only set href on base tag if it existed previously

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -271,7 +271,7 @@ class ClientController extends EventEmitter {
 					currentBaseTag = document.createElement("base");
 					document.head.appendChild(currentBaseTag);
 				}
-				currentBaseTag.href = base.href;
+				if (base.href) currentBaseTag.href = base.href;
 				if (base.target) currentBaseTag.target = base.target;
 			}
 


### PR DESCRIPTION
This comes up when we do a client navigation, where it will set the href on the base tag to "undefined".