### PR TITLE
Avoid an infinite refresh loop in IE9

### DIFF
--- a/packages/react-server/core/components/History.js
+++ b/packages/react-server/core/components/History.js
@@ -94,7 +94,11 @@ History.prototype = {
 		var win = this.win;
 		if (this.canClientNavigate()) {
 			win.history.replaceState(state, title, url);
-		} else {
+		} else if (url !== this.currentUrl()) {
+
+			// On browsers that don't support history navigation, only want to
+			// replace state if the URL is actually changing.  Otherwise we're
+			// in for a potential infinite refresh loop.
 			this.navigationWindow().location.replace(url);
 		}
 	},
@@ -116,6 +120,11 @@ History.prototype = {
 		} else {
 			return win;
 		}
+	},
+
+	// This is current URL for current window (not navigation window).
+	currentUrl: function() {
+		return location.pathname + location.search;
 	},
 };
 


### PR DESCRIPTION
We do a `history.replaceState` on page load to mark the navigation stack frame
with request info.  On browsers that don't support the history navigation API
this was causing a _refresh_ on page load, which lead to an infinite refresh
loop.

This patch modifies the fallback behavior to only trigger a navigation if the
URL changes during a `replaceState`.