### PR TITLE
Better frameback

### DIFF
--- a/packages/react-server-test-pages/pages/navigation/playground.css
+++ b/packages/react-server-test-pages/pages/navigation/playground.css
@@ -26,6 +26,11 @@
 	width: 16px;
 }
 
+.pick-pointer {
+	width: 16px;
+	cursor: pointer;
+}
+
 .not-available {
 	text-decoration: line-through;
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.css
+++ b/packages/react-server-test-pages/pages/navigation/playground.css
@@ -25,3 +25,7 @@
 .page-pointer {
 	width: 16px;
 }
+
+.not-available {
+	text-decoration: line-through;
+}

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -50,10 +50,21 @@ class ClientRenderIndicator extends React.Component {
 		super(props);
 		this.state = {ready: false};
 	}
+	_handleNavEvent(evt) {
+		if (!this._mounted) return;
+		this.setState({ready: evt === 'loadComplete'});
+	}
 	componentDidMount() {
+		this._mounted = true;
 		this.setState({ready: true});
-		window.__reactServerClientController.context
-			.onNavigateStart(() => this.setState({ready: false}));
+		const nav = window.__reactServerClientController.context.navigator;
+		this._navListeners = ['navigateStart', 'loadComplete']
+			.reduce((m,e) => (nav.on(e, m[e] = this._handleNavEvent.bind(this, e)), m), {});
+	}
+	componentWillUnmount() {
+		this._mounted = false;
+		const nav = window.__reactServerClientController.context.navigator;
+		_.forEach(this._navListeners, (v,k) => nav.removeListener(k, v));
 	}
 	componentWillReceiveProps() {
 		this.setState({ready: true});

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -37,13 +37,32 @@ const NormalLink = ({row}) => <a href={LINK(row)}>Normal Link</a>
 
 const ClientTransitionLink = ({row}) => <Link path={LINK(row)}>Client Transition</Link>
 
-const FramebackLink = ({row}) => <Link frameback={true} path={LINK(row)}>Frameback</Link>
-
 const ReuseDom = ({row}) => <Link reuseDom={true} path={LINK(row)}>Reuse DOM</Link>
 
 const BundleData = ({row}) => <Link bundleData={true} path={LINK(row)}>Bundle Data</Link>
 
 const BundleDataAndReuseDom = ({row}) => <Link bundleData={true} reuseDom={true} path={LINK(row)}>Bundle AND Reuse</Link>
+
+class FramebackCell extends React.Component {
+	constructor(props){
+		super(props);
+		this.state = {available: true};
+	}
+	componentDidMount() {
+		if (window.__reactServerIsFrame) {
+			this.setState({available: false});
+		}
+	}
+	render() {
+		return <span className={this.state.available?'available':'not-available'}>
+			<Link path={LINK(this.props.row)} frameback={true} {...this.props.link}>{
+				this.props.children
+			}</Link>
+		</span>
+	}
+}
+
+const FramebackLink = props => <FramebackCell {...props}>Frameback</FramebackCell>
 
 class ClientRenderIndicator extends React.Component {
 	constructor(props){

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -64,6 +64,23 @@ class FramebackCell extends React.Component {
 
 const FramebackLink = props => <FramebackCell {...props}>Frameback</FramebackCell>
 
+const FramebackCTLink = props => <FramebackCell link={{reuseFrame:true}} {...props}>
+	Frameback with Client Transition
+</FramebackCell>
+
+const FramebackBDLink = props => <FramebackCell link={{reuseFrame:true, bundleData:true}} {...props}>
+	Frameback with Bundle
+</FramebackCell>
+
+const FramebackRDLink = props => <FramebackCell link={{reuseFrame:true, reuseDom:true}} {...props}>
+	Frameback with DOM Reuse
+</FramebackCell>
+
+const FramebackBDRDLink = props => <FramebackCell link={{reuseFrame:true, bundleData:true, reuseDom:true}} {...props}>
+	Frameback with bundle AND Reuse
+</FramebackCell>
+
+
 class ClientRenderIndicator extends React.Component {
 	constructor(props){
 		super(props);
@@ -114,6 +131,10 @@ export default class NavigationPlaygroundPage {
 			<BundleData />
 			<BundleDataAndReuseDom />
 			<FramebackLink />
+			<FramebackCTLink />
+			<FramebackBDLink />
+			<FramebackRDLink />
+			<FramebackBDRDLink />
 		</RootContainer>);
 	}
 }

--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -33,17 +33,19 @@ const PagePointer = ({page, row}) => <div className="page-pointer">
 	{+page === +row ? "➟" : ""}
 </div>;
 
-const NormalLink = ({row}) => <a href={LINK(row)}>Normal Link</a>
+const NL       = ({row}) => <a href={LINK(row)}>Normal Link</a>
+const CT       = ({row}) => <Link path={LINK(row)}>CT</Link>
+const RD       = ({row}) => <Link reuseDom={true} path={LINK(row)}>CT/RD</Link>
+const BD       = ({row}) => <Link bundleData={true} path={LINK(row)}>CT/BD</Link>
+const BDRD     = ({row}) => <Link bundleData={true} reuseDom={true} path={LINK(row)}>CT/BD/RD</Link>
+const FB       = (props) => <FBL {...props}></FBL>
+const FBCT     = (props) => <FBL {...props} link={{reuseFrame:true}}>CT</FBL>
+const FBCTBD   = (props) => <FBL {...props} link={{reuseFrame:true, bundleData:true}}>CT/BD</FBL>
+const FBCTRD   = (props) => <FBL {...props} link={{reuseFrame:true, reuseDom:true}}>CT/RD</FBL>
+const FBCTBDRD = (props) => <FBL {...props} link={{reuseFrame:true, bundleData:true, reuseDom:true}}>CT/BD/RD</FBL>
 
-const ClientTransitionLink = ({row}) => <Link path={LINK(row)}>Client Transition</Link>
-
-const ReuseDom = ({row}) => <Link reuseDom={true} path={LINK(row)}>Reuse DOM</Link>
-
-const BundleData = ({row}) => <Link bundleData={true} path={LINK(row)}>Bundle Data</Link>
-
-const BundleDataAndReuseDom = ({row}) => <Link bundleData={true} reuseDom={true} path={LINK(row)}>Bundle AND Reuse</Link>
-
-class FramebackCell extends React.Component {
+// Frameback Link.
+class FBL extends React.Component {
 	constructor(props){
 		super(props);
 		this.state = {available: true};
@@ -54,31 +56,13 @@ class FramebackCell extends React.Component {
 		}
 	}
 	render() {
-		return <span className={this.state.available?'available':'not-available'}>
-			<Link path={LINK(this.props.row)} frameback={true} {...this.props.link}>{
-				this.props.children
-			}</Link>
-		</span>
+		return <Link path={LINK(this.props.row)} frameback={true} {...this.props.link}>
+			<span className={this.state.available?'available':'not-available'}>FB</span>{
+				this.props.children?['/',...this.props.children]:[]
+			}
+		</Link>
 	}
 }
-
-const FramebackLink = props => <FramebackCell {...props}>Frameback</FramebackCell>
-
-const FramebackCTLink = props => <FramebackCell link={{reuseFrame:true}} {...props}>
-	Frameback with Client Transition
-</FramebackCell>
-
-const FramebackBDLink = props => <FramebackCell link={{reuseFrame:true, bundleData:true}} {...props}>
-	Frameback with Bundle
-</FramebackCell>
-
-const FramebackRDLink = props => <FramebackCell link={{reuseFrame:true, reuseDom:true}} {...props}>
-	Frameback with DOM Reuse
-</FramebackCell>
-
-const FramebackBDRDLink = props => <FramebackCell link={{reuseFrame:true, bundleData:true, reuseDom:true}} {...props}>
-	Frameback with bundle AND Reuse
-</FramebackCell>
 
 
 class ClientRenderIndicator extends React.Component {
@@ -120,21 +104,34 @@ export default class NavigationPlaygroundPage {
 		return next();
 	}
 	getElements() {
-		return this.data.map(promise => <RootContainer when={promise} className="row">
-			<PagePointer />
-			<RowIndex />
-			<RowMS />
-			<ClientRenderIndicator />
-			<NormalLink />
-			<ClientTransitionLink />
-			<ReuseDom />
-			<BundleData />
-			<BundleDataAndReuseDom />
-			<FramebackLink />
-			<FramebackCTLink />
-			<FramebackBDLink />
-			<FramebackRDLink />
-			<FramebackBDRDLink />
-		</RootContainer>);
+		return [
+			<RootContainer>
+				<h1>Navigation Playground</h1>
+				<h2>Legend:</h2>
+				<ul>
+					<li>CT: Client Transition</li>
+					<li>RD: Reuse DOM</li>
+					<li>BD: Bundle Data</li>
+					<li>FB: Frameback</li>
+					<li><span className='not-available'>FB</span>: Frameback disabled (already in a frame)</li>
+				</ul>
+			</RootContainer>,
+			...this.data.map(promise => <RootContainer when={promise} className="row">
+				<PagePointer />
+				<RowIndex />
+				<RowMS />
+				<ClientRenderIndicator />
+				<NL />
+				<CT />
+				<RD />
+				<BD />
+				<BDRD />
+				<FB />
+				<FBCT />
+				<FBCTBD />
+				<FBCTRD />
+				<FBCTBDRD />
+			</RootContainer>),
+		]
 	}
 }

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -112,7 +112,7 @@ class ClientController extends EventEmitter {
 				// not a _transition_ to a frame.  When we
 				// reach here we'll just tell the frameback
 				// controller to do its thing.
-				FC.navigateTo(url).then(() => {
+				FC.navigate(request).then(() => {
 					this.context.navigator.finishRoute();
 				});
 

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -212,10 +212,13 @@ class ClientController extends EventEmitter {
 				// an initial `pushState` might not be a
 				// client transition.  It could be a
 				// non-`react-server` use of the history API.
+				//
+				// This also _replaces_ state with the request
+				// URL, which handles client-side redirects.
 				this._history.replaceState(
 					getHistoryStateFrame(),
 					null,
-					location.path
+					url
 				)
 
 				this._setHistoryRequestOpts({
@@ -276,7 +279,6 @@ class ClientController extends EventEmitter {
 							// we're about to load the _next_ page, so we should mark the
 							// redirect navigation finished
 							context.navigator.finishRoute();
-							this._history.replaceState(null, null, err.redirectUrl);
 							context.navigate(new ClientRequest(err.redirectUrl));
 						}, 0);
 					}

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -160,7 +160,7 @@ class ClientController extends EventEmitter {
 		// If this is a History.events.PUSHSTATE navigation,
 		// and we have control of the navigation bar (we're
 		// not in a frameback frame) we should change the URL
-		// in the bar location bar before rendering.
+		// in the location bar before rendering.
 		//
 		// Note that for browsers that do not have pushState,
 		// this will result in a window.location change and

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -202,6 +202,10 @@ class ClientController extends EventEmitter {
 					// forward, then we can also reuse on
 					// the way back.
 					reuseDom: request.getReuseDom(),
+
+					// The same reasoning as for
+					// `reuseDom` also applies here.
+					reuseFrame: request.getReuseFrame(),
 				});
 
 				this._history.pushState(

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -240,7 +240,7 @@ class ClientController extends EventEmitter {
 		 *    History.events.POPSTATE: user clicked back button but browser didn't do a full page load
 		 *    History.events.PAGELOAD: full browser page load, not using History API.
 		 */
-		context.onNavigate( (err, page, path, type) => {
+		context.onNavigate( (err, page) => {
 			logger.debug('Executing navigate action');
 
 			if (err) {

--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -11,6 +11,7 @@ class ClientRequest {
 		frameback,
 		fromOuterFrame,
 		reuseDom,
+		reuseFrame,
 	}={}) {
 		this._url = url;
 		this._opts = {
@@ -18,6 +19,7 @@ class ClientRequest {
 			frameback,
 			fromOuterFrame,
 			reuseDom,
+			reuseFrame,
 		}
 	}
 
@@ -39,6 +41,10 @@ class ClientRequest {
 
 	getReuseDom() {
 		return this._opts.reuseDom;
+	}
+
+	getReuseFrame() {
+		return this._opts.reuseFrame;
 	}
 
 	getBundleData() {

--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -6,11 +6,19 @@ var cookie = require("cookie"),
  */
 class ClientRequest {
 
-	constructor(url, {frameback, reuseDom, bundleData}={}) {
+	constructor(url, {
+		bundleData,
+		frameback,
+		fromOuterFrame,
+		reuseDom,
+	}={}) {
 		this._url = url;
-		this._frameback = frameback;
-		this._reuseDom = reuseDom;
-		this._bundleData = bundleData;
+		this._opts = {
+			bundleData,
+			frameback,
+			fromOuterFrame,
+			reuseDom,
+		}
 	}
 
 	setRoute(route) {
@@ -21,16 +29,24 @@ class ClientRequest {
 		return this._url;
 	}
 
+	getOpts() {
+		return this._opts;
+	}
+
 	getFrameback() {
-		return this._frameback;
+		return this._opts.frameback;
 	}
 
 	getReuseDom() {
-		return this._reuseDom;
+		return this._opts.reuseDom;
 	}
 
 	getBundleData() {
-		return this._bundleData;
+		return this._opts.bundleData;
+	}
+
+	isFromOuterFrame() {
+		return this._opts.fromOuterFrame;
 	}
 
 	getQuery() {

--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -12,7 +12,7 @@ class ClientRequest {
 		reuseDom,
 		reuseFrame,
 
-		// These is for internal statekeeping.  Don't use it yourself.
+		// These are for internal statekeeping.  Don't use them yourself.
 		_framebackExit,
 		_fromOuterFrame,
 	}={}) {

--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -9,17 +9,21 @@ class ClientRequest {
 	constructor(url, {
 		bundleData,
 		frameback,
-		fromOuterFrame,
 		reuseDom,
 		reuseFrame,
+
+		// These is for internal statekeeping.  Don't use it yourself.
+		_framebackExit,
+		_fromOuterFrame,
 	}={}) {
 		this._url = url;
 		this._opts = {
 			bundleData,
 			frameback,
-			fromOuterFrame,
 			reuseDom,
 			reuseFrame,
+			_framebackExit,
+			_fromOuterFrame,
 		}
 	}
 
@@ -49,10 +53,6 @@ class ClientRequest {
 
 	getBundleData() {
 		return this._opts.bundleData;
-	}
-
-	isFromOuterFrame() {
-		return this._opts.fromOuterFrame;
 	}
 
 	getQuery() {

--- a/packages/react-server/core/FramebackController.js
+++ b/packages/react-server/core/FramebackController.js
@@ -164,11 +164,16 @@ class FramebackController extends EventEmitter {
 		// our frame, and we need to pass it through the outer frame's
 		// navigator to get the history navigation stack taken care
 		// of.
+
+		// Can't reuse the frame if our request is for frameback
+		// without frame reuse.
+		const reuseFrame = request.getReuseFrame() || !request.getFrameback();
+
 		request = new ClientRequest(
 			request.getUrl(),
 			_.assign({}, request.getOpts(), {
-				frameback  : false, // Navigation is _for_ frame.
-				reuseFrame : true,  // It's a client transition.
+				frameback: false, // Navigation is _for_ frame.
+				reuseFrame,
 			})
 		);
 		window.parent.__reactServerClientController.context

--- a/packages/react-server/core/FramebackController.js
+++ b/packages/react-server/core/FramebackController.js
@@ -196,6 +196,9 @@ class FramebackController extends EventEmitter {
 	}
 
 	navigateFrame(request){
+
+		// This is a request that we're going to send to the navigator
+		// _in our frame_.
 		const frameRequest = new ClientRequest(
 			request.getUrl(),
 			_.assign({}, request.getOpts(), {
@@ -203,6 +206,7 @@ class FramebackController extends EventEmitter {
 				_fromOuterFrame : true,  // Actually navigate in frame.
 			})
 		)
+
 		this.frame.contentWindow
 			.__reactServerClientController
 			.context

--- a/packages/react-server/core/FramebackController.js
+++ b/packages/react-server/core/FramebackController.js
@@ -158,7 +158,7 @@ class FramebackController extends EventEmitter {
 
 		// If the request is coming from the outer frame's frameback
 		// controller, then the navigator should handle it.
-		if (request.isFromOuterFrame()) return false;
+		if (request.getOpts()._fromOuterFrame) return false;
 
 		// Otherwise this is a client transition request from within
 		// our frame, and we need to pass it through the outer frame's
@@ -167,8 +167,8 @@ class FramebackController extends EventEmitter {
 		request = new ClientRequest(
 			request.getUrl(),
 			_.assign({}, request.getOpts(), {
-				frameback  : true, // Navigation is _for_ frame.
-				reuseFrame : true, // It's a client transition.
+				frameback  : false, // Navigation is _for_ frame.
+				reuseFrame : true,  // It's a client transition.
 			})
 		);
 		window.parent.__reactServerClientController.context
@@ -199,8 +199,8 @@ class FramebackController extends EventEmitter {
 		const frameRequest = new ClientRequest(
 			request.getUrl(),
 			_.assign({}, request.getOpts(), {
-				frameback      : false, // No frameback within frame.
-				fromOuterFrame : true,  // Actually navigate in frame.
+				frameback       : false, // No frameback within frame.
+				_fromOuterFrame : true,  // Actually navigate in frame.
 			})
 		)
 		this.frame.contentWindow

--- a/packages/react-server/core/components/History.js
+++ b/packages/react-server/core/components/History.js
@@ -100,7 +100,13 @@ History.prototype = {
 	},
 
 	canClientNavigate: function() {
-		return this._hasPushState && !this.win.__reactServerIsFrame;
+		return this._hasPushState && this.hasControl();
+	},
+
+	// If we're in a frameback frame we don't have control of the URL bar.
+	// The other page does.
+	hasControl: function() {
+		return !this.win.__reactServerIsFrame;
 	},
 
 	navigationWindow: function() {

--- a/packages/react-server/core/components/Link.jsx
+++ b/packages/react-server/core/components/Link.jsx
@@ -19,6 +19,7 @@ module.exports = React.createClass({
 			bundleData : false,
 			frameback  : false,
 			reuseDom   : false,
+			reuseFrame : false,
 		}
 	},
 
@@ -36,12 +37,13 @@ module.exports = React.createClass({
 		if (!e.metaKey) {
 			e.preventDefault();
 			e.stopPropagation();
-			const {bundleData, frameback, reuseDom} = this.props;
+			const {bundleData, frameback, reuseDom, reuseFrame} = this.props;
 			getCurrentRequestContext().navigate(
 				new ClientRequest(this.props.path, {
 					bundleData,
 					frameback,
 					reuseDom,
+					reuseFrame,
 				}),
 				History.events.PUSHSTATE
 			);

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -5,7 +5,6 @@ var EventEmitter = require('events').EventEmitter,
 	Q = require('q'),
 	History = require("../components/History"),
 	ReactServerAgent = require("../ReactServerAgent"),
-	FramebackController = require("../FramebackController"),
 	PageUtil = require("../util/PageUtil");
 
 var _ = {
@@ -149,7 +148,7 @@ class Navigator extends EventEmitter {
 
 		// If we're managing a frame's navigation, we want _it_ to
 		// use a data bundle.
-		if (this._ignoreCurrentNavigation) return;
+		if (this._ignoreCurrentNavigation) return Q();
 
 		const url = request.getUrl();
 

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -146,6 +146,11 @@ class Navigator extends EventEmitter {
 	}
 
 	_dealWithDataBundleLoading(request) {
+
+		// If we're managing a frame's navigation, we want _it_ to
+		// use a data bundle.
+		if (this._ignoreCurrentNavigation) return;
+
 		const url = request.getUrl();
 
 		// If the request wants all of the data fetched as a bundle

--- a/packages/react-server/core/context/RequestContext.js
+++ b/packages/react-server/core/context/RequestContext.js
@@ -34,6 +34,15 @@ class RequestContext {
 		return this.serverStash;
 	}
 
+	setFramebackController (framebackController) {
+		this.framebackController = framebackController;
+		return this;
+	}
+
+	getFramebackController () {
+		return this.framebackController;
+	}
+
 	setMobileDetect (mobileDetect) {
 		this.mobileDetect = mobileDetect;
 		return this;
@@ -55,8 +64,18 @@ class RequestContext {
 		this.navigator.on('navigateStart', callback);
 	}
 
+	onLoadComplete (callback) {
+		this.navigator.on('loadComplete', callback);
+	}
+
 	navigate (request, type) {
 		this.navigator.navigate(request, type);
+	}
+
+	framebackControllerWillHandle (request, type) {
+		const FC = this.framebackController;
+		if (!FC) return false;
+		return FC.willHandle(request, type);
 	}
 
 }


### PR DESCRIPTION
This is a big change to how frameback (and the history stack generally) is managed, but the changes in behavior are pretty straightforward.

Previously:
- Frameback
    - Each click into a frame destroyed and recreated the frame.
    - Any click _within_ the frame caused a full browser navigation.
- Generally
    - Client transition options (`reuseDom`, `bundleData`) only applied on first click, not on forward/backward browser nav.

With this changeset:
- Frameback
    - A click into a frame _may_ perform a client transition _within_ the frame to the new page.
        - Client transition options (`reuseDom`, `bundleData`) are available.
    - A click _within_ the frame may perform a client transition.
- Generally
    - Client transition options work on forward/backward browser nav.

Sounds simple, right? :feelsgood: 

Some things actually _did_ get simpler.  Some things will make your head hurt.  I've tried to address those with commentary.  Please don't be shy about calling out confusing bits.