### PR TITLE
Update versions in generated package.json

### DIFF
--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -15,9 +15,9 @@
     "babel-runtime": "^6.6.1",
     "react": "~0.14.2",
     "react-dom": "~0.14.2",
-    "react-server": "^0.2.0",
-    "react-server-cli": "^0.2.0",
-    "superagent": "^1.2.0"
+    "react-server": "^0.2.10",
+    "react-server-cli": "^0.2.10",
+    "superagent": "1.2.0"
   },
   "devDependencies": {
     "eslint-config-xo-react": "^0.7.0",


### PR DESCRIPTION
- `react-server` currently requires an _exact_ version of superagent.
- Update the `react-server-*` deps while I'm at it.