### PR TITLE
Preload data bundles for snappy client transitions

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -135,11 +135,6 @@ class ClientController extends EventEmitter {
 
 				RequestLocalStorage.startRequest();
 
-				// If we've got a preload bundle let's inflate
-				// it and avoid firing off a bunch of xhr
-				// requests during `handleRoute`.
-				ReactServerAgent._checkForPreload(url);
-
 				// we need to re-register the request context
 				// as a RequestLocal.
 				this.context.registerRequestLocal();

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -88,12 +88,12 @@ class ClientController extends EventEmitter {
 
 	_startRequest({request, type}) {
 
-		const url = request.getUrl();
-
 		if (request.getFrameback()){
 
 			// Tell the navigator we got this one.
 			this.context.navigator.ignoreCurrentNavigation();
+
+			var url = request.getUrl();
 
 			if (type === History.events.PUSHSTATE) {
 				// Sorry folks.  If we need to do a client

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -88,12 +88,12 @@ class ClientController extends EventEmitter {
 
 	_startRequest({request, type}) {
 
+		const url = request.getUrl();
+
 		if (request.getFrameback()){
 
 			// Tell the navigator we got this one.
 			this.context.navigator.ignoreCurrentNavigation();
-
-			var url = request.getUrl();
 
 			if (type === History.events.PUSHSTATE) {
 				// Sorry folks.  If we need to do a client
@@ -134,6 +134,11 @@ class ClientController extends EventEmitter {
 			if (this._previouslyRendered){
 
 				RequestLocalStorage.startRequest();
+
+				// If we've got a preload bundle let's inflate
+				// it and avoid firing off a bunch of xhr
+				// requests during `handleRoute`.
+				ReactServerAgent._checkForPreload(url);
 
 				// we need to re-register the request context
 				// as a RequestLocal.

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -107,11 +107,13 @@ var API = {
 	preloadDataForURL (url) {
 		if (SERVER_SIDE) throw new Error("Can't preload server-side");
 		if (!BUNDLE_CACHE[url]){
-			BUNDLE_CACHE[url] = this.get(url, BUNDLE_OPTS)
-				.then(data => data.body);
-
+			BUNDLE_CACHE[url] = API._fetchPreloadData(url);
 		}
 		return BUNDLE_CACHE[url];
+	},
+
+	_fetchPreloadData(url) {
+		return this.get(url, BUNDLE_OPTS).then(data => data.body);
 	},
 
 	_rehydratePreloadData(url) {

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -100,6 +100,7 @@ var API = {
 	},
 
 	preloadDataForURL (url) {
+		if (PRELOADS[url]) return PRELOADS[url];
 		return this.get(url, {_react_server_preload_bundle: 1})
 			.then(data => PRELOADS[url] = data.body); // eslint-disable-line no-return-assign
 	},

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -113,7 +113,7 @@ var API = {
 	},
 
 	_fetchPreloadData(url) {
-		return this.get(url, BUNDLE_OPTS).then(data => data.body);
+		return this.get(url, BUNDLE_OPTS).then(data => JSON.stringify(data.body));
 	},
 
 	_rehydratePreloadData(url) {
@@ -121,7 +121,7 @@ var API = {
 		if (!BUNDLE_CACHE[url]) return Q();
 
 		return BUNDLE_CACHE[url]
-			.then(data => API.cache().rehydrate(data));
+			.then(data => API.cache().rehydrate(JSON.parse(data)));
 	},
 
 }

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -10,6 +10,8 @@ function makeRequest (method, url) {
 	return new Request(method, url, API.cache());
 }
 
+const PRELOADS = {};
+
 var API = {
 
 	get (url, data) {
@@ -95,6 +97,17 @@ var API = {
 	 */
 	plugResponse (pluginFunc) {
 		Plugins.forResponse().add(pluginFunc);
+	},
+
+	preloadDataForURL (url) {
+		return this.get(url, {_react_server_preload_bundle: 1})
+			.then(data => PRELOADS[url] = data.body); // eslint-disable-line no-return-assign
+	},
+
+	_checkForPreload (url) {
+		if (PRELOADS[url]) {
+			API.cache().rehydrate(PRELOADS[url]);
+		}
 	},
 
 }

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -14,7 +14,7 @@ function makeRequest (method, url) {
 // REALLY don't want to accidentally cache data across requests on the server.
 // We throw an error if `preloadDataForURL` is called server-side, but it's
 // worth being doubly cautious here.
-const DATA_BUNDLE_CACHE     = SERVER_SIDE?undefined:{};
+const DATA_BUNDLE_CACHE     = SERVER_SIDE?Object.freeze({}):{};
 const DATA_BUNDLE_PARAMETER = '_react_server_data_bundle';
 const DATA_BUNDLE_OPTS      = {[DATA_BUNDLE_PARAMETER]: 1};
 

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -11,13 +11,13 @@ function makeRequest (method, url) {
 	return new Request(method, url, API.cache());
 }
 
-const BUNDLE_CACHE     = {};
-const BUNDLE_PARAMETER = '_react_server_preload_bundle';
-const BUNDLE_OPTS      = {[BUNDLE_PARAMETER]: 1};
+const DATA_BUNDLE_CACHE     = {};
+const DATA_BUNDLE_PARAMETER = '_react_server_data_bundle';
+const DATA_BUNDLE_OPTS      = {[DATA_BUNDLE_PARAMETER]: 1};
 
 var API = {
 
-	BUNDLE_PARAMETER,
+	DATA_BUNDLE_PARAMETER,
 
 	get (url, data) {
 		var req = makeRequest('GET', url);
@@ -106,21 +106,21 @@ var API = {
 
 	preloadDataForURL (url) {
 		if (SERVER_SIDE) throw new Error("Can't preload server-side");
-		if (!BUNDLE_CACHE[url]){
-			BUNDLE_CACHE[url] = API._fetchPreloadData(url);
+		if (!DATA_BUNDLE_CACHE[url]){
+			DATA_BUNDLE_CACHE[url] = API._fetchDataBundle(url);
 		}
-		return BUNDLE_CACHE[url];
+		return DATA_BUNDLE_CACHE[url];
 	},
 
-	_fetchPreloadData(url) {
-		return this.get(url, BUNDLE_OPTS).then(data => JSON.stringify(data.body));
+	_fetchDataBundle(url) {
+		return this.get(url, DATA_BUNDLE_OPTS).then(data => JSON.stringify(data.body));
 	},
 
-	_rehydratePreloadData(url) {
+	_rehydrateDataBundle(url) {
 		// If we don't have any then we can't use it.
-		if (!BUNDLE_CACHE[url]) return Q();
+		if (!DATA_BUNDLE_CACHE[url]) return Q();
 
-		return BUNDLE_CACHE[url]
+		return DATA_BUNDLE_CACHE[url]
 			.then(data => API.cache().rehydrate(JSON.parse(data)));
 	},
 

--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -11,7 +11,10 @@ function makeRequest (method, url) {
 	return new Request(method, url, API.cache());
 }
 
-const DATA_BUNDLE_CACHE     = {};
+// REALLY don't want to accidentally cache data across requests on the server.
+// We throw an error if `preloadDataForURL` is called server-side, but it's
+// worth being doubly cautious here.
+const DATA_BUNDLE_CACHE     = SERVER_SIDE?undefined:{};
 const DATA_BUNDLE_PARAMETER = '_react_server_data_bundle';
 const DATA_BUNDLE_OPTS      = {[DATA_BUNDLE_PARAMETER]: 1};
 

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -4,6 +4,7 @@ var EventEmitter = require('events').EventEmitter,
 	Router = require('routr'),
 	Q = require('q'),
 	History = require("../components/History"),
+	ReactServerAgent = require("../ReactServerAgent"),
 	PageUtil = require("../util/PageUtil");
 
 var _ = {
@@ -65,7 +66,14 @@ class Navigator extends EventEmitter {
 		// The promise returned from `startRoute()` will be rejected
 		// if we're not going to proceed, so resources will be freed.
 		//
-		this.startRoute(route, request, type).then(() => {
+		this
+		.startRoute(route, request, type)
+
+		// If we've got a preload bundle let's inflate it and avoid
+		// firing off a bunch of xhr requests during `handleRoute`.
+		.then(() => ReactServerAgent._rehydratePreloadData(request.getUrl()))
+
+		.then(() => {
 			if (this._ignoreCurrentNavigation){
 				// This is a one-time deal.
 				this._ignoreCurrentNavigation = false;

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -71,7 +71,7 @@ class Navigator extends EventEmitter {
 
 		// If we've got a preload bundle let's inflate it and avoid
 		// firing off a bunch of xhr requests during `handleRoute`.
-		.then(() => ReactServerAgent._rehydratePreloadData(request.getUrl()))
+		.then(() => ReactServerAgent._rehydrateDataBundle(request.getUrl()))
 
 		.then(() => {
 			if (this._ignoreCurrentNavigation){

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -255,8 +255,8 @@ function fragmentLifecycle () {
 function preloadBundleLifecycle () {
 	return [
 		Q(), // NOOP lead-in to prime the reduction
-		setPreloadBundleContentType,
-		writePreloadBundle,
+		setDataBundleContentType,
+		writeDataBundle,
 		handleResponseComplete,
 		endResponse,
 	];
@@ -280,7 +280,7 @@ function setContentType(req, res, context, start, pageObject) {
 	res.set('Content-Type', pageObject.getContentType());
 }
 
-function setPreloadBundleContentType(req, res) {
+function setDataBundleContentType(req, res) {
 	res.set('Content-Type', 'application/json');
 }
 
@@ -752,7 +752,7 @@ function writeResponseData(req, res, context, start, page) {
 	});
 }
 
-function writePreloadBundle(req, res) {
+function writeDataBundle(req, res) {
 
 	const cache = ReactServerAgent.cache();
 

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -205,7 +205,7 @@ function renderPage(req, res, context, start, page) {
 		lifecycleMethods = fragmentLifecycle();
 	} else if (PageUtil.PageConfig.get('isRawResponse')){
 		lifecycleMethods = rawResponseLifecycle();
-	} else if (req.query._react_server_preload_bundle) {
+	} else if (req.query[ReactServerAgent.DATA_BUNDLE_PARAMETER]) {
 		lifecycleMethods = preloadBundleLifecycle();
 	} else {
 		lifecycleMethods = pageLifecycle();

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -206,7 +206,7 @@ function renderPage(req, res, context, start, page) {
 	} else if (PageUtil.PageConfig.get('isRawResponse')){
 		lifecycleMethods = rawResponseLifecycle();
 	} else if (req.query[ReactServerAgent.DATA_BUNDLE_PARAMETER]) {
-		lifecycleMethods = preloadBundleLifecycle();
+		lifecycleMethods = dataBundleLifecycle();
 	} else {
 		lifecycleMethods = pageLifecycle();
 	}
@@ -252,7 +252,7 @@ function fragmentLifecycle () {
 	];
 }
 
-function preloadBundleLifecycle () {
+function dataBundleLifecycle () {
 	return [
 		Q(), // NOOP lead-in to prime the reduction
 		setDataBundleContentType,


### PR DESCRIPTION
Adds a method to preload data for a URL that might be navigated to via client transition.

```javascript
ReactServerAgent.preloadDataForUrl(url);
```

The data is then cached for the lifetime of the client controller.  If a client transition is made to `url` then the `ReactServerAgent` cache is pre-populated.

A new page lifecycle was added to provide bundles of preloaded data.  It just runs `handleRoute`, waits for data to resolve, and then spits out the RSA cache as a JSON blob.  It's triggered by a query-string parameter.

TODO: Invalidation.  Probably need a method to blow away the preload cache.  Maybe also one to drop data for individual URLs.