### PR TITLE
Log a couple of types of errors previously swallowed by the cli

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -250,7 +250,11 @@ module.exports = {
 							});`);
 			} else {
 				routesOutput.push(`
-							cb(unwrapEs6Module(require("${relativePathToPage}")));`);
+							try {
+								cb(unwrapEs6Module(require("${relativePathToPage}")));
+							} catch (e) {
+								console.error('Failed to load page at "${relativePathToPage}"', e.stack);
+							}`);
 			}
 			routesOutput.push(`
 						}


### PR DESCRIPTION
- Errors starting a server were re-thrown in a native promise `.then`
		rejection handler, which just caused the `.then` to return a rejected
		promise that went into the void.  Now logging via `logger.error`.
- Errors loading a page were similarly lost.  Added a try/catch with a
		`console.error`.