### PR TITLE
Link bundle and reuse

### DIFF
--- a/packages/react-server-test-pages/.eslintrc
+++ b/packages/react-server-test-pages/.eslintrc
@@ -5,6 +5,9 @@
     },
     "sourceType": "module"
   },
+  "plugins": [
+    "react"
+  ],
   "rules": {
     "space-return-throw-case": 0,
     "keyword-spacing": 2

--- a/packages/react-server-test-pages/.eslintrc
+++ b/packages/react-server-test-pages/.eslintrc
@@ -5,9 +5,6 @@
     },
     "sourceType": "module"
   },
-  "plugins": [
-    "react"
-  ],
   "rules": {
     "space-return-throw-case": 0,
     "keyword-spacing": 2

--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -9,4 +9,8 @@ module.exports = {
 		entry: "/root/when",
 		description: "<RootElement when={...}>",
 	},
+	NavigationPlayground: {
+		entry: "/navigation/playground",
+		description: "Navigation playground",
+	},
 }

--- a/packages/react-server-test-pages/middleware/RequestToPort.js
+++ b/packages/react-server-test-pages/middleware/RequestToPort.js
@@ -1,10 +1,12 @@
 import {ReactServerAgent} from "react-server";
 export default class RequestToPortMiddleware {
 	handleRoute(next){
-		ReactServerAgent.plugRequest(req => {
-			// TODO: Get port dynamically?
-			req.urlPrefix('localhost:3000');
-		});
+		if (typeof window === "undefined"){
+			ReactServerAgent.plugRequest(req => {
+				// TODO: Get port dynamically?
+				req.urlPrefix('localhost:3000');
+			});
+		}
 		return next();
 	}
 }

