### PR TITLE
The path is at `location.pathname`

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -195,7 +195,7 @@ class ClientController extends EventEmitter {
 					this._history.replaceState(
 						getHistoryStateFrame(),
 						null,
-						location.path
+						location.pathname
 					);
 				}
 
@@ -267,7 +267,7 @@ class ClientController extends EventEmitter {
 
 		const state = _.assign({}, history.state);
 		state.reactServerFrame = _.assign(state.reactServerFrame||{}, opts);
-		this._history.replaceState(state, null, location.path);
+		this._history.replaceState(state, null, location.pathname);
 	}
 
 	_setupNavigateListener () {


### PR DESCRIPTION
`location.path` is undefined.  This is a real bug.

Most browsers just default to the current URL when `undefined` is passed as
the third argument to `history.pushstate`, which masks the bug (makes it
irrelevant, actually).

IE11 replaces the last path element with the string "undefined".

Example: "/navigation/playground" becomes "/navigation/undefined".