### PR TITLE
Issue#145 Replace __reactServerTimingStart with browser's navigation start event

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -53,6 +53,7 @@ class ClientController extends EventEmitter {
 	constructor ({routes}) {
 		super();
 
+		window.__reactServerTimingStart = window.performance ? window.performance.timing.navigationStart : new Date;
 		var wakeTime = new Date - window.__reactServerTimingStart;
 
 		var dehydratedState = window.__reactServerState;


### PR DESCRIPTION
Now that performance API is more readily available in browsers, we want to use the navigation start event for t0 on the client side. This will allow us to remove the script tag that we write synchronously to log the timing on the client side.

The current proxy for t0 comes down after the head is written. This change will inadvertently increase timings that were relying on `__reactServerTimingStart` with however long it takes to write the first byte (TTFB).