### PR TITLE
Update test-pages instructions and link from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@ You could:
 - [Build new features][build-new-features]
 - [Contribute to the discussion][contribute-to-the-discussion]
 
+Head over to [react-server-test-pages](/packages/react-server-test-pages) and
+check out the README to get a test server set up.
+
 ## Contributor License Agreement
 
 To get started, please [sign the Contributor License

--- a/packages/react-server-test-pages/README.md
+++ b/packages/react-server-test-pages/README.md
@@ -4,12 +4,19 @@ This is a place for pages that let us play around with react-server features.
 It's not necessarily for automated tests (though we could build some around
 it), it's for interactive testing during development.
 
-Run it thusly:
+Setup (from the repo root):
 
 ```bash
-$ npm start
+$ npm install
+$ npm run bootstrap
+$ cd packages/react-server-test-pages
+$ npm install react-server-cli@../react-server-cli
+$ npm install react-server@../react-server && npm start
 ```
 
 Then hit http://localhost:3000/ to see what's available.
+
+If you make changes in `packages/react-server` you'll need to `CTRL-C` and
+re-run the last line of the setup to pull them in.
 
 Add pages in `entrypoints.js`.  Instructions are at the top.


### PR DESCRIPTION
Can remove the `react-server-cli` line once #134 lands.