### PR TITLE
Added ability to configure react-server-cli with a .reactserverrc file or through package.json

### DIFF
--- a/packages/react-server-cli/README.md
+++ b/packages/react-server-cli/README.md
@@ -55,7 +55,7 @@ There are three ways to pass options to the CLI, through the command line, `.rea
  1. If there is a `package.json` file in the current directory with an entry named `reactServer`, it is used. Otherwise:
 1. Go back to step 2 in the parent of the current directory. Repeat until you either find a config or hit the root directory.
 
-Note that the programmatic API also searches for config files if you don't pass in an options object.
+Note that the programmatic API also searches for config files, although options sent in explicitly override the config file.
 
 ###JSON options can be set per environment
 
@@ -163,9 +163,7 @@ start(routesRelativePath, {
 })
 ```
 
-All of the values in the second argument are optional, and they have the same defaults as the corresponding CLI arguments explained above.
-
-Note that the programmatic API also searches for config files if you don't pass in an options object. If you want to disable this behavior, send in an empty object as the options object.
+All of the values in the second argument are optional, and they have the same defaults as the corresponding CLI arguments explained above. (Also note that if an option isn't present, the programmatic API will search for a config file in the same way as the CLI.)
 
 ##Future Directions
 

--- a/packages/react-server-cli/README.md
+++ b/packages/react-server-cli/README.md
@@ -43,11 +43,39 @@ It's rare to see a project these days in the JavaScript world that isn't at leas
 To take advantage of the Babel compilation, you need to install the Babel plugins and presets you want and reference them in a `.babelrc` file in your code directory. For more on the `.babelrc` format, see [its documentation here](https://babeljs.io/docs/usage/babelrc/).
 
 ##Options
-Smart defaults are the goal, and `react-server-cli` has two base modes: **development** and **production**. `react-server-cli` will determine which base mode it's in by looking at (in order):
+Smart defaults are the goal, and `react-server-cli` has two base modes: **development** and **production**. `react-server-cli` will determine which base mode it's in by looking at the NODE_ENV environment variable. If it's not "production", then `react-server-cli` will assume we are in development mode.
 
-1. If the `--production` flag was sent in, it's **production**.
-1. If `process.env.NODE_ENV` is `'production'`, it's **production**.
-1. Otherwise, the base mode is **development**.
+###Ways to add options
+
+There are three ways to pass options to the CLI, through the command line, `.reactserverrc` JSON files, or as a `reactServer` entry in `package.json` files. Once `react-server` finds one of these sources of options, it will not search for more. It searches for options this way:
+
+1. If there are any options arguments on the command line, they are used. Otherwise:
+1. `react-server-cli` looks at the current directory.
+ 1. If there is a JSON file named `.reactserverrc` in the directory, it is used. Otherwise:
+ 1. If there is a `package.json` file in the current directory with an entry named `reactServer`, it is used. Otherwise:
+1. Go back to step 2 in the parent of the current directory. Repeat until you either find a config or hit the root directory.
+
+Note that the programmatic API also searches for config files if you don't pass in an options object.
+
+###JSON options can be set per environment
+
+If you are using either `.reactserverrc` or `package.json` to set your react-server options, you can provide environment-specific values in a sub-object at the key `env`. It looks like this:
+
+```json
+{
+	"port": "5000",
+	"env": {
+		"staging": {
+			"port": "4000"
+		},
+		"production": {
+			"port": "80"
+		}
+	}
+}
+```
+
+The values in a particular environment override the main settings. In this example configuration `port` will be set to 80 if `process.env.NODE_ENV` is `production`, 4000 if `process.env.NODE_ENV` is `staging`, and 5000 for any other situation.
 
 ###Development mode: making a great DX
 
@@ -73,7 +101,7 @@ To use `react-server-cli` in this sort of production setup, follow these steps:
 
 ###Setting Options Manually
 
-While development and production mode are good starting points, you can of course choose to override any of the setup by passing in options at the command line:
+While development and production mode are good starting points, you can of course choose to override any of the setup by setting the following options:
 
 #### --routes
 The routes file to load.
@@ -136,6 +164,8 @@ start(routesRelativePath, {
 ```
 
 All of the values in the second argument are optional, and they have the same defaults as the corresponding CLI arguments explained above.
+
+Note that the programmatic API also searches for config files if you don't pass in an options object. If you want to disable this behavior, send in an empty object as the options object.
 
 ##Future Directions
 

--- a/packages/react-server-cli/README.md
+++ b/packages/react-server-cli/README.md
@@ -47,15 +47,16 @@ Smart defaults are the goal, and `react-server-cli` has two base modes: **develo
 
 ###Ways to add options
 
-There are three ways to pass options to the CLI, through the command line, `.reactserverrc` JSON files, or as a `reactServer` entry in `package.json` files. Once `react-server` finds one of these sources of options, it will not search for more. It searches for options this way:
+There are three ways to pass options to the CLI, through the command line, `.reactserverrc` JSON files, or as a `reactServer` entry in `package.json` files. It searches for options this way:
 
-1. If there are any options arguments on the command line, they are used. Otherwise:
+1. If there are any options arguments on the command line, they are used. For the options which aren't specified:
 1. `react-server-cli` looks at the current directory.
- 1. If there is a JSON file named `.reactserverrc` in the directory, it is used. Otherwise:
- 1. If there is a `package.json` file in the current directory with an entry named `reactServer`, it is used. Otherwise:
+ 1. If there is a JSON file named `.reactserverrc` in the directory, its settings are used and we skip to step #4. Otherwise:
+ 1. If there is a `package.json` file in the current directory with an entry named `reactServer`, its settings are used and we skip to step #4. Otherwise:
 1. Go back to step 2 in the parent of the current directory. Repeat until you either find a config or hit the root directory.
+1. If there are any options that still aren't specified, the defaults are used.
 
-Note that the programmatic API also searches for config files, although options sent in explicitly override the config file.
+Note that the programmatic API also searches for config files, although options sent in explicitly to the API function override the config file.
 
 ###JSON options can be set per environment
 

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -1,20 +1,6 @@
 import parseCliArgs from "./parseCliArgs"
 import {start} from "."
 
-// returns true if there are any options sent to react-server-cli
-const usesCustomArgs = () => {
-	for (let arg of process.argv) {
-		if (arg.length > 0 && arg.charAt(0) === "-") {
-			return true;
-		}
-	}
-	return false;
-}
-
 const argv = parseCliArgs();
 
-if (usesCustomArgs()) {
-	start(argv.routes, argv);
-} else {
-	start(argv.routes);
-}
+start(argv.routes, argv);

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -1,44 +1,20 @@
 import parseCliArgs from "./parseCliArgs"
+import {start} from "."
 
-// weirdly, we parse the args twice. the first time we are just looking for --production, which
-// affects the default values for the other args.
-const isProduction = parseCliArgs(false).production || (process.env.NODE_ENV === "production"); //eslint-disable-line no-process-env
-// now if production was sent in on the command line, let's set NODE_ENV if it's unset.
-if (isProduction && !process.env.NODE_ENV) { //eslint-disable-line no-process-env
-	process.env.NODE_ENV = "production"; //eslint-disable-line no-process-env
-}
-const argv = parseCliArgs(isProduction);
-
-// these require calls are after the argument parsing because we want to set NODE_ENV
-// before they get loaded.
-const logging = require("react-server").logging,
-	logger = logging.getLogger(__LOGGER__),
-	start = require(".").start;
-
-// Logging setup. This typically wouldn't be handled here,
-// but the application integration stuff isn't part of this project
-logging.setLevel('main',  argv.logLevel);
-if (!isProduction) {
-	logging.setLevel('time',  'fast');
-	logging.setLevel('gauge', 'ok');
+// returns true if there are any options sent to react-server-cli
+const usesCustomArgs = () => {
+	for (let arg of process.argv) {
+		if (arg.length > 0 && arg.charAt(0) === "-") {
+			return true;
+		}
+	}
+	return false;
 }
 
-// if the server is being launched with some bad practices for production mode, then we
-// should output a warning. if arg.jsurl is set, then hot and minify are moot, since
-// we aren't serving JavaScript & CSS at all.
-if ((!argv.jsUrl && (argv.hot || !argv.minify)) ||  process.env.NODE_ENV !== "production") { //eslint-disable-line no-process-env
-	logger.warning("PRODUCTION WARNING: the following current settings are discouraged in production environments. (If you are developing, carry on!):");
-	if (argv.hot) {
-		logger.warning("-- Hot reload is enabled. Pass --hot=false, pass --production, or set NODE_ENV=production to turn off.");
-	}
+const argv = parseCliArgs();
 
-	if (!argv.minify) {
-		logger.warning("-- Minification is disabled. Pass --minify, pass --production, or set NODE_ENV=production to turn on.");
-	}
-
-	if (process.env.NODE_ENV !== "production") { //eslint-disable-line no-process-env
-		logger.warning("-- NODE_ENV is not set to \"production\".");
-	}
+if (usesCustomArgs()) {
+	start(argv.routes, argv);
+} else {
+	start(argv.routes);
 }
-
-start(argv.routes, argv);

--- a/packages/react-server-cli/src/defaultOptions.js
+++ b/packages/react-server-cli/src/defaultOptions.js
@@ -1,0 +1,16 @@
+// these are the default options for startServer.
+export default {
+	port:3000,
+	jsPort: 3001,
+	hot: true,
+	minify: false,
+	compileOnly: false,
+	logLevel: "debug",
+	env: {
+		production: {
+			hot: false,
+			minify: true,
+			logLevel: "notice",
+		},
+	},
+}

--- a/packages/react-server-cli/src/findOptionsInFiles.js
+++ b/packages/react-server-cli/src/findOptionsInFiles.js
@@ -1,0 +1,41 @@
+// implements the search algorithm for finding react-server config files. see
+// the README.md for a description.
+import path from "path"
+import fs from "fs"
+
+const REACT_SERVER_RC = ".reactserverrc";
+const PACKAGE_JSON = "package.json";
+
+// returns an options object that represents the **first** config file found in the
+// search path. if none are found, returns null.
+// as described in the README, this method starts at dir, and for each directory
+// looks first for a .reactserverrc file, then for a "reactServer" section of
+// the package.json. if it finds neither, it goes up a directory and looks again.
+// it returns the contents of the first config file found; it never merges multiple
+// configurations.
+export default (dir = process.cwd()) => {
+	do {
+		let reactServerRc = null;
+		try {
+			// readFileSync throws if the file doesn't exist.
+			reactServerRc = fs.readFileSync(path.join(dir, REACT_SERVER_RC));
+		} catch (e) {} //eslint-disable-line no-empty
+		if (reactServerRc) {
+			return JSON.parse(reactServerRc);
+		}
+
+		let packageJson = null;
+		try {
+			packageJson = fs.readFileSync(path.join(dir, PACKAGE_JSON));
+		} catch (e) {} //eslint-disable-line no-empty
+
+		if (packageJson) {
+			const parsedPackageJson = JSON.parse(packageJson);
+			if (parsedPackageJson.reactServer) {
+				return parsedPackageJson.reactServer;
+			}
+		}
+	} while (dir !== (dir = path.dirname(dir)))
+
+	return null;
+}

--- a/packages/react-server-cli/src/mergeOptions.js
+++ b/packages/react-server-cli/src/mergeOptions.js
@@ -1,0 +1,29 @@
+// takes in an arrray of options objects for `startServer.js`, and returns a merged
+// version of them. it essentially acts like Object.assign(), so options objects
+// later in the argument list override the properties of ones earlier in the list.
+// like Object.assign, the merging is done on a property-by-property basis;
+// they are not merged deeply.
+// the only thing that makes this not exactly Object.assign is that options objects
+// can have an env attribute that contains overrides for different values for NODE_ENV.
+const merge = (options, ...optionsToBeMerged) => {
+	let optionsCopy = Object.assign({}, options);
+
+	// first merge in any overrides based on the current node environment.
+	if (optionsCopy.env) {
+		const env = optionsCopy.env;
+		delete optionsCopy.env;
+		// if there's an override for the current NODE_ENV, let's use it.
+		if (env[process.env.NODE_ENV]) { //eslint-disable-line no-process-env
+			optionsCopy = merge(optionsCopy, env[process.env.NODE_ENV]); //eslint-disable-line no-process-env
+		}
+	}
+
+	// now merge in the rest of the options objects.
+	if (optionsToBeMerged.length > 0) {
+		return Object.assign(optionsCopy, merge(...optionsToBeMerged));
+	} else {
+		return optionsCopy;
+	}
+}
+
+export default merge;

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -19,6 +19,9 @@ export default (args = process.argv) => {
 		.option("h", {
 			alias: "hot",
 			describe: "Load the app so that it can be hot reloaded in the browser. Default is false in production mode, true otherwise.",
+			// we use undefined as the default because unlike other types, booleans
+			// default to "false", making it impossible to distinguish between not
+			// setting the option at the command line and setting --option=false.
 			default: undefined,
 			type: "boolean",
 		})
@@ -46,6 +49,9 @@ export default (args = process.argv) => {
 		.demand(0)
 		.argv;
 
+	// we remove all the options that have undefined as their value; those are the
+	// ones that weren't on the command line, and we don't want them to override
+	// defaults or config files.
 	return camelize(removeUndefinedValues(parsedArgs));
 }
 

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -1,6 +1,6 @@
 import yargs from "yargs"
 
-export default (isProduction, args = process.argv) => {
+export default (args = process.argv) => {
 	var parsedArgs = yargs(args)
 		.usage('Usage: $0 [options]')
 		.option("routes", {
@@ -9,52 +9,56 @@ export default (isProduction, args = process.argv) => {
 		})
 		.option("p", {
 			alias: "port",
-			default: 3000,
-			describe: "Port to start listening for react-server",
+			describe: "Port to start listening for react-server. Default is 3000.",
 			type: "number",
 		})
 		.option("js-port", {
-			default: 3001,
-			describe: "Port to start listening for react-server's JavaScript",
+			describe: "Port to start listening for react-server's JavaScript. Default is 3001.",
 			type: "number",
 		})
 		.option("h", {
 			alias: "hot",
-			default: !isProduction,
 			describe: "Load the app so that it can be hot reloaded in the browser. Default is false in production mode, true otherwise.",
+			default: undefined,
 			type: "boolean",
 		})
 		.option("m", {
 			alias: "minify",
-			default: isProduction,
 			describe: "Optimize client JS when option is present. Takes a bit longer to compile. Default is true in production mode, false otherwise.",
+			default: undefined,
 			type: "boolean",
 		})
 		.option("log-level", {
-			default: isProduction ? "notice" : "debug",
 			describe: "Set the severity level for the logs being reported. Values are, in ascending order of severity: 'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'. Default is 'notice' in production mode, 'debug' otherwise.",
 			type: "string",
 		})
 		.option("compile-only", {
-			default: false,
 			describe: "Compile the client JavaScript only, and don't start any servers. This is what you want to do if you are building the client JavaScript to be hosted on a CDN. Unless you have a very specific reason, it's almost alway a good idea to only do this in production mode. Defaults to false.",
+			default: undefined,
 			type: "boolean",
 		})
 		.option("js-url", {
 			describe: "A URL base for the pre-compiled client JavaScript. Setting a value for jsurl means that react-server-cli will not compile the client JavaScript at all, and it will not serve up any JavaScript. Obviously, this means that --jsurl overrides all of the options related to JavaScript compilation: --hot, --minify, and --bundleperroute.",
 			type: "string",
 		})
-		.option("production", {
-			default: false,
-			describe: "Forces production mode. If this is not set (or set to false), the CLI falls back to NODE_ENV to determine what mode we are in. Note that production mode only affects the default settings for other options; individual options can still be overridden by setting them directly.",
-			type: "boolean",
-		})
 		.help('?')
 		.alias('?', 'help')
 		.demand(0)
 		.argv;
 
-	return camelize(parsedArgs);
+	return camelize(removeUndefinedValues(parsedArgs));
+}
+
+const removeUndefinedValues = (input) => {
+	const result = Object.assign({}, input);
+
+	for (let key of Object.keys(input)) {
+		if (result[key] === undefined) {
+			delete result[key];
+		}
+	}
+
+	return result;
 }
 
 const camelize = (input) => {

--- a/packages/react-server-cli/src/startServer.js
+++ b/packages/react-server-cli/src/startServer.js
@@ -3,19 +3,35 @@ import http from "http"
 import express from "express"
 import path from "path"
 import compression from "compression"
+import defaultOptions from "./defaultOptions"
 import WebpackDevServer from "webpack-dev-server"
 import compileClient from "./compileClient"
+import mergeOptions from "./mergeOptions"
+import findOptionsInFiles from "./findOptionsInFiles"
 
 const logger = logging.getLogger(__LOGGER__);
 
-export default (routesRelativePath, {
-		port = 3000,
-		jsPort = 3001,
-		hot = true,
-		minify = false,
-		compileOnly = false,
+// if you *don't* send in any options, we will try to find either a .reactserverrc
+// file or a reactServer section in a package.json using findOptionsInFiles.
+export default (routesRelativePath, options = findOptionsInFiles()) => {
+	// for the option properties that weren't sent in or provided in a config file,
+	// we merge in the defaults.
+	options = mergeOptions(defaultOptions, options);
+
+	setupLogging(options.logLevel);
+	logProductionWarnings(options);
+
+	return startImpl(routesRelativePath, options);
+}
+
+const startImpl = (routesRelativePath, {
+		port,
+		jsPort,
+		hot,
+		minify,
+		compileOnly,
 		jsUrl,
-} = {}) => {
+}) => {
 
 	const routesPath = path.join(process.cwd(), routesRelativePath);
 	const routes = require(routesPath);
@@ -127,4 +143,34 @@ const handleCompilationErrors = (err, stats) => {
 		// TODO: handle this more intelligently, perhaps with a --reportwarnings flag or with different
 		// behavior based on whether or not --minify is set.
 	}
+}
+
+const setupLogging = (logLevel) => {
+	logging.setLevel('main',  logLevel);
+	// TODO: the time and gauge log levels should also be parameters.
+	if (process.env.NODE_ENV !== "production") { //eslint-disable-line no-process-env
+		logging.setLevel('time',  'fast');
+		logging.setLevel('gauge', 'ok');
+	}
+}
+
+const logProductionWarnings = ({hot, minify, jsUrl}) => {
+	// if the server is being launched with some bad practices for production mode, then we
+	// should output a warning. if arg.jsurl is set, then hot and minify are moot, since
+	// we aren't serving JavaScript & CSS at all.
+	if ((!jsUrl && (hot || !minify)) ||  process.env.NODE_ENV !== "production") { //eslint-disable-line no-process-env
+		logger.warning("PRODUCTION WARNING: the following current settings are discouraged in production environments. (If you are developing, carry on!):");
+		if (hot) {
+			logger.warning("-- Hot reload is enabled. Set hot to false or set NODE_ENV=production to turn off.");
+		}
+
+		if (!minify) {
+			logger.warning("-- Minification is disabled. Set minify to true or set NODE_ENV=production to turn on.");
+		}
+
+		if (process.env.NODE_ENV !== "production") { //eslint-disable-line no-process-env
+			logger.warning("-- NODE_ENV is not set to \"production\".");
+		}
+	}
+
 }

--- a/packages/react-server-cli/src/startServer.js
+++ b/packages/react-server-cli/src/startServer.js
@@ -11,12 +11,11 @@ import findOptionsInFiles from "./findOptionsInFiles"
 
 const logger = logging.getLogger(__LOGGER__);
 
-// if you *don't* send in any options, we will try to find either a .reactserverrc
-// file or a reactServer section in a package.json using findOptionsInFiles.
-export default (routesRelativePath, options = findOptionsInFiles()) => {
-	// for the option properties that weren't sent in or provided in a config file,
-	// we merge in the defaults.
-	options = mergeOptions(defaultOptions, options);
+export default (routesRelativePath, options = {}) => {
+	// for the option properties that weren't sent in, look for a config file
+	// (either .reactserverrc or a reactServer section in a package.json). for
+	// options neither passed in nor in a config file, use the defaults.
+	options = mergeOptions(defaultOptions, findOptionsInFiles() || {}, options);
 
 	setupLogging(options.logLevel);
 	logProductionWarnings(options);


### PR DESCRIPTION
@gigabo mentioned in [a comment](https://github.com/redfin/react-server/pull/49#issuecomment-205476978) on PR #49 that it would be nice if there was a config file way to launch `react-server-cli`. I agree, and that's what this PR does.

If you send in any arguments at the command line, nothing changes. But if you don't, then it starts looking in the current directory for either a `.reactserverrc` file or a `reactServer` section of package.json. If it doesn't find either of those, it starts crawling up the directory hierarchy to find a config file. It uses the first config file it finds; it doesn't try to find multiple configs and merge them. For any values that aren't specified, it uses the same defaults it used before.

Additionally, as in Babel, it allows for config overrides on a per-environment basis. All you do is include a `env` attribute in your config, like this:

```json
{
  "port": 4000,
  "env": {
    "production": 5000
  }
}
```

In this example, the port will be 5000 when NODE_ENV is set to "production" and 4000 otherwise.

Other notes:

* I got rid of the `--production` flag; it seemed like it was excessively confusing to me, both at the command line and in terms of the code. It also felt like setting NODE_ENV to production is a fairly normal thing these days, and we should just go with that convention and not provide a second way to do it. Let me know if you disagree.
* I moved the logging warnings from the CLI-specific code into `startServer` so that they will happen for API uses as well as CLI uses.
* One side effect of this PR is that the API now has different config defaults when NODE_ENV is production, which was not true before. This is by design, but I wanted to call it out.