### PR TITLE
Fix error object normalization in logger interceptor

### DIFF
--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -25,4 +25,8 @@ module.exports = {
 		entry: "/navigation/data-bundle-cache",
 		description: "Data bundle cache",
 	},
+	ErrorLogs: {
+		entry: "/error/logs",
+		description: "Generate errors in the logs",
+	},
 }

--- a/packages/react-server-test-pages/pages/error/logs.js
+++ b/packages/react-server-test-pages/pages/error/logs.js
@@ -1,0 +1,16 @@
+import Q from "q";
+
+import {RootElement} from "react-server";
+
+function fail() {
+	return Q().then(() => { throw new Error("Fail!") });
+}
+
+export default class ErrorLogsPage {
+	getElements() {
+		return [
+			<div>Check the logs</div>,
+			<RootElement when={fail()}>Nope</RootElement>,
+		]
+	}
+}

--- a/packages/react-server/core/logging/server.js
+++ b/packages/react-server/core/logging/server.js
@@ -2,7 +2,7 @@ var winston = require('winston')
 ,   common  = require('./common')
 ,   _ = {
 	mapValues     : require("lodash/mapValues"),
-	pick          : require("lodash/pick"),
+	pickBy        : require("lodash/pickBy"),
 	isPlainObject : require("lodash/isPlainObject"),
 	isEmpty       : require("lodash/isEmpty"),
 	trimStart     : require("lodash/trimStart"),
@@ -68,7 +68,7 @@ function errorInterceptor (level, msg, meta) {
 // massage the error into a format suitable for logging
 function normalizeError (err) {
 	if (err instanceof Error) {
-		return _.pick({
+		return _.pickBy({
 			message: err.message,
 			stack: err.stack,
 		}, val => !_.isEmpty(val));


### PR DESCRIPTION
Error messages and stack traces were missing from logs on the server.

Also added a test page that just generates an error in the logs.