### PR TITLE
Support promises returned in getHeadStylesheets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 1
+indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -13,6 +13,10 @@ module.exports = {
 		entry: "/navigation/playground",
 		description: "Navigation playground",
 	},
+	StylePromises: {
+		entry: "/styles/promises",
+		description: "Stylesheets returned from promises",
+	},
 	NavigationDataBundleCache: {
 		entry: "/navigation/data-bundle-cache",
 		description: "Data bundle cache",

--- a/packages/react-server-test-pages/pages/styles/promises.js
+++ b/packages/react-server-test-pages/pages/styles/promises.js
@@ -1,0 +1,31 @@
+
+import React from "react";
+
+export default class StylePromises {
+	getHeadStylesheets () {
+		return [
+			delay(1000)
+				.then(() => "./styles/first.css"),
+			delay(100)
+				.then(() => "./styles/second.css"),
+		];
+	}
+
+	getElements () {
+		return [
+			<div>If first.css shows up before second.css in the body of this page, all is well.</div>,
+		]
+	}
+
+}
+
+function delay(ms) {
+	let _res;
+	const p = new Promise(function (res) {
+		_res = res;
+	});
+	setTimeout(() => {
+		_res()
+	}, ms);
+	return p;
+}

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -304,39 +304,40 @@ class ClientController extends EventEmitter {
 				this._renderLinkTags(page);
 			}
 
-			cssHelper.ensureCss(routeName, page);
+			cssHelper.ensureCss(routeName, page)
+				.then(() =>
+					page.getBodyClasses().then((classes) => {
+						classes.push(`route-${routeName}`);
+						document.body.className = classes.join(' ');
+					}))
+				.then(() => this._render(page)).catch((err) => {
+					logger.error("Error during client transition render", err);
+				}).then(() => {
 
-			page.getBodyClasses().then((classes) => {
-				classes.push(`route-${routeName}`);
-				document.body.className = classes.join(' ');
-			}).then(() => this._render(page)).catch((err) => {
-				logger.error("Error during client transition render", err);
-			}).then(() => {
-
-				// We're responsible for letting the navigator
-				// know when we're more or less done stomping
-				// around in the current request context
-				// setting things up.
-				//
-				// We can't _guarantee_ that pages/middleware
-				// haven't set timers to mess with things in
-				// the future, so we need to wait a bit before
-				// letting the navigator yank our context if
-				// an immediate subsequent navigation is
-				// scheduled.
-				//
-				// I don't like this magic delay here, but it
-				// gives us a better shot at falling after
-				// things like lazy load images do their
-				// post-render wire-up.
-				//
-				// Anything that the current page does in the
-				// request context _after_ this timeout has
-				// elapsed and we've started a subsequent
-				// navigation is pure corruption. :p
-				//
-				setTimeout(() => context.navigator.finishRoute(), 200);
-			}).done();
+					// We're responsible for letting the navigator
+					// know when we're more or less done stomping
+					// around in the current request context
+					// setting things up.
+					//
+					// We can't _guarantee_ that pages/middleware
+					// haven't set timers to mess with things in
+					// the future, so we need to wait a bit before
+					// letting the navigator yank our context if
+					// an immediate subsequent navigation is
+					// scheduled.
+					//
+					// I don't like this magic delay here, but it
+					// gives us a better shot at falling after
+					// things like lazy load images do their
+					// post-render wire-up.
+					//
+					// Anything that the current page does in the
+					// request context _after_ this timeout has
+					// elapsed and we've started a subsequent
+					// navigation is pure corruption. :p
+					//
+					setTimeout(() => context.navigator.finishRoute(), 200);
+				}).done();
 
 		});
 

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -207,16 +207,21 @@ function standardizeScripts(scripts) {
 }
 
 function standardizeStyles(styles) {
-	return PageUtil.makeArray(styles).map((style) => {
-		if (style.href || style.text) {
-			if (!style.type) style.type = "text/css";
-			if (!style.media) style.media = "";
+	return PageUtil.makeArray(styles).map(styleOrP => {
+		return Q(styleOrP).then(style => {
+			if (!style) {
+				return null;
+			}
+			if (style.href || style.text) {
+				if (!style.type) style.type = "text/css";
+				if (!style.media) style.media = "";
 
-			return style;
-		}
+				return style;
+			}
 
-		// if the answer was a string, let's make a script object
-		return {href:style, type:"text/css", media:""};
+			// if the answer was a string, let's make a script object
+			return {href:style, type:"text/css", media:""};
+		});
 	})
 }
 


### PR DESCRIPTION
We can return promises (almost) everywhere else. Seems reasonable to return them here too. (Plus it unblocks having a middleware that reads a route-->stylesheet mapping from a file server-side and provides it to the client.)

Risks: timing of stylesheets could delay page rendering.