### PR TITLE
Route framback pop through the navigator

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -119,6 +119,13 @@ class ClientController extends EventEmitter {
 				this.context.navigator.finishRoute();
 			});
 
+		} else if (this.framebackController.isActive()) {
+
+			// Tell the navigator we got this one, too.
+			this.context.navigator.ignoreCurrentNavigation();
+			this.framebackController.navigateBack();
+			this.context.navigator.finishRoute();
+
 		} else {
 
 			// If this is a secondary request (client transition)
@@ -573,22 +580,18 @@ class ClientController extends EventEmitter {
 
 			CURRENT_STATE_FRAME = frame;
 
-			if (this.framebackController.isActive()){
-				this.framebackController.navigateBack();
-			} else {
-				var frameback = (state||{}).frameback;
-				if (context) {
-					var path = this._history.getPath();
+			var frameback = (state||{}).frameback;
+			if (context) {
+				var path = this._history.getPath();
 
-					// Pass in "popstate" because this is
-					// when a user clicks the forward/back
-					// button.
-					context.navigate(
-						new ClientRequest(path, {frameback}),
-						History.events.POPSTATE
-					);
+				// Pass in "popstate" because this is
+				// when a user clicks the forward/back
+				// button.
+				context.navigate(
+					new ClientRequest(path, {frameback}),
+					History.events.POPSTATE
+				);
 
-				}
 			}
 		};
 


### PR DESCRIPTION
Need to update the navigator's current request back to outer page so, for
example, `RequestContext.getCurrentPath()` works correctly.

This is a more natural flow through the back-nav.