### PR TITLE
Fix `Link` component `className` passthrough

### DIFF
--- a/packages/react-server/core/components/Link.jsx
+++ b/packages/react-server/core/components/Link.jsx
@@ -26,7 +26,7 @@ module.exports = React.createClass({
 
 	render: function () {
 		return (
-			<a href={this.props.path} onClick={this._onClick} className={this.className}>{this.props.children}</a>
+			<a href={this.props.path} onClick={this._onClick} className={this.props.className}>{this.props.children}</a>
 		);
 	},
 


### PR DESCRIPTION
Wasn't pulling from `props`.