### PR TITLE
Adding needed dependencies so test pages project can startup.

### DIFF
--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -13,8 +13,11 @@
   "dependencies": {
     "lodash": "^4.8.2",
     "q": "1.4.1",
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2",
     "react-server": "^0.1.5",
-    "react-server-cli": "^0.1.5"
+    "react-server-cli": "^0.1.5",
+    "superagent": "^1.2.0"
   },
   "devDependencies": {
     "babel-plugin-react-require": "^2.1.0",


### PR DESCRIPTION
The test pages project wasn't starting up correctly because it needs `react`, `react-dom`, and `superagent` to start up. I added them to the `package.json`.