### PR TITLE
Add a test endpoint for data errors

### DIFF
--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -9,6 +9,10 @@ module.exports = {
 		entry: "/root/when",
 		description: "<RootElement when={...}>",
 	},
+	RootError: {
+		entry: "/root/error",
+		description: "A data error for a root element",
+	},
 	AboveTheFold: {
 		entry: "/root/aboveTheFold",
 		description: "Above The Fold Count",

--- a/packages/react-server-test-pages/pages/data/error.js
+++ b/packages/react-server-test-pages/pages/data/error.js
@@ -1,0 +1,5 @@
+export default class ErrorPage {
+	handleRoute() {
+		return {code: 500};
+	}
+}

--- a/packages/react-server-test-pages/pages/root/error.js
+++ b/packages/react-server-test-pages/pages/root/error.js
@@ -1,0 +1,44 @@
+import {ReactServerAgent, RootElement, Link} from "react-server";
+
+const Okay = ({ok}) => <div>Okay: {""+ok}</div>
+
+export default class RootWhenPage {
+	handleRoute(next) {
+
+		// A good data request with a response of {ok: true}
+		this.good = ReactServerAgent.get('/data/delay')
+			.then(res => res.body);
+
+		// A data request to an endpoint that returns 500.
+		this.bad = ReactServerAgent.get('/data/error');
+
+		// A good data request with an error in post-processing.
+		this.worse = ReactServerAgent.get('/data/delay')
+			.then(() => { throw new Error("Die!") })
+
+		return next();
+	}
+	getElements() {
+		const next = `/root/error?page=${
+			+(this.getRequest().getQuery().page||0)+1
+		}`
+		return [
+			<div>Before good data root</div>,
+			<RootElement when={this.good}>
+				<Okay />
+			</RootElement>,
+			<div>After good data root</div>,
+			<div>Before bad data root</div>,
+			<RootElement when={this.bad}>
+				<Okay />
+			</RootElement>,
+			<div>After bad data root</div>,
+			<div>Before worse data root</div>,
+			<RootElement when={this.worse}>
+				<Okay />
+			</RootElement>,
+			<div>After worse data root</div>,
+			<Link path={next}>Next</Link>,
+		]
+	}
+}

--- a/packages/react-server-test-pages/routes.js
+++ b/packages/react-server-test-pages/routes.js
@@ -20,6 +20,10 @@ module.exports = {
 			path: ["/data/echo-css"],
 			page: "./pages/data/EchoCssPage",
 		},
+		DataError: {
+			path: ["/data/error"],
+			page: "./pages/data/error",
+		},
 	}, _.reduce(require('./entrypoints'), (obj, val, key) => {
 		if (!val.path) val.path = [val.entry];
 		val.page = `./pages${val.entry}`;


### PR DESCRIPTION
Trying to reproduce the behavior described in #189.

@nampas - I haven't been able to repro.  I tried:

1. An endpoint that returns 500
2. A response handler that throws an exception

Neither produces the behavior described in #189.  Can you see anything different about this setup and your repro environment that could help me trigger the bug here?