--- a/packages/react-server-test-pages/pages/data/delay.js
+++ b/packages/react-server-test-pages/pages/data/delay.js
@@ -7,10 +7,9 @@ export default class DelayDataPage {
 	getContentType() {
 		return 'application/json';
 	}
-	handleRoute(next) {
-		return Q.delay(this.getRequest().getQuery().ms||0).then(next);
-	}
 	getResponseData() {
-		return JSON.stringify({'ok': true});
+		const { ms, val } = this.getRequest().getQuery();
+		return Q.delay(ms||0)
+			.then(() => val||JSON.stringify({'ok':true}));
 	}
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.css
+++ b/packages/react-server-test-pages/pages/navigation/playground.css
@@ -1,5 +1,6 @@
 .row {
 	border: 1px solid black;
+	height: 36px;
 }
 
 .row div {
@@ -18,6 +19,7 @@
 
 .render-indicator {
 	width: 16px;
+	line-height: 16px;
 }
 
 .page-pointer {

--- a/packages/react-server-test-pages/pages/navigation/playground.css
+++ b/packages/react-server-test-pages/pages/navigation/playground.css
@@ -1,0 +1,25 @@
+.row {
+	border: 1px solid black;
+}
+
+.row div {
+	display: inline-block;
+	padding: 4px;
+}
+
+.row-index {
+	width: 64px;
+}
+
+.row-ms {
+	width: 64px;
+	text-align: right;
+}
+
+.render-indicator {
+	width: 16px;
+}
+
+.page-pointer {
+	width: 16px;
+}

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -34,6 +34,8 @@ const ClientTransitionLink = ({row}) => <Link path={`${BASE}?page=${row}`}>Clien
 
 const FramebackLink = ({row}) => <Link frameback={true} path={`${BASE}?page=${row}`}>Frameback</Link>
 
+const ReuseDom = ({row}) => <Link reuseDom={true} path={`${BASE}?page=${row}`}>Reuse DOM</Link>
+
 class ClientRenderIndicator extends React.Component {
 	constructor(props){
 		super(props);
@@ -64,7 +66,8 @@ export default class NavigationPlaygroundPage {
 			<ClientRenderIndicator />
 			<NormalLink />
 			<ClientTransitionLink />
-			<FramebackLink/>
+			<FramebackLink />
+			<ReuseDom />
 		</RootContainer>);
 	}
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -44,19 +44,19 @@ const BundleDataAndReuseDom = ({row}) => <Link bundleData={true} reuseDom={true}
 class ClientRenderIndicator extends React.Component {
 	constructor(props){
 		super(props);
-		this.state = {emoji: "⌛️"};
+		this.state = {ready: false};
 	}
 	componentDidMount() {
-		this.setState({emoji: "✓"});
+		this.setState({ready: true});
 		window.__reactServerClientController.context
-			.onNavigateStart(() => this.setState({emoji: "⌛️"}));
+			.onNavigateStart(() => this.setState({ready: false}));
 	}
 	componentWillReceiveProps() {
-		this.setState({emoji: "✓"});
+		this.setState({ready: true});
 	}
 	render() {
 		return <div className="render-indicator">
-			{this.state.emoji}
+			{this.state.ready?"✓":"⌛️"}
 		</div>
 	}
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -37,6 +37,10 @@ const FramebackLink = ({row}) => <Link frameback={true} path={LINK(row)}>Frameba
 
 const ReuseDom = ({row}) => <Link reuseDom={true} path={LINK(row)}>Reuse DOM</Link>
 
+const BundleData = ({row}) => <Link bundleData={true} path={LINK(row)}>Bundle Data</Link>
+
+const BundleDataAndReuseDom = ({row}) => <Link bundleData={true} reuseDom={true} path={LINK(row)}>Bundle AND Reuse</Link>
+
 class ClientRenderIndicator extends React.Component {
 	constructor(props){
 		super(props);
@@ -72,8 +76,10 @@ export default class NavigationPlaygroundPage {
 			<ClientRenderIndicator />
 			<NormalLink />
 			<ClientTransitionLink />
-			<FramebackLink />
 			<ReuseDom />
+			<BundleData />
+			<BundleDataAndReuseDom />
+			<FramebackLink />
 		</RootContainer>);
 	}
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -44,6 +44,11 @@ class ClientRenderIndicator extends React.Component {
 	}
 	componentDidMount() {
 		this.setState({emoji: "✓"});
+		window.__reactServerClientController.context
+			.onNavigateStart(() => this.setState({emoji: "⌛️"}));
+	}
+	componentWillReceiveProps() {
+		this.setState({emoji: "✓"});
 	}
 	render() {
 		return <div className="render-indicator">

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -32,6 +32,8 @@ const NormalLink = ({row}) => <a href={`${BASE}?page=${row}`}>Normal Link</a>
 
 const ClientTransitionLink = ({row}) => <Link path={`${BASE}?page=${row}`}>Client Transition</Link>
 
+const FramebackLink = ({row}) => <Link frameback={true} path={`${BASE}?page=${row}`}>Frameback</Link>
+
 class ClientRenderIndicator extends React.Component {
 	constructor(props){
 		super(props);
@@ -62,6 +64,7 @@ export default class NavigationPlaygroundPage {
 			<ClientRenderIndicator />
 			<NormalLink />
 			<ClientTransitionLink />
+			<FramebackLink/>
 		</RootContainer>);
 	}
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -9,6 +9,10 @@ import {
 
 require('./playground.css');
 
+// Each row listens to `navigateStart'.
+// Give ourselves some buffer.
+require('events').EventEmitter.defaultMaxListeners = 128;
+
 const ROWS = _.range(32);
 const BASE = "/navigation/playground";
 const LINK = row => `${BASE}?page=${row}`

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -11,6 +11,7 @@ require('./playground.css');
 
 const ROWS = _.range(32);
 const BASE = "/navigation/playground";
+const LINK = row => `${BASE}?page=${row}`
 
 function GET(row) {
 	const ms  = row*16;
@@ -28,13 +29,13 @@ const PagePointer = ({page, row}) => <div className="page-pointer">
 	{+page === +row ? "➟" : ""}
 </div>;
 
-const NormalLink = ({row}) => <a href={`${BASE}?page=${row}`}>Normal Link</a>
+const NormalLink = ({row}) => <a href={LINK(row)}>Normal Link</a>
 
-const ClientTransitionLink = ({row}) => <Link path={`${BASE}?page=${row}`}>Client Transition</Link>
+const ClientTransitionLink = ({row}) => <Link path={LINK(row)}>Client Transition</Link>
 
-const FramebackLink = ({row}) => <Link frameback={true} path={`${BASE}?page=${row}`}>Frameback</Link>
+const FramebackLink = ({row}) => <Link frameback={true} path={LINK(row)}>Frameback</Link>
 
-const ReuseDom = ({row}) => <Link reuseDom={true} path={`${BASE}?page=${row}`}>Reuse DOM</Link>
+const ReuseDom = ({row}) => <Link reuseDom={true} path={LINK(row)}>Reuse DOM</Link>
 
 class ClientRenderIndicator extends React.Component {
 	constructor(props){

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-unused-vars */
+import _ from "lodash";
+import React from "react";
+import {
+	Link,
+	ReactServerAgent,
+	RootContainer,
+} from "react-server";
+
+require('./playground.css');
+
+const ROWS = _.range(32);
+const BASE = "/navigation/playground";
+
+function GET(row) {
+	const ms  = row*16;
+	const val = JSON.stringify({row, ms});
+	return ReactServerAgent
+		.get('/data/delay', {ms, val})
+		.then(res => _.assign({}, this, res.body));
+}
+
+const RowIndex = ({row}) => <div className="row-index">Row {row}</div>;
+
+const RowMS = ({ms}) => <div className="row-ms">{ms}ms</div>;
+
+const PagePointer = ({page, row}) => <div className="page-pointer">
+	{+page === +row ? "➟" : ""}
+</div>;
+
+const NormalLink = ({row}) => <a href={`${BASE}?page=${row}`}>Normal Link</a>
+
+const ClientTransitionLink = ({row}) => <Link path={`${BASE}?page=${row}`}>Client Transition</Link>
+
+class ClientRenderIndicator extends React.Component {
+	constructor(props){
+		super(props);
+		this.state = {emoji: "⌛️"};
+	}
+	componentDidMount() {
+		this.setState({emoji: "✓"});
+	}
+	render() {
+		return <div className="render-indicator">
+			{this.state.emoji}
+		</div>
+	}
+}
+
+export default class NavigationPlaygroundPage {
+	handleRoute(next) {
+		const {page} = this.getRequest().getQuery();
+		this.data = ROWS.map(GET.bind({page}));
+
+		return next();
+	}
+	getElements() {
+		return this.data.map(promise => <RootContainer when={promise} className="row">
+			<PagePointer />
+			<RowIndex />
+			<RowMS />
+			<ClientRenderIndicator />
+			<NormalLink />
+			<ClientTransitionLink />
+		</RootContainer>);
+	}
+}

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -457,9 +457,10 @@ class ClientController extends EventEmitter {
 					}
 				}
 
-				if (element.containerOpen || element.containerClose){
-					return; // Nothing left to do.
-				}
+			}
+
+			if (element.containerOpen || element.containerClose){
+				return; // Nothing left to do.
 			}
 
 			var name  = PageUtil.getElementDisplayName(element)

--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -6,10 +6,11 @@ var cookie = require("cookie"),
  */
 class ClientRequest {
 
-	constructor(url, {frameback, reuseDom}={}) {
+	constructor(url, {frameback, reuseDom, bundleData}={}) {
 		this._url = url;
 		this._frameback = frameback;
 		this._reuseDom = reuseDom;
+		this._bundleData = bundleData;
 	}
 
 	setRoute(route) {
@@ -26,6 +27,10 @@ class ClientRequest {
 
 	getReuseDom() {
 		return this._reuseDom;
+	}
+
+	getBundleData() {
+		return this._bundleData;
 	}
 
 	getQuery() {

--- a/packages/react-server/core/ExpressServerRequest.js
+++ b/packages/react-server/core/ExpressServerRequest.js
@@ -52,6 +52,10 @@ class ExpressServerRequest {
 		return this._wrappedRequest.body;
 	}
 
+	getBundleData() {
+		return false; // Not on the server.
+	}
+
 }
 
 module.exports = ExpressServerRequest;

--- a/packages/react-server/core/components/Link.jsx
+++ b/packages/react-server/core/components/Link.jsx
@@ -8,14 +8,17 @@ module.exports = React.createClass({
 	displayName: 'Link',
 
 	propTypes: {
-		path: React.PropTypes.string.isRequired,
-                frameback: React.PropTypes.bool,
+		path       : React.PropTypes.string.isRequired,
+		bundleData : React.PropTypes.bool,
+		frameback  : React.PropTypes.bool,
+		reuseDom   : React.PropTypes.bool,
 	},
 
 	getDefaultProps(){
 		return {
-			frameback: false,
-			reuseDom: false,
+			bunndleData : false,
+			frameback   : false,
+			reuseDom    : false,
 		}
 	},
 
@@ -33,9 +36,10 @@ module.exports = React.createClass({
 		if (!e.metaKey) {
 			e.preventDefault();
 			e.stopPropagation();
-			const {frameback, reuseDom} = this.props;
+			const {bundleData, frameback, reuseDom} = this.props;
 			getCurrentRequestContext().navigate(
 				new ClientRequest(this.props.path, {
+					bundleData,
 					frameback,
 					reuseDom,
 				}),

--- a/packages/react-server/core/components/Link.jsx
+++ b/packages/react-server/core/components/Link.jsx
@@ -15,6 +15,7 @@ module.exports = React.createClass({
 	getDefaultProps(){
 		return {
 			frameback: false,
+			reuseDom: false,
 		}
 	},
 
@@ -32,8 +33,12 @@ module.exports = React.createClass({
 		if (!e.metaKey) {
 			e.preventDefault();
 			e.stopPropagation();
+			const {frameback, reuseDom} = this.props;
 			getCurrentRequestContext().navigate(
-				new ClientRequest(this.props.path, {frameback:this.props.frameback}),
+				new ClientRequest(this.props.path, {
+					frameback,
+					reuseDom,
+				}),
 				History.events.PUSHSTATE
 			);
 		} else {

--- a/packages/react-server/core/components/Link.jsx
+++ b/packages/react-server/core/components/Link.jsx
@@ -16,9 +16,9 @@ module.exports = React.createClass({
 
 	getDefaultProps(){
 		return {
-			bunndleData : false,
-			frameback   : false,
-			reuseDom    : false,
+			bundleData : false,
+			frameback  : false,
+			reuseDom   : false,
 		}
 	},
 


### PR DESCRIPTION
Added two new optional props to `<Link>` elements (and the `ClientRequest` constructor):

- `reuseDom`: Don't blow away the DOM on client transition.
- `bundleData`: Fetch the data as a bundle (instead of request-by-request).

The `bundleData` option currently also _caches_ the bundle forever.  Still need to deal with invalidation.

This PR also adds a navigation playground for testing out the various forms of navigation in `react-server`.  Pretty snappy with bundling and DOM reuse. :)

Frameback needs some love.  Gonna tackle that next.