### PR TITLE
Update master title right before frameback navigation

### DIFF
--- a/packages/react-server/core/FramebackController.js
+++ b/packages/react-server/core/FramebackController.js
@@ -92,6 +92,8 @@ class FramebackController extends EventEmitter {
 		logger.debug(`Navigating to ${url}`);
 
 		this.active = true;
+		// update master title in case the title has changed since initialization
+		this.masterTitle = document.title;
 
 		this.hideMaster();
 


### PR DESCRIPTION
Get the newest document title before frameback happens. This is to pick up any potential changes to the title made by the page. I kept the `masterTitle` initialization in the constructor as fallback, since there should never be a case where we expect `this.masterTitle` to return undefined.