### PR TITLE
Documentation whitespace changes

### DIFF
--- a/packages/react-server/docs/data-proposal.md
+++ b/packages/react-server/docs/data-proposal.md
@@ -3,38 +3,91 @@
 First off, I’d like to lay out the principles/beliefs that drive this proposal:
 
 
-1. **Best practices for data flow in React are changing fast**. Last year, Facebook announced Flux as a design pattern, and they eventually released an implementation, which had some definite rough spots (singletons, string actions, lots of boilerplate). A bunch of other implementations that use the same basic model with different ideas have cropped up since then. This year, Facebook announced Relay as a design pattern, and they say they eventually would like to open source that, too, but it’s clear that a lot of teams at Facebook still use Flux without Relay. Everything is changing pretty fast, and any data flow we use now will probably change pretty radically in the next two years. As David Nolen said at ReactJSConf: “The whole point of the Flux architecture was, “Here’s one way because we’re not sure yet what the right way is”. And in fact, the truth is this is software, there’s probably going to be 4 or 5 ways that address different dimensions of the problem.”
+1. **Best practices for data flow in React are changing fast**. Last year,
+   Facebook announced Flux as a design pattern, and they eventually released
+   an implementation, which had some definite rough spots (singletons, string
+   actions, lots of boilerplate). A bunch of other implementations that use
+   the same basic model with different ideas have cropped up since then. This
+   year, Facebook announced Relay as a design pattern, and they say they
+   eventually would like to open source that, too, but it’s clear that a lot
+   of teams at Facebook still use Flux without Relay. Everything is changing
+   pretty fast, and any data flow we use now will probably change pretty
+   radically in the next two years. As David Nolen said at ReactJSConf: “The
+   whole point of the Flux architecture was, “Here’s one way because we’re not
+   sure yet what the right way is”. And in fact, the truth is this is
+   software, there’s probably going to be 4 or 5 ways that address different
+   dimensions of the problem.”
 
-1. **None of the currently available solutions for data flow is perfect**. I think of the things I’ve heard about, Relay has the best story, but it would require a TON of work on both front-end and back-end to implement for Redfin, and I don’t think we should do that now. All of the other solutions have strengths and drawbacks.
+1. **None of the currently available solutions for data flow is perfect**. I
+   think of the things I’ve heard about, Relay has the best story, but it
+   would require a TON of work on both front-end and back-end to implement for
+   Redfin, and I don’t think we should do that now. All of the other solutions
+   have strengths and drawbacks.
 
-1. **Flux’s one-way data flow is its best idea**. The core problem that Flux seems to be solving is not having tons of boilerplate code in your components that pass props and handlers up and down the tree. Global actions allow nodes in the component tree to send messages to the data, which eventually bubbles up and causes a re-render.
+1. **Flux’s one-way data flow is its best idea**. The core problem that Flux
+   seems to be solving is not having tons of boilerplate code in your
+   components that pass props and handlers up and down the tree. Global
+   actions allow nodes in the component tree to send messages to the data,
+   which eventually bubbles up and causes a re-render.
 
-1. **Other libraries did a better job implementing Flux’s pattern than Facebook did.** Libraries like reflux and Hoverboard have tried to address some of the implementation weaknesses of Facebook’s stock Flux, and we should use their best insights. The biggest weaknesses of Flux that I see are:
+1. **Other libraries did a better job implementing Flux’s pattern than
+   Facebook did.** Libraries like reflux and Hoverboard have tried to address
+   some of the implementation weaknesses of Facebook’s stock Flux, and we
+   should use their best insights. The biggest weaknesses of Flux that I see
+   are:
 
  * Stores and the dispatcher are singletons, which is especially problematic for server-side rendering.
  * Actions are represented by globally unique strings.
  * Common use cases like firing an action require a lot of boilerplate.
  * Stores are often used as React props, leaking their API to components.
 
-1. **Actions are not necessary on the server.** Server-side rendering is a point-in-time rendering of the component tree, not a living, mutating UX, as it is on the client. Actions are really only needed for the latter.
+1. **Actions are not necessary on the server.** Server-side rendering is a
+   point-in-time rendering of the component tree, not a living, mutating UX,
+   as it is on the client. Actions are really only needed for the latter.
 
-1. **Immutable data is a great tool, but we have to support mutable data**. I think immutable data structures are an insanely good match for React, and we should migrate towards them. However, we have mutable data models right now, and we shouldn’t require teams to port from those models just to get rendering in react-server. I want any data flow we use right now to be compatible with immutable data, but I think to start we will be using it with mutable objects.
+1. **Immutable data is a great tool, but we have to support mutable data**. I
+   think immutable data structures are an insanely good match for React, and
+   we should migrate towards them. However, we have mutable data models right
+   now, and we shouldn’t require teams to port from those models just to get
+   rendering in react-server. I want any data flow we use right now to be
+   compatible with immutable data, but I think to start we will be using it
+   with mutable objects.
 
-1. **Passing Props Down Through the Component Tree Is Not That Bad**. This is probably the most controversial thing I believe. I agree that it’d be nicer not to pass down props, and I would love to have Relay’s solution to the problem if I had a magic wand. However, in a practical matter I don’t think it’s that difficult to manage: most changes that are made to endpoints (like adding a field to CorgiHome) will filter down automatically through the component tree without changing anything, our component trees aren’t generally that deep, and prop passing code is not particularly hard to write or understand when you do need to add it.
+1. **Passing Props Down Through the Component Tree Is Not That Bad**. This is
+   probably the most controversial thing I believe. I agree that it’d be nicer
+   not to pass down props, and I would love to have Relay’s solution to the
+   problem if I had a magic wand. However, in a practical matter I don’t think
+   it’s that difficult to manage: most changes that are made to endpoints
+   (like adding a field to CorgiHome) will filter down automatically through
+   the component tree without changing anything, our component trees aren’t
+   generally that deep, and prop passing code is not particularly hard to
+   write or understand when you do need to add it.
 
 # Key Concepts: Stores, State, Actions, and Root Elements.
 
-Having outlined the basic principles, let's look at the key concepts of this proposal: Stores, State, Actions, and Root Elements.
+Having outlined the basic principles, let's look at the key concepts of this
+proposal: Stores, State, Actions, and Root Elements.
 
-*Root Elements* are mounted React elements that are at the root of their render tree (i.e. React elements currently in the document that had "React.render" called on them.) Root State is passed into them as props. There can be multiple Root Elements in a page (as when `getElements` returns an array in react-server).
+*Root Elements* are mounted React elements that are at the root of their
+render tree (i.e. React elements currently in the document that had
+"React.render" called on them.) Root State is passed into them as props. There
+can be multiple Root Elements in a page (as when `getElements` returns an
+array in react-server).
 
-*State* is an object representing the state of a Store at any particular point in time. It is separate from the Store in that it does not respond to Actions. The State from the various Stores is bundled up into Root State and passed to Root Elements; Stores are *not* passed to Root Elements. Ideally, State would be an immutable data structure, but it can be mutable.
+*State* is an object representing the state of a Store at any particular point
+in time. It is separate from the Store in that it does not respond to Actions.
+The State from the various Stores is bundled up into Root State and passed to
+Root Elements; Stores are *not* passed to Root Elements. Ideally, State would
+be an immutable data structure, but it can be mutable.
 
-*Root State* is an aggregation of one or more States from one or more Stores in the App that is then passed into a Root Element. Note that there can be multiple Root States, because there can be multiple Root Elements in a page.
+*Root State* is an aggregation of one or more States from one or more Stores
+in the App that is then passed into a Root Element. Note that there can be
+multiple Root States, because there can be multiple Root Elements in a page.
 
 *Stores* are objects that hold State and manage the changes to the State.
 
-*Actions* are events that fire from elements anywhere in the render tree. Stores listen to Actions and potentially mutate State in response.
+*Actions* are events that fire from elements anywhere in the render tree.
+Stores listen to Actions and potentially mutate State in response.
 
 With these terms, let's chart out what a typical data flow would look like:
 
@@ -67,15 +120,24 @@ With these terms, let's chart out what a typical data flow would look like:
       }
     });
 ```
-1. The call to `setState` triggers a change event to be fired from the Store. If the Store is a child of a parent Store, then the change event is propagated up to the root. At the root, the change event for the Store has a handler that will bundle the Root State and pass it over to the Root Element.
+1. The call to `setState` triggers a change event to be fired from the Store.
+   If the Store is a child of a parent Store, then the change event is
+   propagated up to the root. At the root, the change event for the Store has
+   a handler that will bundle the Root State and pass it over to the Root
+   Element.
 
-1. The Root Element will pass down subparts of the State to its children, who will pass down subparts to their children, and the current State will be rendered.
+1. The Root Element will pass down subparts of the State to its children, who
+   will pass down subparts to their children, and the current State will be
+   rendered.
 
 # Rough API
 
 ## `Actions`
 
-I think we should actually just use the [Actions from refluxjs](https://github.com/spoike/refluxjs#creating-actions). They are easy to create, they have an awesome pattern for child actions that fire on completion or error, and they are just functions.
+I think we should actually just use the [Actions from
+refluxjs](https://github.com/spoike/refluxjs#creating-actions). They are easy
+to create, they have an awesome pattern for child actions that fire on
+completion or error, and they are just functions.
 
 The only change I would propose is just aliasing `Actions.createActions` to `Reflux.createActions`.
 
@@ -83,7 +145,8 @@ The only change I would propose is just aliasing `Actions.createActions` to `Ref
 
 ### `Stores`
 
