### PR TITLE
Don't run tests in prepublish

### DIFF
--- a/packages/generator-react-server/package.json
+++ b/packages/generator-react-server/package.json
@@ -32,7 +32,6 @@
   },
   "repository": "redfin/packages/generator-react-server",
   "scripts": {
-    "prepublish": "npm test",
     "test": "ava test && xo && nsp check"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Takes too long.  We'd already ditched this for other packages, but one snuck
in with the yeoman generator.