### PR TITLE
Simplify routes file by making `method` optional

### DIFF
--- a/integration-tests/src/specRuntime/testHelper.js
+++ b/integration-tests/src/specRuntime/testHelper.js
@@ -40,7 +40,6 @@ var writeRoutesFile = function (specFile, routes, tempDir) {
 		routesForReactServer += `
 			route${index}: {
 				path: ["${url}"],
-				method: 'get',
 				page: "${routeAbsPath}",
 			},`;
 	});
@@ -50,7 +49,6 @@ var writeRoutesFile = function (specFile, routes, tempDir) {
 	routesForReactServer += `
 		transitionPage: {
 			path: ["/__transition"],
-			method: "get",
 			page: "${transitionPageAbsPath}",
 		}}};`;
 	mkdirp.sync(tempDir);

--- a/packages/react-server-cli/README.md
+++ b/packages/react-server-cli/README.md
@@ -19,12 +19,11 @@ module.exports = {
 	routes: {
 		BazRoute: {
 			path: ["/"],
-			method: "get",
+			method: "get", // optional
 			page: "./BazPage"
 		},
 		BakRoute: {
 			path: ["/bak"],
-			method: "get",
 			page: "./BakPage"
 		}
 	}

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -157,10 +157,12 @@ module.exports = {
 
 		routesOutput.push(`
 		${routeName}: {`);
-		for (let name of ["path", "method"]) {
-			routesOutput.push(`
-			${name}: "${route[name]}",`);
-		}
+		routesOutput.push(`
+			path: "${route.path}",`);
+		// if the route doesn't have a method, we'll assume it's "get". routr doesn't
+		// have a default (method is required), so we set it here.
+		routesOutput.push(`
+			method: "${route.method || "get"}",`);
 
 		let formats = normalizeRoutesPage(route.page);
 		routesOutput.push(`

--- a/packages/react-server-test-pages/routes.js
+++ b/packages/react-server-test-pages/routes.js
@@ -10,16 +10,13 @@ module.exports = {
 	routes: _.assign({
 		Index: {
 			path: ["/"],
-			method: "get",
 			page: "./pages/index",
 		},
 		DataDelay: {
 			path: ["/data/delay"],
-			method: "get",
 			page: "./pages/data/delay",
 		},
 	}, _.reduce(require('./entrypoints'), (obj, val, key) => {
-		if (!val.method) val.method = "get";
 		if (!val.path) val.path = [val.entry];
 		val.page = `./pages${val.entry}`;
 		obj[key] = val;

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -58,7 +58,8 @@ Read more on [our dev blog](https://www.redfin.com/devblog/2015/09/thoughts-on-t
 					// The relative path that this route responds to; so for an Express
 					// instance on 127.0.0.1 port 3000, respond to http://127.0.0.1/
 					path: ['/'],
-					// The http verb to respond to, e.g. get, put, post, patch, delete
+					// The http verb to respond to, e.g. get, put, post, patch, delete.
+					// This is optional, and defaults to 'get'.
 					method: 'get',
 					page: function () {
 						// TODO: returning an invalid object here (for instance, returning


### PR DESCRIPTION
This is a pretty minor PR that makes `method` optional in routes files, defaulting to `get`.