### PR TITLE
Default options for cli overwrite config file options

### DIFF
--- a/packages/react-server-cli/src/defaultOptions.js
+++ b/packages/react-server-cli/src/defaultOptions.js
@@ -23,6 +23,7 @@ export default {
 	gaugeLogLevel: "ok",
 	https: false,
 	longTermCaching: false,
+	routes: "./routes.js",
 	env: {
 		production: {
 			hot: false,

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -4,7 +4,6 @@ export default (args = process.argv) => {
 	var parsedArgs = yargs(args)
 		.usage('Usage: $0 [options]')
 		.option("routes", {
-			default: "./routes.js",
 			describe: "The routes file to load.",
 		})
 		.option("p", {
@@ -13,7 +12,6 @@ export default (args = process.argv) => {
 			type: "number",
 		})
 		.option("host", {
-			default: "localhost",
 			describe: "Hostname to start listening for react-server",
 			type: "string",
 		})


### PR DESCRIPTION
While working #200, I discovered the config files (Specifically the `host` option) were not being set. This is due to parseCliArgs.js having a "default" which comes later in the array which is passed to merge (in mergeOptions.js). This causes the cli default to always override the config file in the case of routes and host.

I've removed the defaults from parseCliArgs.js and moved the routes default to defaultOptions.js. I think that this makes the most sense for default options to be set and is always overwritten by the cli or config file. A better long term solution might be to make the "default" key in the "parseCliArgs.js" file to merely be for display.