### PR TITLE
Cleaning up promise-from-getHeadStylesheets test page

### DIFF
--- a/packages/react-server-test-pages/pages/data/EchoCssPage.js
+++ b/packages/react-server-test-pages/pages/data/EchoCssPage.js
@@ -1,0 +1,13 @@
+
+export default class EchoCssPage {
+	setConfigValues() {
+		return { isRawResponse: true };
+	}
+	getContentType() {
+		return 'text/css';
+	}
+	getResponseData() {
+		const {css} = this.getRequest().getQuery();
+		return css;
+	}
+}

--- a/packages/react-server-test-pages/pages/styles/promises.js
+++ b/packages/react-server-test-pages/pages/styles/promises.js
@@ -1,19 +1,32 @@
 
 import React from "react";
 
+const greenBackground = `
+	body {
+		background: green;
+	}
+`;
+
+const redBackground = `
+	body {
+		background: red;
+	}
+`;
+
 export default class StylePromises {
 	getHeadStylesheets () {
 		return [
-			delay(1000)
-				.then(() => "./styles/first.css"),
-			delay(100)
-				.then(() => "./styles/second.css"),
+			delay(1000).then(() => `/data/echo-css?css=${encodeURIComponent(redBackground)}`),
+			delay(100).then(() => `/data/echo-css?css=${encodeURIComponent(greenBackground)}`),
 		];
 	}
 
 	getElements () {
 		return [
-			<div>If first.css shows up before second.css in the body of this page, all is well.</div>,
+			<div>
+				<h2>If the background is GREEN at page load, all is well!</h2>
+				<div>If it flashes red first, all is _not_ well.</div>
+			</div>,
 		]
 	}
 

--- a/packages/react-server-test-pages/routes.js
+++ b/packages/react-server-test-pages/routes.js
@@ -16,6 +16,10 @@ module.exports = {
 			path: ["/data/delay"],
 			page: "./pages/data/delay",
 		},
+		CssEcho: {
+			path: ["/data/echo-css"],
+			page: "./pages/data/EchoCssPage",
+		},
 	}, _.reduce(require('./entrypoints'), (obj, val, key) => {
 		if (!val.path) val.path = [val.entry];
 		val.page = `./pages${val.entry}`;


### PR DESCRIPTION
Cleaning up getHeadStylesheets with promises test page.

@gigabo encouraged me to be cute, so I added a date endpoint for test pages that echoes CSS back. 