### PR TITLE
Links should transclude classes

### DIFF
--- a/packages/react-server/core/components/Link.jsx
+++ b/packages/react-server/core/components/Link.jsx
@@ -12,6 +12,7 @@ module.exports = React.createClass({
 		bundleData : React.PropTypes.bool,
 		frameback  : React.PropTypes.bool,
 		reuseDom   : React.PropTypes.bool,
+		className  : React.PropTypes.string,
 	},
 
 	getDefaultProps(){
@@ -25,7 +26,7 @@ module.exports = React.createClass({
 
 	render: function () {
 		return (
-			<a href={this.props.path} onClick={this._onClick}>{this.props.children}</a>
+			<a href={this.props.path} onClick={this._onClick} className={this.className}>{this.props.children}</a>
 		);
 	},
 


### PR DESCRIPTION
The `Link` component should pass classes attached to it the the underlying anchor tag.