-`Stores` is a JS helper for creating Store Factory functions. Stores are for holding data. Note that a Store is a Reflux Store instance.
+`Stores` is a JS helper for creating Store Factory functions. Stores are for
+holding data. Note that a Store is a Reflux Store instance.
 
 ```
 // in MyStore.js
@@ -107,7 +170,10 @@ module.exports = class MyPage {
 Stores are event emitters, so they can be listened to using normal Event Emitter listener code.
 
 ### `Store.state`
-The Store instance will have a `this.state` object, representing its current State. Like React, `this.state` should be considered to be an immutable, and attributes of `this.state` should _never_ be set. Stores are, however, free to read attributes from the state.
+The Store instance will have a `this.state` object, representing its current
+State. Like React, `this.state` should be considered to be an immutable, and
+attributes of `this.state` should _never_ be set. Stores are, however, free to
+read attributes from the state.
 
 ### `Store.setState(state: Object)`
 Like React, this method merges `state` into the current `this.state`:
@@ -117,20 +183,38 @@ Like React, this method merges `state` into the current `this.state`:
 console.log(this.state); // output: {foo:1, bar:2}
 this.setState({bar:3, qux: 4}); // state will now be: {foo:1, bar:3, qux:4}
 ```
-Also like React, `setState` may be carried out asynchronously (in order to batch up multiple Stores' changes), so `this.state` may not change immediately after a call to `this.setState()`.
+Also like React, `setState` may be carried out asynchronously (in order to
+batch up multiple Stores' changes), so `this.state` may not change immediately
+after a call to `this.setState()`.
 
-The `setState` method also emits a `change` event so that listeners will know that the Store's State has changed.
+The `setState` method also emits a `change` event so that listeners will know
+that the Store's State has changed.
 
 #### Child Stores
-Also, if the value of any of the keys in the `state` argument is a Store, then the value in `this.state` will be that child Store's State, not the child Store itself. Further, adding a child store in this way will automatically make this Store listen to that child Store's change events. This means that hooking up parent and child Stores is generally as easy as
+Also, if the value of any of the keys in the `state` argument is a Store, then
+the value in `this.state` will be that child Store's State, not the child
+Store itself. Further, adding a child store in this way will automatically
+make this Store listen to that child Store's change events. This means that
+hooking up parent and child Stores is generally as easy as
 ```
 this.setState({propertyHistory: new propertyHistoryStore});
 ```
-If you need something more intricate than Stores just listening to their child Stores, you can hook up Stores manually to listen to changes in other Stores. However, it is important to make sure that event listening tree doesn't have cycles. If a cycle of `setState` calls occurs, the framework will throw an Error.
+If you need something more intricate than Stores just listening to their child
+Stores, you can hook up Stores manually to listen to changes in other Stores.
+However, it is important to make sure that event listening tree doesn't have
+cycles. If a cycle of `setState` calls occurs, the framework will throw an
+Error.
 
 #### Pending Values
 
-Many stores fetch data via asynchronous processes, often an HTTP JSON call. To make it easy to code asynchronous values into a Store, we have the notion of _Pending Values_. If you call `setState` and the value of a property is a Promise (or any `then`-able), then that name is not immediately added to `state`. Instead, once the promise resolves, the name is added to `state` with the value of the resolved promise. If the promise rejects, then the name is added with the value being the error that was thrown. (TODO: is that right? sounds hard to use in error cases.)
+Many stores fetch data via asynchronous processes, often an HTTP JSON call. To
+make it easy to code asynchronous values into a Store, we have the notion of
+_Pending Values_. If you call `setState` and the value of a property is a
+Promise (or any `then`-able), then that name is not immediately added to
+`state`. Instead, once the promise resolves, the name is added to `state` with
+the value of the resolved promise. If the promise rejects, then the name is
+added with the value being the error that was thrown. (TODO: is that right?
+sounds hard to use in error cases.)
 
 ```
 var A = Stores.createStoreFactory({})();
@@ -152,13 +236,15 @@ setTimeout(() => {
 
 ### `Store.when(names: String | [String]) : Promise(Object)`
 
-Returns a promise that resolves when all of the values with names in `names` have a non-pending non-`undefined` value.
+Returns a promise that resolves when all of the values with names in `names`
+have a non-pending non-`undefined` value.
 
 The value of the promise is a hash of the names to their values.
 
 ### `Store.whenResolved() : Promise(Object)`
 
-Returns a promise that resolves when there are no more pending values in the Store's `state`.
+Returns a promise that resolves when there are no more pending values in the
+Store's `state`.
 
 ## RootElements
 
@@ -166,9 +252,15 @@ Returns a promise that resolves when there are no more pending values in the Sto
 
 Takes in a Store and a ReactElement or a Function to create a Root Element that is linked in a one-way data flow with the Store.
 
-If `element` is a ReactElement, the Root Element will be that element with a `prop` for every key-value pair in the Store's `state` mixed in. Any change events in the Store will automatically update the Root Element's props and, of course, force a re-render.
+If `element` is a ReactElement, the Root Element will be that element with a
+`prop` for every key-value pair in the Store's `state` mixed in. Any change
+events in the Store will automatically update the Root Element's props and, of
+course, force a re-render.
 
-If `element` is a Function, it will be called every time the Store updates with the state, and it should return a ReactElement that should be used at that moment. This is useful, for example, for mapping names that the Store uses to names that the control uses:
+If `element` is a Function, it will be called every time the Store updates
+with the state, and it should return a ReactElement that should be used at
+that moment. This is useful, for example, for mapping names that the Store
+uses to names that the control uses:
 
 ```
 // imagine store has fields foo and bar, which you want
@@ -184,9 +276,15 @@ This method would be most likely called in react-server's Page API method `getEl
 
 Returns an `EarlyPromise` of a ReactElement that resolves when all the values in `names` are not pending and not `undefined`.
 
-If `element` is a ReactElement, the Root Element will be that element with a `prop` for every key-value pair in the Store's `state` mixed in. Any change events in the Store will automatically update the Root Element's props and, of course, force a re-render. Note that *all* of the Store's `state` is mixed in to the Root Element, not just the properties referenced in `names`.
+If `element` is a ReactElement, the Root Element will be that element with a
+`prop` for every key-value pair in the Store's `state` mixed in. Any change
+events in the Store will automatically update the Root Element's props and, of
+course, force a re-render. Note that *all* of the Store's `state` is mixed in
+to the Root Element, not just the properties referenced in `names`.
 
-If `element` is a Function, it will be called every time the Store updates with the state, and it should return a ReactElement that should be used at that moment.
+If `element` is a Function, it will be called every time the Store updates
+with the state, and it should return a ReactElement that should be used at
+that moment.
 
 If the Promise is resolved Early, it returns the Element that would be created with the state available at the time.
 

--- a/packages/react-server/docs/page-api.md
+++ b/packages/react-server/docs/page-api.md
@@ -3,7 +3,8 @@ A binding of URL paths to a Page class that can render the results for those URL
 
 `path: String | RegEx | [ String | RegEx ]`
 
-* A string or regex that will be tested against the path of the URL to determine if this route applies.
+* A string or regex that will be tested against the path of the URL to
+  determine if this route applies.
 
 `method, optional: String | [String]`
 
@@ -16,25 +17,47 @@ A binding of URL paths to a Page class that can render the results for those URL
 
 #Page
 
-An HTML page to be rendered. Note that this Page may be rendered as a result of either an HTTP request or a client-side navigation. The Page’s core responsibilities are to:
+An HTML page to be rendered. Note that this Page may be rendered as a result
+of either an HTTP request or a client-side navigation. The Page’s core
+responsibilities are to:
 
 * handle redirects or forwarding to other pages
 * translate the URL/request into any necessary backend data requests
-* produce all of the elements to be included in the HTML Page <head>.
+* produce all of the elements to be included in the HTML Page `<head>`.
 * produce one or more ReactElements that will render the page
 
 The rendering process follows the following flow:
 
-1. The request is compared to all the routes, and a Page constructor is retrieved.
+1. The request is compared to all the routes, and a Page constructor is
+   retrieved.
 1. The Page constructor is called.
-1. `setConfigValues` is called.  This method may return an object representing configuration overrides for the page.
-1. `handleRoute` is called with the current Request to determine if this request needs to be redirected or forwarded.
- * If a redirect is returned (code 301 or 302), the user-visible URL will change, and the routing process will start again at step #1.
- * If a forward is returned (a Page constructor), then routing will jump back to step #2 with the new Page constructor.
+1. `setConfigValues` is called.  This method may return an object representing
+   configuration overrides for the page.
+1. `handleRoute` is called with the current Request to determine if this
+   request needs to be redirected or forwarded.
+ * If a redirect is returned (code 301 or 302), the user-visible URL will
+   change, and the routing process will start again at step #1.
+ * If a forward is returned (a Page constructor), then routing will jump back
+   to step #2 with the new Page constructor.
  * Otherwise, continue on.
-1. If they exist, `getTitle`, `getScripts`, `getSystemScripts`, `getHeadStylesheets`, `getMetaTags`, and `getBodyClasses` are called, and their results are written into the head of the response (via `response.write` on server and DOM operations on the client). On the server, if any of those methods return a Promise, the writing of the ReactElements is blocked until the Promises resolve. On the client, ReactElements can be written out to the document body before the title or meta tags are resolved.
-1. `getElements` is called, and the resulting ReactElements are rendered and written out to the document in the order they were returned from getElements. On both client and server side, rendering of element N will always block on rendering of element N - 1. We may ease this restriction later.
-1. If a timeout is reached on the server, the EarlyPromises of ReactElements may be forced to resolve via `getValue`, and the resulting elements will be rendered and written out to the document. If `getElements` returns a Promise that is not an EarlyPromise, then nothing will be written out in the case of a timeout.
+1. If they exist, `getTitle`, `getScripts`, `getSystemScripts`,
+   `getHeadStylesheets`, `getMetaTags`, and `getBodyClasses` are called, and
+   their results are written into the head of the response (via
+   `response.write` on server and DOM operations on the client). On the
+   server, if any of those methods return a Promise, the writing of the
+   ReactElements is blocked until the Promises resolve. On the client,
+   ReactElements can be written out to the document body before the title or
+   meta tags are resolved.
+1. `getElements` is called, and the resulting ReactElements are rendered and
+   written out to the document in the order they were returned from
+   getElements. On both client and server side, rendering of element N will
+   always block on rendering of element N - 1. We may ease this restriction
+   later.
+1. If a timeout is reached on the server, the EarlyPromises of ReactElements
+   may be forced to resolve via `getValue`, and the resulting elements will be
+   rendered and written out to the document. If `getElements` returns a
+   Promise that is not an EarlyPromise, then nothing will be written out in
+   the case of a timeout.
 
 
 # Page methods
@@ -52,7 +75,8 @@ react-server page interface.
 
 `static middleware() : [Page classes]`
 
-* An array of page classes that should be used as mixins for this page. See Middleware section below to see what these are for.
+* An array of page classes that should be used as mixins for this page. See
+  Middleware section below to see what these are for.
 
 ## PAGE_METHODS
 
@@ -60,21 +84,41 @@ Each of these methods receives a function, `next`, as its sole argument.
 This `next function may be used to call the default implementation of the
 function in question.
 
-`handleRoute(request:Request, loader:Loader, next: Function), optional: {code?: int, location?: String, page?:Page} | Promise({code?: int, location?: String, page?:Page})`
+`handleRoute(request:Request, loader:Loader, next: Function), optional:
+{code?: int, location?: String, page?:Page} | Promise({code?: int, location?:
+String, page?:Page})`
 
-* This method is called before any of the other methods, and its purpose is to kick off any async data fetching the page needs to do and to make sure that we are on the correct page. It returns an object (or Promise of object) that always has a `code` field, which is the HTTP result code to return.
+* This method is called before any of the other methods, and its purpose is to
+  kick off any async data fetching the page needs to do and to make sure that
+  we are on the correct page. It returns an object (or Promise of object) that
+  always has a `code` field, which is the HTTP result code to return.
 
-* `handleRoute` takes in a Request object so that the Page will know exactly what information it should display. For best performance, the Page should start any data requests that are necessary for first render in handleRoute.
+* `handleRoute` takes in a Request object so that the Page will know exactly
+  what information it should display. For best performance, the Page should
+  start any data requests that are necessary for first render in handleRoute.
 
-* The Loader is an HTTP loading interface that supports client caching of results in HTML and late arrival of HTTP responses that occur after a rendering timeout.
+* The Loader is an HTTP loading interface that supports client caching of
+  results in HTML and late arrival of HTTP responses that occur after a
+  rendering timeout.
 
-* If the `code` is 301 or 302, then it must also return a `location` String to tell the browser where to redirect.
+* If the `code` is 301 or 302, then it must also return a `location` String to
+  tell the browser where to redirect.
 
-* If the `handleRoute` returns an object with a `page` property and no `code` property, then the current page object is thrown away, and routing forwards control to the page that was returned, starting with `handleRoute()`. This is helpful for having centralized error pages for things like 404 Not Found or 500 Server Error.
+* If the `handleRoute` returns an object with a `page` property and no `code`
+  property, then the current page object is thrown away, and routing forwards
+  control to the page that was returned, starting with `handleRoute()`. This
+  is helpful for having centralized error pages for things like 404 Not Found
+  or 500 Server Error.
 
-* Note that HTTP codes will not be returned when performing client-side page transitions. However, 302 and 301 codes will use the History API to change the URL on client-side transitions, resulting in an effective redirect. For browsers that do not support the History API, the browser may load the new page from scratch.
+* Note that HTTP codes will not be returned when performing client-side page
+  transitions. However, 302 and 301 codes will use the History API to change
+  the URL on client-side transitions, resulting in an effective redirect. For
+  browsers that do not support the History API, the browser may load the new
+  page from scratch.
 
-* The other methods in this Page object will not be called until and unless the result from `handleRoute` resolves and the return value has a `code` property.
+* The other methods in this Page object will not be called until and unless
+  the result from `handleRoute` resolves and the return value has a `code`
+  property.
 
 * Default: `{code:200}`
 
@@ -92,7 +136,11 @@ function in question.
 
 `getSystemScripts(next: Function): String | Script | [String | Script]`
 
-* URLs for the critical client-side JavaScript files that make react-server run on the client side, including both the react-server runtime, this page class, and its bundled dependencies. Do not override this method unless you are doing something very tricky, like packaging react-server for the client with something other than the standard Webpack.
+* URLs for the critical client-side JavaScript files that make react-server
+  run on the client side, including both the react-server runtime, this page
+  class, and its bundled dependencies. Do not override this method unless you
+  are doing something very tricky, like packaging react-server for the client
+  with something other than the standard Webpack.
 
 * Default: the URLs of the files that react-server needs to run on the client-side.
 
@@ -102,25 +150,29 @@ function in question.
 
 * URLs for the stylesheets that should be loaded in the head for this page.
 
-* If the method returns a `String` value, it is interpreted as a `Style` of the form `{href:<value>, type:"text/css"}`.
+* If the method returns a `String` value, it is interpreted as a `Style` of
+  the form `{href:<value>, type:"text/css"}`.
 
 * **for v2:** allow Promises as return value
 
 `getMetaTags(next: Function): Meta | Promise(Meta) | [Meta | Promise(Meta)]`
 
-* A set of Meta objects that represent the meta tags for this page. If it’s a promise and the promise returns null, the meta tag will not be used.
+* A set of Meta objects that represent the meta tags for this page. If it’s a
+  promise and the promise returns null, the meta tag will not be used.
 
 * Default: []
 
 `getLinkTags(next: Function): Link | Promise(Link) | [Link | Promise(Link)]`
 
-* A set of Link objects that represent the link tags for this page. If it’s a promise and the promise returns null, the link tag will not be used.
+* A set of Link objects that represent the link tags for this page. If it’s a
+  promise and the promise returns null, the link tag will not be used.
 
 * Default: []
 
 `getBase(next: Function): Base | Promise(Base | null) | null`
 
-* Returns the value of the HTML `<base>` tag. If null, there will be no <base> tag in the head.
+* Returns the value of the HTML `<base>` tag. If null, there will be no <base>
+  tag in the head.
 
 * Default: null
 
@@ -130,13 +182,19 @@ function in question.
 
 * Default: []
 
-`getElements(next: Function): ReactElement | EarlyPromise(ReactElement) | Promise(ReactElement) | [ ReactElement | EarlyPromise(ReactElement) | Promise(ReactElement) ]`
+`getElements(next: Function): ReactElement | EarlyPromise(ReactElement) |
+Promise(ReactElement) | [ ReactElement | EarlyPromise(ReactElement) |
+Promise(ReactElement) ]`
 
-* The React elements, in page order, which make up the HTML of this Page. For convenience, you can return a single element or an array of elements.
+* The React elements, in page order, which make up the HTML of this Page. For
+  convenience, you can return a single element or an array of elements.
 
-* When an array is returned, each of the elements will be put in a separate container div, which will be siblings of each other. If an element is null, it will not result in anything rendered to the document.
+* When an array is returned, each of the elements will be put in a separate
+  container div, which will be siblings of each other. If an element is null,
+  it will not result in anything rendered to the document.
 
-* If the any of the return values are EarlyPromises, they may be rendered in a partial state using `getValue`.
+* If the any of the return values are EarlyPromises, they may be rendered in a
+  partial state using `getValue`.
 
 `getResponseData(next: Function): String | Buffer | Promise(String) | Promise(Buffer)`
 
@@ -158,7 +216,8 @@ function in question.
 
 * **NOT YET IMPLEMENTED**
 
-* The set of HTTP headers that should be sent back from this page. HAS NO EFFECT WHEN A PAGE IS TRANSITIONED TO ON THE CLIENT.
+* The set of HTTP headers that should be sent back from this page. HAS NO
+  EFFECT WHEN A PAGE IS TRANSITIONED TO ON THE CLIENT.
 
 * RECOMMENDATION: v2, sigh.
 
@@ -190,11 +249,19 @@ The page may call these methods on itself.
 
 # Middleware
 
-Middlewares are objects that implement any subset of the Page API and are called before a `Page` in a chained fashion. If a middleware doesn’t implement a method, it is skipped. If a middleware does implement a method, it can completely handle the method (thereby completely ignoring the Page’s implementation), or it can pass through to the Page’s implementation using the `next` argument.
+Middlewares are objects that implement any subset of the Page API and are
+called before a `Page` in a chained fashion. If a middleware doesn’t implement
+a method, it is skipped. If a middleware does implement a method, it can
+completely handle the method (thereby completely ignoring the Page’s
+implementation), or it can pass through to the Page’s implementation using the
+`next` argument.
 
 # Request
 
-The request that led to rendering a page, which is similar to a standard Express Request but is somewhat more constrained because of the need to be applicable on both client and server side. Note that several methods return special “not available” values when run on the client side.
+The request that led to rendering a page, which is similar to a standard
+Express Request but is somewhat more constrained because of the need to be
+applicable on both client and server side. Note that several methods return
+special “not available” values when run on the client side.
 
 `getUrl(): String`
 
@@ -208,26 +275,40 @@ The request that led to rendering a page, which is similar to a standard Express
 
 `getHttpHeader(name: String): String | Request.HEADERS_NOT_AVAILABLE`
 
-* Gets the value for a particular HTTP header. If this is a client-side page transition, then the response will always be Request.HEADERS_NOT_AVAILABLE.
+* Gets the value for a particular HTTP header. If this is a client-side page
+  transition, then the response will always be Request.HEADERS_NOT_AVAILABLE.
 
 `getHttpHeaders(): Object | Request.HEADERS_NOT_AVAILABLE`
 
-* Returns all the HTTP headers as name:value pairs. If this is a client-side page transition, then the response will always be Request.HEADERS_NOT_AVAILABLE.
+* Returns all the HTTP headers as name:value pairs. If this is a client-side
+  page transition, then the response will always be
+  Request.HEADERS_NOT_AVAILABLE.
 
 `getCookie(name: String): String`
 
-* Retrieves the value of the cookie with the specified name. Note that httpOnly cookies will not be available on the client-side.
+* Retrieves the value of the cookie with the specified name. Note that
+  httpOnly cookies will not be available on the client-side.
 
 `getCookies(): Object`
 
-* Returns all cookies as name:value pairs. Note that httpOnly cookies will not be available on the client-side.
+* Returns all cookies as name:value pairs. Note that httpOnly cookies will not
+  be available on the client-side.
 
 # EarlyPromise(T) extends Promise(T)
 
-A Promise that can be interrupted and forced to return a value while still pending, perhaps with a value that is only partly finished. The main use case is for timeouts that fire before Promise fulfillment, but for values that could be useful in a partially finished state (imagine an image that could be useful, if fuzzy, when half-decrypted). This allows the client to retrieve a partially usable value even if the Promise never fulfills.
+A Promise that can be interrupted and forced to return a value while still
+pending, perhaps with a value that is only partly finished. The main use case
+is for timeouts that fire before Promise fulfillment, but for values that
+could be useful in a partially finished state (imagine an image that could be
+useful, if fuzzy, when half-decrypted). This allows the client to retrieve a
+partially usable value even if the Promise never fulfills.
 
 `getValue(): T`
 
-* Returns the value of the Promise, perhaps in a partially completed state if the promise is still pending. May return null if there is nothing of interest yet available. If the promise has already fulfilled, then get **MUST** return the value that was resolved. If the promise rejected, then get **MUST** throw that same error.
+* Returns the value of the Promise, perhaps in a partially completed state if
+  the promise is still pending. May return null if there is nothing of
+  interest yet available. If the promise has already fulfilled, then get
+  **MUST** return the value that was resolved. If the promise rejected, then
+  get **MUST** throw that same error.
 
 * This method **MUST NOT** throw an error if it is fulfilled or pending.

--- a/packages/react-server/docs/understanding-rendering.md
+++ b/packages/react-server/docs/understanding-rendering.md
@@ -1,27 +1,55 @@
 # Understanding Rendering
 
-Given that react-server is about using universal JavaScript to make server- and client-side rendering as similar as possible, it can be hard to understand which part of a large react-server application is rendering any given part of a "finished" html document.  This guide will help you understand how different parts of the rendering lifecycle take place, and how the final document is assembled.
+Given that react-server is about using universal JavaScript to make server-
+and client-side rendering as similar as possible, it can be hard to understand
+which part of a large react-server application is rendering any given part of
+a "finished" html document.  This guide will help you understand how different
+parts of the rendering lifecycle take place, and how the final document is
+assembled.
 
-On the server, in renderMiddleware, each component to render is represented by a promise that's resolved immediately if there's no data requirement, or when data resolves, if created by RootElements.createWhenResolved, or a similar function (note that this is ​_effectively_​ what happens; the actual rendering can happen out of order, but elements are streamed to the browser sequentially).
+On the server, in renderMiddleware, each component to render is represented by
+a promise that's resolved immediately if there's no data requirement, or when
+data resolves, if created by RootElements.createWhenResolved, or a similar
+function (note that this is _effectively_ what happens; the actual
+rendering can happen out of order, but elements are streamed to the browser
+sequentially).
 
-## On the server​
-​*pre-timeout:*​
+## On the server
+*pre-timeout:*
 - for each promise for a React component (in order):
-   - if it is resolved already, render the component returned by the promise and stream it to the client
-   - if it isn't resolved, we'll wait until it is resolved ​_or_​ the timeout is hit.
+   - if it is resolved already, render the component returned by the promise
+     and stream it to the client
+   - if it isn't resolved, we'll wait until it is resolved _or_
+     the timeout is hit.
 
-​*when timeout is hit*​:
+*when timeout is hit*:
 - for each promise that hasn't yet rendered (in order):
-   - call getValue() -- we ​_force_ it to give us a component to render; by default, this is whatever component was passed to RootElement.createWhenResolved, but we render it _without_​ data being available, and stream it to the client as is.
+   - call getValue() -- we _force_ it to give us a component to render;
+     by default, this is whatever component was passed to
+     RootElement.createWhenResolved, but we render it _without_ data
+     being available, and stream it to the client as is.
 
-- keep http connection open on server, streaming out `<script>` tags with new data responses as they resolve
+- keep http connection open on server, streaming out `<script>` tags with new
+  data responses as they resolve
 
 ## In the browser
-- do an initial render of ​_all_​ components w/ whatever data was available server-side (so that react can re-attach without getting confused)
+- do an initial render of _all_ components w/ whatever data was
+  available server-side (so that react can re-attach without getting confused)
 - set up data promises client-side for all data not yet received
-- resolve promises on the store whenever new data arrives, until all data has arrived
+- resolve promises on the store whenever new data arrives, until all data has
+  arrived
 
-The timeout, then, is the ​_maximum_​ amount of time we're willing to wait to render server-side before _any_ content is render in the browser.  To ensure that the final document is completed after the server has timed out, we're force-render everything server-side immediately following  the timeout, then let the client pick up where the server left off.  Some middleware components may render immediately, if they are first in the document and do not require an asynchronous data call, regardless of timeout.
+The timeout, then, is the _maximum_ amount of time we're willing
+to wait to render server-side before _any_ content is render in the browser.
+To ensure that the final document is completed after the server has timed out,
+we're force-render everything server-side immediately following  the timeout,
+then let the client pick up where the server left off.  Some middleware
+components may render immediately, if they are first in the document and do
+not require an asynchronous data call, regardless of timeout.
 
-For projects that ensure that elements on the page don't "jump" (change absolute location on the page) as other elements render in, they'll need to set the data wait on the server to a time that is longer than  if they don't have good no-data content in the widgets
-- always render placeholder ​_something_​ server-side, even if they don't have data.
+For projects that ensure that elements on the page don't "jump" (change
+absolute location on the page) as other elements render in, they'll need to
+set the data wait on the server to a time that is longer than  if they don't
+have good no-data content in the widgets
+- always render placeholder _something_ server-side, even if they don't have
+  data.

--- a/packages/react-server/docs/why-react-server.md
+++ b/packages/react-server/docs/why-react-server.md
@@ -1,14 +1,32 @@
 # react-server
 
-React is an amazing library for client-side user interface, and it has the added benefit of being able to be rendered on the server, which is crucial for SEO, SEM, and user experience. However, server-side rendering in practice is significantly more complicated than just calling `React.renderToString` and piping out the result, especially if you want to make sure your site loads quickly in a mobile-first world.
+React is an amazing library for client-side user interface, and it has the
+added benefit of being able to be rendered on the server, which is crucial for
+SEO, SEM, and user experience. However, server-side rendering in practice is
+significantly more complicated than just calling `React.renderToString` and
+piping out the result, especially if you want to make sure your site loads
+quickly in a mobile-first world.
 
 `react-server`:
-1. Smoothes out the common problems you run into with React server-side rendering.
-1. Encodes performance best practices into the framework, making it easy to build high performance websites by default.
+1. Smoothes out the common problems you run into with React server-side
+   rendering.
+1. Encodes performance best practices into the framework, making it easy to
+   build high performance websites by default.
 
 ## What we talk about when we talk about performance
 
-When we talk about performance in `react-server`, we're mostly talking about _perceived performance_. We believe that [WebPageTest](http://www.webpagetest.org/) is correct to focus on how much time it takes from the moment the user navigates the browser until the content above the fold is painted. There are other important perceived performance metrics (like time to first content painted, time to all content painted, and time to full interactivity), but in developing react-server, we have focused most on reducing time to above-the-fold paint. WebPageTest's [Speed Index](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index) is probably the best current measure of above-the-fold paint speed, as it takes into account how quickly the content is painted during load, not just the total time to full completion.
+When we talk about performance in `react-server`, we're mostly talking about
+_perceived performance_. We believe that
+[WebPageTest](http://www.webpagetest.org/) is correct to focus on how much
+time it takes from the moment the user navigates the browser until the content
+above the fold is painted. There are other important perceived performance
+metrics (like time to first content painted, time to all content painted, and
+time to full interactivity), but in developing react-server, we have focused
+most on reducing time to above-the-fold paint. WebPageTest's [Speed
+Index](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index)
+is probably the best current measure of above-the-fold paint speed, as it
+takes into account how quickly the content is painted during load, not just
+the total time to full completion.
 
 In order to facilitate blazing perceived performance, `react-server` implements the following:
 
@@ -24,95 +42,319 @@ We'll examine each of these in turn and discuss why it makes it easier for web d
 
 ## Parallelize backend queries
 
-Traditional server-side rendering in frameworks like Ruby on Rails or Java Servlets has suffered from the fact that calls to the backend are usually synchronous. This means that every call to the backend to retrieve data happens in serial, meaning that page latency is at least the sum of the execution time of all backend requests. As a result, every feature added to a page slows down the time to first byte, and performance of the page degrades over time.
+Traditional server-side rendering in frameworks like Ruby on Rails or Java
+Servlets has suffered from the fact that calls to the backend are usually
+synchronous. This means that every call to the backend to retrieve data
+happens in serial, meaning that page latency is at least the sum of the
+execution time of all backend requests. As a result, every feature added to a
+page slows down the time to first byte, and performance of the page degrades
+over time.
 
-In traditional LAMP, LAMJ, or RoR stacks, attempts to optimize this problem usually involve rewriting backend queries to retrieve more data at once, lowering the roundtrip cost to the backend, but this is time-consuming, error-prone, and often has unpredictable effects on performance, particularly for systems that use RDBMSes as their data store. Developers who care about performance have strong incentives to create bigger and more complicated backend queries to keep performance acceptable, which creates instability risk.
+In traditional LAMP, LAMJ, or RoR stacks, attempts to optimize this problem
+usually involve rewriting backend queries to retrieve more data at once,
+lowering the roundtrip cost to the backend, but this is time-consuming,
+error-prone, and often has unpredictable effects on performance, particularly
+for systems that use RDBMSes as their data store. Developers who care about
+performance have strong incentives to create bigger and more complicated
+backend queries to keep performance acceptable, which creates instability
+risk.
 
-In `react-server`, we advocate for performing as much of the backend data access as possible in parallel to speed up time to first byte from the server. Thus, if there are 10 backend data calls that each take 50ms, the server can theoretically finish access to the backend in 50ms rather than 500ms in a traditional, serial stack. Additionally, developers working with `react-server` and looking to speed up server performance have the right incentives: they are encouraged to break down big backend queries into smaller, more parallelizable queries. Smaller, more focused queries lower the risk of strain on the backend. Performance work can also have the added benefit of increasing stability.
+In `react-server`, we advocate for performing as much of the backend data
+access as possible in parallel to speed up time to first byte from the server.
+Thus, if there are 10 backend data calls that each take 50ms, the server can
+theoretically finish access to the backend in 50ms rather than 500ms in a
+traditional, serial stack. Additionally, developers working with
+`react-server` and looking to speed up server performance have the right
+incentives: they are encouraged to break down big backend queries into
+smaller, more parallelizable queries. Smaller, more focused queries lower the
+risk of strain on the backend. Performance work can also have the added
+benefit of increasing stability.
 
-Parallel data access is mostly facilitated by node itself, which is built for highly asynchronous server applications. `react-server`, however, assumes that you will access the backend in a massively parallel way, and it facilitates building a user interface on top of parallel, asynchronous data access.
+Parallel data access is mostly facilitated by node itself, which is built for
+highly asynchronous server applications. `react-server`, however, assumes that
+you will access the backend in a massively parallel way, and it facilitates
+building a user interface on top of parallel, asynchronous data access.
 
 ## Use a client-side data cache
 
-One thing you quickly learn when you use React server-side rendering is that you have to "reconnect" React on the client side to the HTML markup you generated on the server side, and that's not always as easy as it seems. Ideally, reconnecting goes something like this:
+One thing you quickly learn when you use React server-side rendering is that
+you have to "reconnect" React on the client side to the HTML markup you
+generated on the server side, and that's not always as easy as it seems.
+Ideally, reconnecting goes something like this:
 
-1. On the server side, call `React.renderToString` on a React element that you wish to render. This returns a string that represents a document fragment. The root of that document fragment will have an attribute (`data-react-checksum`) that is a simple checksum of the text of the entire fragment.
+1. On the server side, call `React.renderToString` on a React element that you
+   wish to render. This returns a string that represents a document fragment.
+   The root of that document fragment will have an attribute
+   (`data-react-checksum`) that is a simple checksum of the text of the entire
+   fragment.
 1. The server returns the document fragment to the browser wrapped in an HTML page.
-1. In the browser, once the document has been loaded, the JavaScript code runs again, this time calling `React.render` on the React element and also passing in the root of the pre-rendered HTML in the document.
-1. React will construct a virtual DOM and run its checksum on that virtual DOM. If the checksum matches the `data-react-checksum` embedded in the pre-rendered HTML, React knows that the browser DOM is already in sync with its virtual DOM, and React doesn't have to do any browser DOM operations. If React finds that the checksums differ, however, it will blow away the existing DOM and replace it with the contents of the virtual DOM. This is a potentially expensive operation, and you want to avoid it if you can.
+1. In the browser, once the document has been loaded, the JavaScript code runs
+   again, this time calling `React.render` on the React element and also
+   passing in the root of the pre-rendered HTML in the document.
+1. React will construct a virtual DOM and run its checksum on that virtual
+   DOM. If the checksum matches the `data-react-checksum` embedded in the
+   pre-rendered HTML, React knows that the browser DOM is already in sync with
+   its virtual DOM, and React doesn't have to do any browser DOM operations.
+   If React finds that the checksums differ, however, it will blow away the
+   existing DOM and replace it with the contents of the virtual DOM. This is a
+   potentially expensive operation, and you want to avoid it if you can.
 
-The key lesson here is that when you send down pre-rendered markup from the server, you must also send down the exact data you used to construct that markup. If you don't, it's very likely that the virtual DOM you construct on the client side will end up looking different than the HTML you generated on the server side, and you will lose a major performance benefit of server-side rendering.
+The key lesson here is that when you send down pre-rendered markup from the
+server, you must also send down the exact data you used to construct that
+markup. If you don't, it's very likely that the virtual DOM you construct on
+the client side will end up looking different than the HTML you generated on
+the server side, and you will lose a major performance benefit of server-side
+rendering.
 
-In `react-server`, components on the server side load data via HTTP calls to the backend services of their choice, and `react-server` packages all those results into a **client-side data cache** that is sent down to the browser along with the HTML markup. The client-side data cache ensures that when the code runs again in the browser, it will have access to exactly the same data that the server side code did, and the client will therefore generate exactly the same DOM as the server did.
+In `react-server`, components on the server side load data via HTTP calls to
+the backend services of their choice, and `react-server` packages all those
+results into a **client-side data cache** that is sent down to the browser
+along with the HTML markup. The client-side data cache ensures that when the
+code runs again in the browser, it will have access to exactly the same data
+that the server side code did, and the client will therefore generate exactly
+the same DOM as the server did.
 
-But a client-side data cache doesn't just help with correctness when reconnecting client-side code to server-side markup; there's also a huge performance benefit. The client-side data cache makes sure that data calls on the client return instantly, as they don't require an expensive network call to download data. From a developers perspective, this happens transparently and by default.
+But a client-side data cache doesn't just help with correctness when
+reconnecting client-side code to server-side markup; there's also a huge
+performance benefit. The client-side data cache makes sure that data calls on
+the client return instantly, as they don't require an expensive network call
+to download data. From a developers perspective, this happens transparently
+and by default.
 
 ## Stream pre-rendered HTML
 
-Once we have parallel backend services and a client-side data cache, we're well on our way to developing a web experience that has good perceived performance.
+Once we have parallel backend services and a client-side data cache, we're
+well on our way to developing a web experience that has good perceived
+performance.
 
-However, as our page gets more longer and more fully featured, we run into another problem: our entire page, from header to footer, needs to be generated before we can send even the first byte to the browser. This means that the browser is waiting for all of our backend calls to finish and for `React.renderToString` to return on the server before it even sees a body tag. We can easily lose hundreds of milliseconds or more during which the browser could be parsing and even displaying above-the-fold content.
+However, as our page gets more longer and more fully featured, we run into
+another problem: our entire page, from header to footer, needs to be generated
+before we can send even the first byte to the browser. This means that the
+browser is waiting for all of our backend calls to finish and for
+`React.renderToString` to return on the server before it even sees a body tag.
+We can easily lose hundreds of milliseconds or more during which the browser
+could be parsing and even displaying above-the-fold content.
 
-To solve this, `react-server` has the concept of a `RootElement`. Every page in a `react-server` app has multiple `RootElements`, and they stream down to the browser as soon as they are ready to render. That way, adding more content to a page at the bottom need not slow down above-the-fold paint.
+To solve this, `react-server` has the concept of a `RootElement`. Every page
+in a `react-server` app has multiple `RootElements`, and they stream down to
+the browser as soon as they are ready to render. That way, adding more content
+to a page at the bottom need not slow down above-the-fold paint.
 
-As a common example, imagine that we have a simple site where we want to show a user his or her profile. The page has three main sections: header, profile, and footer. While the profile section probably needs information from our backend, it's likely that the header doesn't need any at all. If we make the header its own `RootElement`, `react-server` will start streaming the header to the browser immediately, without waiting on any backend services at all, meaning that the user's browser can get a header back potentially within just a few milliseconds. Browsers are well equipped to render partial pages, and the user will be shown some content while the primary part of the page is still loading.
+As a common example, imagine that we have a simple site where we want to show
+a user his or her profile. The page has three main sections: header, profile,
+and footer. While the profile section probably needs information from our
+backend, it's likely that the header doesn't need any at all. If we make the
+header its own `RootElement`, `react-server` will start streaming the header
+to the browser immediately, without waiting on any backend services at all,
+meaning that the user's browser can get a header back potentially within just
+a few milliseconds. Browsers are well equipped to render partial pages, and
+the user will be shown some content while the primary part of the page is
+still loading.
 
 ## Render quickly despite a slow backend
 
-Now we have a server that is executing backend requests in parallel, sending down a client data cache, and streaming out HTML as soon as it's ready for the browser. Added together, these features make it feasible for complicated, interactive sites to paint on screen in hundreds of milliseconds on desktop and under a second on mobile.
+Now we have a server that is executing backend requests in parallel, sending
+down a client data cache, and streaming out HTML as soon as it's ready for the
+browser. Added together, these features make it feasible for complicated,
+interactive sites to paint on screen in hundreds of milliseconds on desktop
+and under a second on mobile.
 
-However, we still have a problem: in the real world, things go wrong, and sometimes the backend is slow to respond. Maybe garbage collection is causing a performance blip; maybe a DDoS has hit one of your APIs. Operations can be unpredictable, and we need to degrade smartly in that case. What's worse, our emphasis on parallel queries across many different backend servers can increase the risk that we will encounter a server experiencing a performance issue.
+However, we still have a problem: in the real world, things go wrong, and
+sometimes the backend is slow to respond. Maybe garbage collection is causing
+a performance blip; maybe a DDoS has hit one of your APIs. Operations can be
+unpredictable, and we need to degrade smartly in that case. What's worse, our
+emphasis on parallel queries across many different backend servers can
+increase the risk that we will encounter a server experiencing a performance
+issue.
 
 When server rendering is stuck waiting for a slow backend, there are three choices the server can make.
 
-First, the server can just wait for as long as it takes for the backend to return before rendering. Obviously, this is dangerous, as we have no idea how long the backend will take. And in the meantime, the end user is getting no feedback as to whether the site is making progress or not. If we leave the user hanging for a second or three while we wait on the backend, we can expect that he or she will walk away.
+First, the server can just wait for as long as it takes for the backend to
+return before rendering. Obviously, this is dangerous, as we have no idea how
+long the backend will take. And in the meantime, the end user is getting no
+feedback as to whether the site is making progress or not. If we leave the
+user hanging for a second or three while we wait on the backend, we can expect
+that he or she will walk away.
 
-Second, the server can timeout and render the page using just the data that did come back, re-requesting the offending endpoint on the client side. A page will frequently depend on a dozen or more API endpoints, and it's often the case that a reasonably usable page can be constructed even when one or two of the data endpoints is missing. This requires some more care in UI coding, as it's necessary to handle null data and display appropriate errors or loading spinners, but it's a good strategy for getting the user back a degraded but possibly usable experience. In this strategy we also re-issue the offending data request on the client side and, if the data ever returns, we re-render the page with the slowpoke data included.
+Second, the server can timeout and render the page using just the data that
+did come back, re-requesting the offending endpoint on the client side. A page
+will frequently depend on a dozen or more API endpoints, and it's often the
+case that a reasonably usable page can be constructed even when one or two of
+the data endpoints is missing. This requires some more care in UI coding, as
+it's necessary to handle null data and display appropriate errors or loading
+spinners, but it's a good strategy for getting the user back a degraded but
+possibly usable experience. In this strategy we also re-issue the offending
+data request on the client side and, if the data ever returns, we re-render
+the page with the slowpoke data included.
 
-While this second approach improves perceived performance at the cost of a small amount of UI special case coding, it has one major flaw: it increases both the latency of and load on the slow backend query.
+While this second approach improves perceived performance at the cost of a
+small amount of UI special case coding, it has one major flaw: it increases
+both the latency of and load on the slow backend query.
 
-To see how it increases latency, imagine that we have a page that is coded to timeout and render at 300ms after the HTTP request comes in. Further, imagine that nine of its backend queries complete in 50ms, but one laggard API is consistently taking 400ms due to underpowered hardware. At 300ms after the request, the server decides to render without the slow API data, and it sends the rendered HTML down to the client. Let's assume that the browser takes another 500ms to parse and display all the content, and it then re-issues an XHR to retrieve the missing data call. It is now about 800ms after the initial request, and we reset the clock on the slow data request. The slow API request takes another 400ms to complete, meaning that the data doesn't get to the browser until 1.2s after the first request, even though the actual latency was a third of that.
+To see how it increases latency, imagine that we have a page that is coded to
+timeout and render at 300ms after the HTTP request comes in. Further, imagine
+that nine of its backend queries complete in 50ms, but one laggard API is
+consistently taking 400ms due to underpowered hardware. At 300ms after the
+request, the server decides to render without the slow API data, and it sends
+the rendered HTML down to the client. Let's assume that the browser takes
+another 500ms to parse and display all the content, and it then re-issues an
+XHR to retrieve the missing data call. It is now about 800ms after the initial
+request, and we reset the clock on the slow data request. The slow API request
+takes another 400ms to complete, meaning that the data doesn't get to the
+browser until 1.2s after the first request, even though the actual latency was
+a third of that.
 
-What's worse, in this example we've doubled the load on an already fragile service by making a call from both the server and the client. This is the kind of design that cascading failures are made of: it creates a tipping point in performance where a poorly performing service suddenly gets penalized with double the traffic, potentially bringing the service down.
+What's worse, in this example we've doubled the load on an already fragile
+service by making a call from both the server and the client. This is the kind
+of design that cascading failures are made of: it creates a tipping point in
+performance where a poorly performing service suddenly gets penalized with
+double the traffic, potentially bringing the service down.
 
-To see the third way that server rendering engines can deal with misbehaving backends, notice that in our example, the slow data query has actually returned at 400ms, while the browser is rendering the content that came down from the server. We have the data on the server side, and if we could figure out a way to send it down to the client, we'd be able to avoid both the extra latency and the extra load on the backend.
+To see the third way that server rendering engines can deal with misbehaving
+backends, notice that in our example, the slow data query has actually
+returned at 400ms, while the browser is rendering the content that came down
+from the server. We have the data on the server side, and if we could figure
+out a way to send it down to the client, we'd be able to avoid both the extra
+latency and the extra load on the backend.
 
-It turns out that this is possible. By leaving the HTTP connection from the server to the client open and not closing the HTML document with an `</html>` tag, we can wait for the laggard data endpoint to return and then push it down in an inline `<script>` tag when it completes. The client side code will see this as an event that requires a re-render, and the slow data will be incorporated into the page. We will paint for the user as early as possible, and we won't increase the load on the backend service.
+It turns out that this is possible. By leaving the HTTP connection from the
+server to the client open and not closing the HTML document with an `</html>`
+tag, we can wait for the laggard data endpoint to return and then push it down
+in an inline `<script>` tag when it completes. The client side code will see
+this as an event that requires a re-render, and the slow data will be
+incorporated into the page. We will paint for the user as early as possible,
+and we won't increase the load on the backend service.
 
-`react-server` implements this third strategy **by default**. A developer doesn't need to do anything to get fault-tolerance and still have fast painting for the end user.
+`react-server` implements this third strategy **by default**. A developer
+doesn't need to do anything to get fault-tolerance and still have fast
+painting for the end user.
 
 ## Enforce page hygiene through the `Page` API
 
-Beyond data loading, there are a ton of frontend best practices that have been known for years, primarily around how to load CSS and JavaScript in the most performant way. [Steve Souders](https://www.stevesouders.com/) pioneered this field with his books [High Performance Websites](http://www.amazon.com/dp/0596529309?tag=stevsoud-20&camp=14573&creative=327641&linkCode=as1&creativeASIN=0596529309&adid=00GNM1ZWW77KSD0RERXN&) and [Even Faster Websites](http://www.amazon.com/dp/0596522304?tag=stevsoud-20&camp=213381&creative=390973&linkCode=as4&creativeASIN=0596522304&adid=09TZDJ7Z5GDMJPAM6XC6&), and others have built on that work.
+Beyond data loading, there are a ton of frontend best practices that have been
+known for years, primarily around how to load CSS and JavaScript in the most
+performant way. [Steve Souders](https://www.stevesouders.com/) pioneered this
+field with his books [High Performance
+Websites](http://www.amazon.com/dp/0596529309?tag=stevsoud-20&camp=14573&creative=327641&linkCode=as1&creativeASIN=0596529309&adid=00GNM1ZWW77KSD0RERXN&)
+and [Even Faster
+Websites](http://www.amazon.com/dp/0596522304?tag=stevsoud-20&camp=213381&creative=390973&linkCode=as4&creativeASIN=0596522304&adid=09TZDJ7Z5GDMJPAM6XC6&),
+and others have built on that work.
 
-Unfortunately, though, although these rules are fairly  well-known, they can be hard to follow in practice. Even if you have a page that follows all of the rules perfectly, over time other engineers come in and add features that make performance mistakes. A single external synchronous JavaScript file can obliterate months of careful performance work. Regular performance testing is one way to guard against mishaps, but it requires a lot of infrastructure and operational complexity.
+Unfortunately, though, although these rules are fairly  well-known, they can
+be hard to follow in practice. Even if you have a page that follows all of the
+rules perfectly, over time other engineers come in and add features that make
+performance mistakes. A single external synchronous JavaScript file can
+obliterate months of careful performance work. Regular performance testing is
+one way to guard against mishaps, but it requires a lot of infrastructure and
+operational complexity.
 
-In `react-server`, we've attempted to implement well-known asset loading performance practices by default, and when possible make it impossible for developers to contravene them. Our `Page` API requires that developers define their CSS and JavaScript in a structured way, and since there is no way for developers to write directly to the output stream, there simply is no way for them to include those assets in incorrect ways. For example, there is literally no way in `react-server` to load a JavaScript file in a blocking manner (which is the default in most browsers and depressingly common on the web).
+In `react-server`, we've attempted to implement well-known asset loading
+performance practices by default, and when possible make it impossible for
+developers to contravene them. Our `Page` API requires that developers define
+their CSS and JavaScript in a structured way, and since there is no way for
+developers to write directly to the output stream, there simply is no way for
+them to include those assets in incorrect ways. For example, there is
+literally no way in `react-server` to load a JavaScript file in a blocking
+manner (which is the default in most browsers and depressingly common on the
+web).
 
-Furthermore, as new asset loading best practices are discovered and refined, they can be centrally implemented in `react-server` without changing client code. Providing an API between the developer and the HTML written out allows forward compatibility with new performance gains.
+Furthermore, as new asset loading best practices are discovered and refined,
+they can be centrally implemented in `react-server` without changing client
+code. Providing an API between the developer and the HTML written out allows
+forward compatibility with new performance gains.
 
 ## Enable single page applications without code bloat
 
-Navigating to a new page is one of the slowest things that happens in modern web apps. A new HTML page needs to be generated and downloaded, and only then will CSS and JavaScript be downloaded, parsed, and executed. Even well-architected pages will have dependencies which can add serial steps to the page load waterfall, and many developers underestimate how long it takes to parse and execute JavaScript.
+Navigating to a new page is one of the slowest things that happens in modern
+web apps. A new HTML page needs to be generated and downloaded, and only then
+will CSS and JavaScript be downloaded, parsed, and executed. Even
+well-architected pages will have dependencies which can add serial steps to
+the page load waterfall, and many developers underestimate how long it takes
+to parse and execute JavaScript.
 
-To combat this, over the past decade some in the web developer community have embraced the [single-page application](http://en.wikipedia.org/wiki/Single-page_application), or SPA. The idea behind an SPA is that the browser downloads all the code for an application on first page load. The upside to this is that when a user clicks on an internal link that would normally download a new HTML page and force a reparsing of CSS & JavaScript, the app can instead simply use XHR to download the data for the new page and generate the new page on the fly through DOM manipulation.
+To combat this, over the past decade some in the web developer community have
+embraced the [single-page
+application](http://en.wikipedia.org/wiki/Single-page_application), or SPA.
+The idea behind an SPA is that the browser downloads all the code for an
+application on first page load. The upside to this is that when a user clicks
+on an internal link that would normally download a new HTML page and force a
+reparsing of CSS & JavaScript, the app can instead simply use XHR to download
+the data for the new page and generate the new page on the fly through DOM
+manipulation.
 
-This potentially makes page-to-page transitions quite quick, but it has a more sinister effect on the application's first load time. As you add new pages to the app, the first load time gets longer and longer; large SPAs can easily end up having megabytes of JavaScript on first load if not optimized. What's worse, the code that's being preloaded is often not needed, as it's unlikely that a user will click on every different page in an app.
+This potentially makes page-to-page transitions quite quick, but it has a more
+sinister effect on the application's first load time. As you add new pages to
+the app, the first load time gets longer and longer; large SPAs can easily end
+up having megabytes of JavaScript on first load if not optimized. What's
+worse, the code that's being preloaded is often not needed, as it's unlikely
+that a user will click on every different page in an app.
 
-While many SPA frameworks [have ways](https://oclazyload.readme.io/) to lazy-load code for developers who are looking to optimize, in `react-server`, lazy loading is **built-in as the default**. In `react-server`, the developer declaratively defines the logical Pages in their app. When a user navigates to a URL, only the CSS and JavaScript for that page is loaded into the browser. When the user navigates to a second page in your app, the CSS & JavaScript for that second page is automatically asynchronously loaded (and the CSS for the first page is automatically removed from the page so as not to cause rendering bugs). Under the covers, `react-server` uses [webpack](http://webpack.github.io/) to lazily load code. This ensures that page-to-page navigation is fast, but that adding new pages to an app doesn't slow it down.
+While many SPA frameworks [have ways](https://oclazyload.readme.io/) to
+lazy-load code for developers who are looking to optimize, in `react-server`,
+lazy loading is **built-in as the default**. In `react-server`, the developer
+declaratively defines the logical Pages in their app. When a user navigates to
+a URL, only the CSS and JavaScript for that page is loaded into the browser.
+When the user navigates to a second page in your app, the CSS & JavaScript for
+that second page is automatically asynchronously loaded (and the CSS for the
+first page is automatically removed from the page so as not to cause rendering
+bugs). Under the covers, `react-server` uses
+[webpack](http://webpack.github.io/) to lazily load code. This ensures that
+page-to-page navigation is fast, but that adding new pages to an app doesn't
+slow it down.
 
 ## Look ahead to HTTP/2
 
-Finally, we believe that `react-server` puts developers ahead of the game in the transition from HTTP/1.x to HTTP/2. **We haven't implemented any HTTP/2 support yet**, but we believe our APIs and performance optimizations will translate very well to HTTP/2. A few of the ideas we have for HTTP/2 are:
+Finally, we believe that `react-server` puts developers ahead of the game in
+the transition from HTTP/1.x to HTTP/2. **We haven't implemented any HTTP/2
+support yet**, but we believe our APIs and performance optimizations will
+translate very well to HTTP/2. A few of the ideas we have for HTTP/2 are:
 
-* **Server Push for CSS and JavaScript**: Currently in `react-server`, the server knows which CSS files and JavaScript files are associated with a particular page very early in the rendering process, but we have to wait for the document head to be sent down to the browser and for the browser to turn around and request the assets. This is exactly the scenario that Server Push was made for; `react-server` could start pushing CSS and JavaScript files as soon as the HTTP request connection is made. As an added benefit, the first 100 or 200ms of an HTTP connection are often a dead time in the client-server connection as the server works on rendering, so the bandwidth is underutilized. Pushing CSS and JavaScript will use bandwidth better and potentially even help overcome TCP slowstart.
+* **Server Push for CSS and JavaScript**: Currently in `react-server`, the
+  server knows which CSS files and JavaScript files are associated with a
+  particular page very early in the rendering process, but we have to wait for
+  the document head to be sent down to the browser and for the browser to turn
+  around and request the assets. This is exactly the scenario that Server Push
+  was made for; `react-server` could start pushing CSS and JavaScript files as
+  soon as the HTTP request connection is made. As an added benefit, the first
+  100 or 200ms of an HTTP connection are often a dead time in the
+  client-server connection as the server works on rendering, so the bandwidth
+  is underutilized. Pushing CSS and JavaScript will use bandwidth better and
+  potentially even help overcome TCP slowstart.
 
-* **Server push of API endpoints**: In the current version of `react-server`, the backend API results are sent down in a client-side cache, as noted above. That cache is implemented as an inline `<script>` tag in the HTML page, and it works, but it could be better. First, it doesn't use the browser cache when an API result is cacheable. Second, we currently wait until the end of the page to send down the client-side cache, as we don't want to block sending down markup. With server push, we could fix both of these problems. API endpoints would be pushed separately and therefore cacheable by URL, and interleaving of streams would mean that we could send down API results as soon as we get them without blocking the sending of HTML markup.
+* **Server push of API endpoints**: In the current version of `react-server`,
+  the backend API results are sent down in a client-side cache, as noted
+  above. That cache is implemented as an inline `<script>` tag in the HTML
+  page, and it works, but it could be better. First, it doesn't use the
+  browser cache when an API result is cacheable. Second, we currently wait
+  until the end of the page to send down the client-side cache, as we don't
+  want to block sending down markup. With server push, we could fix both of
+  these problems. API endpoints would be pushed separately and therefore
+  cacheable by URL, and interleaving of streams would mean that we could send
+  down API results as soon as we get them without blocking the sending of HTML
+  markup.
 
-* **Server push of other assets, such as images**: Further down the road, we suspect it will be possible to put hooks into the rendering to pre-emptively send down images before our HTML finishes rendering.
+* **Server push of other assets, such as images**: Further down the road, we
+  suspect it will be possible to put hooks into the rendering to pre-emptively
+  send down images before our HTML finishes rendering.
 
-* **Use stream priority as a way to tune performance** As web networking guru Ilya Grigorik [has written](http://chimera.labs.oreilly.com/books/1230000000545/ch13.html#_removing_1_x_optimizations), the transition to HTTP/2 will mean that developers will need to unlearn the performance habits they learned in HTTP/1.x. We believe that a performant HTTP/2 implementation will involve the browser downloading more independent HTTP resources than HTTP/1, but they will of course be multiplexed over a single TCP connection. Using stream priority smartly with application logic may become critical for best HTTP/2 performance, and `react-server` will be positioned perfectly to test out the best way to tune that.
+* **Use stream priority as a way to tune performance** As web networking guru
+  Ilya Grigorik [has
+  written](http://chimera.labs.oreilly.com/books/1230000000545/ch13.html#_removing_1_x_optimizations),
+  the transition to HTTP/2 will mean that developers will need to unlearn the
+  performance habits they learned in HTTP/1.x. We believe that a performant
+  HTTP/2 implementation will involve the browser downloading more independent
+  HTTP resources than HTTP/1, but they will of course be multiplexed over a
+  single TCP connection. Using stream priority smartly with application logic
+  may become critical for best HTTP/2 performance, and `react-server` will be
+  positioned perfectly to test out the best way to tune that.
 
 ## Final thoughts
 
-React is rightly celebrated for its speed and ease-of-coding when rendering in the browser, but it requires some extra help to be truly fast on the server-side as well. `react-server` provides that help, and we've seen really fantastic performance results so far in our own site. However, we know that we built this for ourselves, and we're certain that there are use cases we never considered. Please let us know what we missed  so that we can make `react-server` a robust server-side rendering solution for React that truly guarantees great performance by default. Thanks!
+React is rightly celebrated for its speed and ease-of-coding when rendering in
+the browser, but it requires some extra help to be truly fast on the
+server-side as well. `react-server` provides that help, and we've seen really
+fantastic performance results so far in our own site. However, we know that we
+built this for ourselves, and we're certain that there are use cases we never
+considered. Please let us know what we missed  so that we can make
+`react-server` a robust server-side rendering solution for React that truly
+guarantees great performance by default. Thanks!

--- a/packages/react-server/docs/writing-middleware.md
+++ b/packages/react-server/docs/writing-middleware.md
@@ -1,12 +1,29 @@
 # What is a middleware?
 
-Middleware are plugins that allow for some transformation of the request or response object while react-server is processing the request and response.  First, the request object is passed down through each middleware in the middleware stack in turn, calling `next()` to indicate that they are done with the request object and ready to yield control down the chain.  At some point, one of the middlewares may decide that it should respond to the request, and a request object is created.  This request object is passed through each of the middlewares on the way back up, who each may mutate the response object in some way.
+Middleware are plugins that allow for some transformation of the request or
+response object while react-server is processing the request and response.
+First, the request object is passed down through each middleware in the
+middleware stack in turn, calling `next()` to indicate that they are done with
+the request object and ready to yield control down the chain.  At some point,
+one of the middlewares may decide that it should respond to the request, and a
+request object is created.  This request object is passed through each of the
+middlewares on the way back up, who each may mutate the response object in
+some way.
 
-An example use case for a middleware might be for a user verification system.  The user middleware is invoked as part of the middleware chain with the request object, retrieves the jwt from the request, and makes an asynchronous request to a jwt verifier that returns a promise before calling `next()`.  Then, after the rest of the middleware have been called, and control has been yielded back up to the user authentication verification middleware with the response object, the middleware can check the promise from the verifier to ensure the user has a valid jwt.  If the user does not, the middleware can change the response to be a 403 forbidden.
+An example use case for a middleware might be for a user verification system.
+The user middleware is invoked as part of the middleware chain with the
+request object, retrieves the jwt from the request, and makes an asynchronous
+request to a jwt verifier that returns a promise before calling `next()`.
+Then, after the rest of the middleware have been called, and control has been
+yielded back up to the user authentication verification middleware with the
+response object, the middleware can check the promise from the verifier to
+ensure the user has a valid jwt.  If the user does not, the middleware can
+change the response to be a 403 forbidden.
 
 # What does a react-server middleware look like?
 
-Here's a simple react-server middleware that only sets the ContentType header to application/json for json responses.
+Here's a simple react-server middleware that only sets the ContentType header
+to application/json for json responses.
 
 	module.exports = class JsonEndpoint {
 
@@ -30,4 +47,5 @@ Here's a simple react-server middleware that only sets the ContentType header to
 
 # How do I find out more?
 
-The best place to learn more about how to write middleware is by looking at core/util/PageUtil.
+The best place to learn more about how to write middleware is by looking at
+core/util/PageUtil.


### PR DESCRIPTION
Going to make some updates to these docs, and wanted to get some
non-substantive changes out of the way first to make diffs easier to read down
the road.

- Broke up long lines
    - GitHub's diff UI breaks on very long lines
    - Linewise diffs in general are easier to read with shorter lines
    - Long lines take more cursor time to traverse (linear seek vs 2d seek)
- Removed some zero-width space characters
- Wrapped a `<head>` in backticks so it shows up