### PR TITLE
Dont blow away the dom on client transition

### DIFF
--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -6,9 +6,10 @@ var cookie = require("cookie"),
  */
 class ClientRequest {
 
-	constructor(url, {frameback}={}) {
+	constructor(url, {frameback, reuseDom}={}) {
 		this._url = url;
 		this._frameback = frameback;
+		this._reuseDom = reuseDom;
 	}
 
 	setRoute(route) {
@@ -21,6 +22,10 @@ class ClientRequest {
 
 	getFrameback() {
 		return this._frameback;
+	}
+
+	getReuseDom() {
+		return this._reuseDom;
 	}
 
 	getQuery() {

--- a/packages/react-server/core/__tests__/integration/containers/ContainersSpec.js
+++ b/packages/react-server/core/__tests__/integration/containers/ContainersSpec.js
@@ -17,7 +17,7 @@ describe("A page's root elements", () => {
 		}, (value, attr) => desc(
 			`can have "${attr}" attribute on ${root}`,
 			'/attributesOn'+root,
-			element => expect(element.getAttribute(attr)).toBe(value),
+			element => expect(element).toBeTruthy() && expect(element.getAttribute(attr)).toBe(value),
 			query
 		));
 	});
@@ -61,7 +61,7 @@ describe("A page's root elements", () => {
 	// Expect the contents of the first root element to be 'foo'.
 	function makeSingleDesc(prefix) {
 		return (txt, url) => desc(`${prefix} ${txt}`, url,
-			element => expect(element.innerHTML).toMatch('foo')
+			element => expect(element).toBeTruthy() && expect(element.innerHTML).toMatch('foo')
 		)
 	}
 


### PR DESCRIPTION
When doing client transitions, we can reuse the dom by letting React diff the shadow dom as it would with component re-renders, which reduces client-side render time.  This adds an option to ClientRequest that reuses the dom on client transitions.  Example use:

```
require('react-server')
  .getCurrentRequestContext()
  .navigate(new ClientRequest('http://example.com/client-transition', { reuseDom: true }, History.events.PUSHSTATE);
```