### PR TITLE
Approximate above the fold paint time using synchronous script

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -55,6 +55,7 @@ class ClientController extends EventEmitter {
 
 		window.__reactServerTimingStart = window.performance ? window.performance.timing.navigationStart : new Date;
 		var wakeTime = new Date - window.__reactServerTimingStart;
+		var aboveTheFold = window.performance ? (window.__displayAboveTheFold - window.__reactServerTimingStart) : 0;
 
 		var dehydratedState = window.__reactServerState;
 
@@ -82,6 +83,8 @@ class ClientController extends EventEmitter {
 
 		// Log this after loglevel is set.
 		logger.time('wakeFromStart', wakeTime);
+		// this is a proxy for when above the fold content gets painted (displayed) on the browser
+		logger.time('displayAboveTheFold.fromStart', aboveTheFold);
 	}
 
 	terminate() {

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -834,6 +834,7 @@ function writeElements(res, elements) {
 
 		if (i === RLS().atfCount - 1){
 
+			logAboveTheFoldTime(res);
 			// Okay, we've sent all of our above-the-fold HTML,
 			// now we can let the client start waking nodes up.
 			bootstrapClient(res)
@@ -878,6 +879,13 @@ function writeElement(res, element, i){
 			_.map(element.attrs, (v, k) => ` ${k}="${attrfy(v)}"`)
 		}>${element.html}</div>`);
 	}
+}
+
+function logAboveTheFoldTime(res) {
+	// write a synchronous script to record the time on the browser when above the fold content shows up
+	// this is a proxy for "first paint" when the DOM is parsed and painted
+	renderScriptsSync([{text:'__displayAboveTheFold=new Date;' +
+		'window.performance && window.performance.mark && window.performance.mark("displayAboveTheFold.fromStart");'}], res);
 }
 
 function bootstrapClient(res) {


### PR DESCRIPTION
It would be great to have a timing for when above the fold elements are parsed and painted on the client side. A proxy for this would be a synchronous script tag written to the client side right after above the fold elements are written. I'm also using `performance.mark` so that this time point shows up in WPT. In practice, this approximates "first paint" time to within 100ms!

This would really help us understand user-perceived performances on the client side and can help us approximate speed index.

The implementation of this "display" time is different from `displayElement.fromStart`, which might be confusing. There is a separate issue #169 to improve `displayElement` timings.