### PR TITLE
Add test case for getAboveTheFold with RootContainers

### DIFF
--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -9,6 +9,10 @@ module.exports = {
 		entry: "/root/when",
 		description: "<RootElement when={...}>",
 	},
+	AboveTheFold: {
+		entry: "/root/aboveTheFold",
+		description: "Above The Fold Count",
+	},
 	NavigationPlayground: {
 		entry: "/navigation/playground",
 		description: "Navigation playground",

--- a/packages/react-server-test-pages/pages/root/aboveTheFold.js
+++ b/packages/react-server-test-pages/pages/root/aboveTheFold.js
@@ -1,0 +1,28 @@
+import {ReactServerAgent, RootContainer, RootElement} from "react-server"; // eslint-disable-line
+
+// TODO: when we implement <TheFold/> (https://github.com/redfin/react-server/issues/161),
+// update this test page to use the new API
+
+export default class RootWhenPage {
+	handleRoute(next) {
+		this.data = ReactServerAgent.get('/data/delay?ms=200');
+		return next();
+	}
+	getElements() {
+		return [
+			<RootContainer>
+				<div>One</div>
+			</RootContainer>,
+			<RootElement when={this.data}><div>Two</div></RootElement>,
+			<RootContainer>
+				<div>Three - there should be script tags starting from right after me b/c my getAboveTheFoldCount is 3!</div>
+				<RootElement when={this.data}><div>Four</div></RootElement>
+			</RootContainer>,
+			<div>Five</div>,
+		]
+	}
+
+	getAboveTheFoldCount() {
+		return 3;
+	}
+}


### PR DESCRIPTION
This is the test page I wrote to play with `getAboveTheFoldCount` - it's currently not going to show the right result, because I implemented it to do what I wanted it to do (not count `RootContainer` tags towards the `getAboveTheFoldCount`) - lemme know if I oughta change the text to have the reality match the expectations