### PR TITLE
Make npm version badge less blurry

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ See [the contributing guide](CONTRIBUTING.md) to get started.
 
 [build-badge-img]: https://travis-ci.org/redfin/react-server.svg?branch=master
 [build-url]: https://travis-ci.org/redfin/react-server
-[npm-badge-img]: https://badge.fury.io/js/react-server.png
+[npm-badge-img]: https://badge.fury.io/js/react-server.svg
 [npm-url]: https://npmjs.org/package/react-server


### PR DESCRIPTION
We were using a pretty blurry png for the npm version badge
<img width="490" alt="screen shot 2016-05-15 at 2 24 20 pm" src="https://cloud.githubusercontent.com/assets/3477707/15276881/412092f6-1aa9-11e6-95ff-d65bf36f31a9.png">

Now its a much less blurry svg badge
<img width="487" alt="screen shot 2016-05-15 at 2 27 31 pm" src="https://cloud.githubusercontent.com/assets/3477707/15276882/483fdf06-1aa9-11e6-81ca-235e81f62d11.png">

