### PR TITLE
Add debug script to react-server-test-pages

### DIFF
--- a/packages/react-server-test-pages/README.md
+++ b/packages/react-server-test-pages/README.md
@@ -19,4 +19,6 @@ Then hit http://localhost:3000/ to see what's available.
 If you make changes in `packages/react-server` you'll need to `CTRL-C` and
 re-run the last line of the setup to pull them in.
 
+If you wish to run the test server in debug mode, simply replace `npm start` with `npm run debug`.
+
 Add pages in `entrypoints.js`.  Instructions are at the top.

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prepublish": "gulp build",
     "start": "react-server-cli",
-    "test": "gulp test"
+    "test": "gulp test",
+    "debug": "node-debug --debug-brk=0 -p 9000 react-server-cli"
   },
   "author": "Bo Borgerson",
   "license": "Apache-2.0",
@@ -19,5 +20,8 @@
     "react-server-cli": "^0.2.6",
     "react-server-data-bundle-cache": "^0.2.6",
     "superagent": "1.2.0"
+  },
+  "devDependencies": {
+    "node-inspector": "^0.12.8"
   }
 }


### PR DESCRIPTION
Let us use `npm run debug` in `react-server-test-pages`! I didn't know whether or not to pin a version on `node-inspector`, please let me know if I should and which one to pin to!