### PR TITLE
Point to `react-server-cli` from the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ Render in the browser for seamless transitions from page to page.
 
 # Just getting started with `react-server`?
 
-The easiest way to start is with
-[`react-server-cli`](packages/react-server-cli), which will take care of the
-_server_ part and let you get up and running right away.
+Start with [`react-server-cli`](packages/react-server-cli), which will take
+care of the _server_ part and get you up and running right away.
 
-Once you're hungry for more have a look at
-[`react-server`](packages/react-server) itself for more complete info.
+Once you're hungry for more dig into
+[`react-server`](packages/react-server) itself.
 
 # Monorepo?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-server monorepo [![Build Status][build-badge-img]][build-url]
 
-React pages that render on the server for blazing fast page load and in the
-browser for seamless transitions between pages.
+React framework with server render for blazing fast page load and seamless
+transitions between pages in the browser.
 
 # Just getting started with `react-server`?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # react-server monorepo [![Build Status][build-badge-img]][build-url]
 
-## Just getting started with `react-server`?
+Write pages in `React`.  Render on the server for blazing fast page load.
+Render in the browser for seamless transisitions from page to page.
+
+# Just getting started with `react-server`?
 
 The easiest way to get up and running is with
 [`react-server-cli`](packages/react-server-cli), which will take care of the

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-server monorepo [![Build Status][build-badge-img]][build-url]
 
 Write pages in `React`.  Render on the server for blazing fast page load.
-Render in the browser for seamless transisitions from page to page.
+Render in the browser for seamless transitions from page to page.
 
 # Just getting started with `react-server`?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Render in the browser for seamless transitions from page to page.
 
 # Just getting started with `react-server`?
 
-The easiest way to get up and running is with
+The easiest way to start is with
 [`react-server-cli`](packages/react-server-cli), which will take care of the
 _server_ part and let you get up and running right away.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-server monorepo [![Build Status][build-badge-img]][build-url]
 
-Write pages in `React`.  Render on the server for blazing fast page load.
-Render in the browser for seamless transitions from page to page.
+React pages that render on the server for blazing fast page load and in the
+browser for seamless transitions from page to page.
 
 # Just getting started with `react-server`?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-server monorepo [![Build Status][build-badge-img]][build-url]
 
 React pages that render on the server for blazing fast page load and in the
-browser for seamless transitions from page to page.
+browser for seamless transitions between pages.
 
 # Just getting started with `react-server`?
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # react-server monorepo [![Build Status][build-badge-img]][build-url]
 
+## Just getting started with `react-server`?
+
+The easiest way to get up and running is with
+[`react-server-cli`](packages/react-server-cli), which will take care of the
+_server_ part and let you get up and running right away.
+
+Once you're hungry for more have a look at
+[`react-server`](packages/react-server) itself for more complete info.
+
 # Monorepo?
 
 It's a thing, now.  All the cool kids are doing it, like [React](https://github.com/facebook/react/tree/master/packages), [Meteor](https://github.com/meteor/meteor/tree/devel/packages), [Ember](https://github.com/emberjs/ember.js/tree/master/packages), and [Babel](https://github.com/babel/babel/tree/master/packages).  All of the packages are versioned in lockstep, which makes it easier for us to make strong guarantees about the interoperability of the packages that work together in the react-server ecosystem.
-
-# react-server?
-The best place to start is [react-server's README](packages/react-server/README.md), though you will likely want to read all of [react-server's docs](packages/react-server/docs).
 
 # Contributing
 


### PR DESCRIPTION
It's a much faster way to get up and running.