### PR TITLE
Remove dependency on `debug`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,4 @@ addons:
       - g++-4.8
 
 before_script:
-  - npm install -g gulp lerna
-  - lerna bootstrap
-
-script: gulp travis-ci
+  - npm run bootstrap

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "gulp": "3.9.1",
     "gulp-chug": "0.5.1",
     "gulp-install": "0.6.0",
-    "lerna": "^1.1.1"
+    "lerna": "v2.0.0-beta.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "bootstrap": "lerna bootstrap",
+    "test": "gulp test"
+  },
   "devDependencies": {
     "eslint": "0.24.1",
     "eslint-plugin-react": "3.0.0",

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^0.14.2",
     "react-server": "^0.1.5",
     "react-server-cli": "^0.1.5",
-    "superagent": "^1.2.0"
+    "superagent": "1.2.0"
   },
   "devDependencies": {
     "babel-plugin-react-require": "^2.1.0",

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -17,7 +17,6 @@
     "cls-q": "1.1.0",
     "cookie": "0.1.2",
     "cookie-parser": "1.3.3",
-    "debug": "2.1.0",
     "eventemitter3": "0.1.6",
     "express-state": "1.2.0",
     "lodash": "3.10.1",


### PR DESCRIPTION
I don't think we're actually using this?

I don't think we've used this since before `logging` (~January 2015)?

Anyway, `nsp` reported a regexp denial of service vulerability.  So, instead
of upgrading I'm just removing, since... I don't think we're actually using
this? :grin:

![image](https://cloud.githubusercontent.com/assets/115908/14752464/46cfc4ce-0884-11e6-9c82-1c56e733763a.png)
