### PR TITLE
Root when

### DIFF
--- a/packages/react-server-test-pages/README.md
+++ b/packages/react-server-test-pages/README.md
@@ -7,5 +7,9 @@ it), it's for interactive testing during development.
 Run it thusly:
 
 ```bash
-$ gulp build && node index.js
+$ npm start
 ```
+
+Then hit http://localhost:3000/ to see what's available.
+
+Add pages in `entrypoints.js`.  Instructions are at the top.

--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -1,0 +1,12 @@
+// These show up on the index page (homepage).
+// Your `path` must be able to handle `entry`.
+// Your module must live at `pages${entry}`.
+// If you don't include a `path`, it will be created for you from `entry`.
+// Your method will be defaulted to "get".
+// The default `description` is your route _key_.
+module.exports = {
+	RootWhen: {
+		entry: "/root/when",
+		description: "<RootElement when={...}>",
+	},
+}

--- a/packages/react-server-test-pages/middleware/RequestToPort.js
+++ b/packages/react-server-test-pages/middleware/RequestToPort.js
@@ -1,0 +1,10 @@
+import {ReactServerAgent} from "react-server";
+export default class RequestToPortMiddleware {
+	handleRoute(next){
+		ReactServerAgent.plugRequest(req => {
+			// TODO: Get port dynamically?
+			req.urlPrefix('localhost:3000');
+		});
+		return next();
+	}
+}

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -11,6 +11,7 @@
   "author": "Bo Borgerson",
   "license": "Apache-2.0",
   "dependencies": {
+    "lodash": "^4.8.2",
     "q": "1.4.1",
     "react-server": "^0.1.5",
     "react-server-cli": "^0.1.5"

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -11,6 +11,7 @@
   "author": "Bo Borgerson",
   "license": "Apache-2.0",
   "dependencies": {
+    "q": "1.4.1",
     "react-server": "^0.1.5",
     "react-server-cli": "^0.1.5"
   },

--- a/packages/react-server-test-pages/pages/data/delay.js
+++ b/packages/react-server-test-pages/pages/data/delay.js
@@ -1,0 +1,16 @@
+import Q from "q";
+
+export default class DelayDataPage {
+	setConfigValues() {
+		return { isRawResponse: true };
+	}
+	getContentType() {
+		return 'application/json';
+	}
+	handleRoute(next) {
+		return Q.delay(this.getRequest().getQuery().ms||0).then(next);
+	}
+	getResponseData() {
+		return JSON.stringify({'ok': true});
+	}
+}

--- a/packages/react-server-test-pages/pages/index.js
+++ b/packages/react-server-test-pages/pages/index.js
@@ -1,5 +1,13 @@
+import entrypoints from "../entrypoints";
+import _ from "lodash";
+
 export default class IndexPage {
 	getElements() {
-		return <div>Hello, World!</div>;
+		return <div>
+			<h1>Entrypoints:</h1>
+			<ul>{_.map(entrypoints, (val, key) => <li>
+				<a href={val.entry}>{val.description||key}</a>
+			</li>)}</ul>
+		</div>
 	}
 }

--- a/packages/react-server-test-pages/pages/root/when.js
+++ b/packages/react-server-test-pages/pages/root/when.js
@@ -1,0 +1,18 @@
+import {ReactServerAgent, RootElement} from "react-server"; // eslint-disable-line
+
+export default class RootWhenPage {
+	handleRoute(next) {
+		this.data = ReactServerAgent.get('/data/delay?ms=1000');
+
+		return next();
+	}
+	getElements() {
+		return [
+			<div>Immediate</div>,
+			<RootElement when={this.data}>
+				<div>After one second data request</div>
+			</RootElement>,
+			<div>Immediate</div>,
+		]
+	}
+}

--- a/packages/react-server-test-pages/routes.js
+++ b/packages/react-server-test-pages/routes.js
@@ -1,9 +1,13 @@
+const _ = require('lodash');
+
 module.exports = {
 	// these will be applied to every page in the site.
-	middleware: [],
+	middleware: [
+		"./middleware/RequestToPort",
+	],
 
 	// this maps URLs to modules that export a Page class.
-	routes: {
+	routes: _.assign({
 		Index: {
 			path: ["/"],
 			method: "get",
@@ -14,5 +18,11 @@ module.exports = {
 			method: "get",
 			page: "./pages/data/delay",
 		},
-	},
+	}, _.reduce(require('./entrypoints'), (obj, val, key) => {
+		if (!val.method) val.method = "get";
+		if (!val.path) val.path = [val.entry];
+		val.page = `./pages${val.entry}`;
+		obj[key] = val;
+		return obj;
+	}, {})),
 }

--- a/packages/react-server-test-pages/routes.js
+++ b/packages/react-server-test-pages/routes.js
@@ -9,5 +9,10 @@ module.exports = {
 			method: "get",
 			page: "./pages/index",
 		},
+		DataDelay: {
+			path: ["/data/delay"],
+			method: "get",
+			page: "./pages/data/delay",
+		},
 	},
 }

--- a/packages/react-server/core/components/RootContainer.js
+++ b/packages/react-server/core/components/RootContainer.js
@@ -14,6 +14,7 @@ module.exports = RootContainer;
 
 RootContainer.propTypes = {
 	listen: React.PropTypes.func,
+	when: React.PropTypes.object, // A promise.
 	_isRootContainer: React.PropTypes.bool,
 }
 

--- a/packages/react-server/core/components/RootElement.js
+++ b/packages/react-server/core/components/RootElement.js
@@ -116,7 +116,7 @@ RootElement.ensureRootElementWithContainer = function(element, container) {
 		return element;
 	}
 
-        const {listen, when} = container.props;
+	const {listen, when} = container.props;
 
 	return <RootElement listen={listen} when={when}>{element}</RootElement>;
 }


### PR DESCRIPTION
The `<RootElement listen={...}>` is really concise with gated emitters, but for general stores it's easier to have the gate and the emitter separate.  It's also nice to be able to have two gates even with gated emitters.

So, this adds `<RootElement when={...}>`.  The promise can resolve with a props object, but it doesn't _need_ to.  Render-time props are the union of `listen` emitter props and `when` promise props, with the promise winning collisions.