### PR TITLE
Handle render before load in frameback frame

### DIFF
--- a/packages/react-server-test-pages/pages/navigation/playground.js
+++ b/packages/react-server-test-pages/pages/navigation/playground.js
@@ -116,6 +116,12 @@ export default class NavigationPlaygroundPage {
 
 		return next();
 	}
+	getTitle() {
+		const {page} = this.getRequest().getQuery();
+		return typeof page === "undefined"
+			?"Navigation Playground"
+			:"Page "+page
+	}
 	getElements() {
 		return [
 			<RootContainer>

--- a/packages/react-server/core/FramebackController.js
+++ b/packages/react-server/core/FramebackController.js
@@ -283,7 +283,11 @@ class FramebackController extends EventEmitter {
 
 		// If the frame has a client controller we'll listen to when
 		// _it_ tells us it's done loading.
-		if (clientController && !clientController.__parentIsListening) {
+		//
+		// It may have finished _before_ we get here, so we'll also check
+		// whether it has already set its `_previouslyRendered` flag.
+		//
+		if (clientController && !clientController.__parentIsListening && !clientController._previouslyRendered) {
 			clientController.__parentIsListening = true;
 			clientController.context.onLoadComplete(this._handleFrameLoad.bind(this, frame));
 			return;


### PR DESCRIPTION
Frame may already be fully rendered during `_handleFrameLoad`.