### PR TITLE
Build hygenie; try to log more information about the failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-replace": "0.5.2",
     "gulp-sourcemaps": "1.3.0",
     "gulp-substituter": "0.3.0",
+    "gulp-util": "^3.0.7",
     "handlebars": "1.3.0",
     "handlebars-loader": "0.1.7",
     "jasmine": "2.3.1",

--- a/packages/react-server-cli/gulpfile.babel.js
+++ b/packages/react-server-cli/gulpfile.babel.js
@@ -2,25 +2,21 @@ import eslint from "gulp-eslint";
 import gulp from "gulp";
 import babel from "gulp-babel";
 import logging from "react-server-gulp-module-tagger";
+import gutil from "gulp-util";
 
 gulp.task("default", () => {
 	return gulp.src("src/**/*.js")
-		.pipe(logging({trim: 'react-server/packages/'}))
+		.pipe(logging({trim: "react-server/packages/"}))
 		.pipe(babel())
-		.pipe(gulp.dest("target"));
+		.pipe(gulp.dest("target"))
+		.on("error", gutil.log);
 });
 
 gulp.task("eslint", [], () => {
 	return gulp.src("src/*.js")
-        // eslint() attaches the lint output to the eslint property
-        // of the file object so it can be used by other modules.
-        .pipe(eslint())
-        // eslint.format() outputs the lint results to the console.
-        // Alternatively use eslint.formatEach() (see Docs).
-        .pipe(eslint.format())
-        // To have the process exit with an error code (1) on
-        // lint error, return the stream and pipe to failOnError last.
-        .pipe(eslint.failAfterError());
+				.pipe(eslint())
+				.pipe(eslint.format())
+				.pipe(eslint.failAfterError());
 });
 
 // there are no tests for this project :(

--- a/packages/react-server-data-bundle-cache/gulpfile.js
+++ b/packages/react-server-data-bundle-cache/gulpfile.js
@@ -1,32 +1,34 @@
-const path   = require('path');
-const gulp   = require('gulp');
-const nsp    = require('gulp-nsp');
-const babel  = require('gulp-babel');
-const eslint = require('gulp-eslint');
-const rename = require('gulp-rename');
-const tagger = require('react-server-gulp-module-tagger');
+const path   = require("path");
+const gulp   = require("gulp");
+const nsp    = require("gulp-nsp");
+const babel  = require("gulp-babel");
+const eslint = require("gulp-eslint");
+const rename = require("gulp-rename");
+const tagger = require("react-server-gulp-module-tagger");
 
 const SRC = "src/**/*.js";
 
-gulp.task('build', ['build-index', 'build-lib']);
+gulp.task("build", ["build-index", "build-lib"]);
 
-gulp.task('build-index', () => gulp.src('main.js')
-	.pipe(tagger({trim: 'react-server/packages/'}))
-	.pipe(rename('index.js'))
+gulp.task("build-index", () => gulp.src("main.js")
+	.pipe(tagger({trim: "react-server/packages/"}))
+	.pipe(rename("index.js"))
 	.pipe(gulp.dest("."))
+	.on("error", gutil.log)
 )
 
-gulp.task('build-lib', () => gulp.src(SRC)
+gulp.task("build-lib", () => gulp.src(SRC)
 	.pipe(babel())
 	.pipe(gulp.dest("./lib"))
+	.on("error", gutil.log)
 );
 
-gulp.task('eslint', [], () =>  gulp.src(SRC)
+gulp.task("eslint", [], () =>  gulp.src(SRC)
 	.pipe(eslint())
 	.pipe(eslint.format())
 	.pipe(eslint.failAfterError())
 );
 
-gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
+gulp.task("nsp", (cb) => nsp({package: path.resolve("package.json")}, cb));
 
-gulp.task('test', ['nsp', 'eslint']);
+gulp.task("test", ["nsp", "eslint"]);

--- a/packages/react-server-examples/gulpfile.babel.js
+++ b/packages/react-server-examples/gulpfile.babel.js
@@ -3,15 +3,9 @@ import gulp from "gulp";
 
 gulp.task("eslint", [], () => {
 	return gulp.src(["./hello-world/*.js"])
-        // eslint() attaches the lint output to the eslint property
-        // of the file object so it can be used by other modules.
-        .pipe(eslint())
-        // eslint.format() outputs the lint results to the console.
-        // Alternatively use eslint.formatEach() (see Docs).
-        .pipe(eslint.format())
-        // To have the process exit with an error code (1) on
-        // lint error, return the stream and pipe to failOnError last.
-        .pipe(eslint.failAfterError());
+				.pipe(eslint())
+				.pipe(eslint.format())
+				.pipe(eslint.failAfterError());
 });
 
 // there are no tests for this project :(

--- a/packages/react-server-gulp-module-tagger/gulpfile.js
+++ b/packages/react-server-gulp-module-tagger/gulpfile.js
@@ -1,14 +1,14 @@
-const path   = require('path');
-const gulp   = require('gulp');
-const nsp    = require('gulp-nsp');
-const eslint = require('gulp-eslint');
+const path   = require("path");
+const gulp   = require("gulp");
+const nsp    = require("gulp-nsp");
+const eslint = require("gulp-eslint");
 
-gulp.task('eslint', [], () =>  gulp.src("index.js")
+gulp.task("eslint", [], () =>  gulp.src("index.js")
 	.pipe(eslint())
 	.pipe(eslint.format())
 	.pipe(eslint.failAfterError())
 );
 
-gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
+gulp.task("nsp", (cb) => nsp({package: path.resolve("package.json")}, cb));
 
-gulp.task('test', ['nsp', 'eslint']);
+gulp.task("test", ["nsp", "eslint"]);

--- a/packages/react-server-integration-tests/gulpfile.babel.js
+++ b/packages/react-server-integration-tests/gulpfile.babel.js
@@ -7,11 +7,11 @@ function isVerbose () {
 	return !!options.verbose;
 }
 var availableOptions = {
-	'boolean': [ 'verbose', 'skipSourcemaps' ],
-	'string' : [ 'specs' ],
-	'default': {
-		'verbose': false,
-		'skipSourcemaps': false,
+	"boolean": [ "verbose", "skipSourcemaps" ],
+	"string" : [ "specs" ],
+	"default": {
+		"verbose": false,
+		"skipSourcemaps": false,
 	},
 }
 var options = minimist(process.argv.slice(2), availableOptions);
@@ -35,15 +35,11 @@ function getSpecGlob (prefix) {
 gulp.task("compile", () => {
 	return gulp.src("src/**/*.js")
 		.pipe(babel())
-		.pipe(gulp.dest("target"));
+		.pipe(gulp.dest("target"))
+		.on("error", gutil.log);
 });
 
 gulp.task("test", ["compile"], function() {
-
 	return gulp.src(getSpecGlob("target/**/__tests__/**/"))
 		.pipe(jasmine(isVerbose() ? {verbose:true, includeStackTrace: true} : {}));
-});
-
-gulp.task("eslint", [], function() {
-	// we don't care as much about linting tests.
 });

--- a/packages/react-server-test-pages/gulpfile.babel.js
+++ b/packages/react-server-test-pages/gulpfile.babel.js
@@ -9,7 +9,7 @@ gulp.task("travis-ci", ["build"]);
 
 gulp.task("build", ["eslint", "nsp"]);
 
-gulp.task('nsp', cb => nsp({package: path.resolve('package.json')}, cb));
+gulp.task("nsp", cb => nsp({package: path.resolve("package.json")}, cb));
 
 gulp.task("eslint", [], () => gulp.src(SRC)
 	.pipe(eslint())

--- a/packages/react-server/gulpfile.js
+++ b/packages/react-server/gulpfile.js
@@ -1,6 +1,6 @@
 var gulp = require("gulp"),
-	path = require('path'),
-	nsp = require('gulp-nsp'),
+	path = require("path"),
+	nsp = require("gulp-nsp"),
 	replace = require("gulp-replace"),
 	rename = require("gulp-rename"),
 	sourcemaps = require("gulp-sourcemaps"),
@@ -9,17 +9,18 @@ var gulp = require("gulp"),
 	jasmine = require("gulp-jasmine"),
 	common = require("./buildutils/gulp-common"),
 	logging = require("react-server-gulp-module-tagger"),
-	istanbul = require('gulp-istanbul'),
+	istanbul = require("gulp-istanbul"),
 	gulpif = require("gulp-if"),
 	minimist = require("minimist"),
-	eslint = require('gulp-eslint');
+	eslint = require("gulp-eslint"),
+	gutil = require("gulp-util");
 
 var availableOptions = {
-	'boolean': [ 'verbose', 'skipSourcemaps' ],
-	'string' : [ 'specs' ],
-	'default': {
-		'verbose': false,
-		'skipSourcemaps': false,
+	"boolean": [ "verbose", "skipSourcemaps" ],
+	"string" : [ "specs" ],
+	"default": {
+		"verbose": false,
+		"skipSourcemaps": false,
 	},
 }
 var options = minimist(process.argv.slice(2), availableOptions);
@@ -51,11 +52,11 @@ var src = ["core/**/*.js", "core/**/*.jsx", "core/**/*.json"];
 
 function compile(serverSide) {
 	var codeFilter = filter(["**/*.js", "**/*.jsx"]);
-	var dest = 'target/' + (serverSide ? "server" : "client");
+	var dest = "target/" + (serverSide ? "server" : "client");
 	return gulp.src(src)
 		.pipe(codeFilter)
-			.pipe(changed(dest, {extension: '.js'}))
-			.pipe(logging({trim: 'react-server/packages/'}))
+			.pipe(changed(dest, {extension: ".js"}))
+			.pipe(logging({trim: "react-server/packages/"}))
 			.pipe(replace("SERVER_SIDE", serverSide ? "true" : "false"))
 			.pipe(gulpif(shouldSourcemap(), sourcemaps.init()))
 			.pipe(common.es6Transform())
@@ -64,10 +65,11 @@ function compile(serverSide) {
 				path.extname = ".js";
 			}))
 		.pipe(codeFilter.restore())
-		.pipe(gulp.dest(dest));
+		.pipe(gulp.dest(dest))
+		.on("error", gutil.log);
 }
 
-gulp.task('compile', ["compileClient", "compileServer"]);
+gulp.task("compile", ["compileClient", "compileServer"]);
 
 gulp.task("compileClient", function() {
 	return compile(false);
@@ -79,32 +81,31 @@ gulp.task("compileServer", function() {
 
 gulp.task("build", ["compile"]);
 
-gulp.task('watch', function () {
+gulp.task("watch", function () {
 	gulp.watch(src, ["build"]);
 });
 
 gulp.task("test-coverage", ["compileServer", "compileClient"], function(cb) {
-	gulp.src(['target/server/**/*.js', "!target/server/test/**/*.js", "!target/server/test-temp/**/*.js"])
+	gulp.src(["target/server/**/*.js", "!target/server/test/**/*.js", "!target/server/test-temp/**/*.js"])
 		.pipe(istanbul({includeUntested:true})) // Covering files
 		.pipe(gulp.dest("target/server-covered")) // copy covered files to a parallel directory
-		.on('finish', function () {
+		.on("finish", function () {
 			gulp.src("target/server/test/**/*.js")
 				.pipe(gulp.dest("target/server-covered/test"))
 				.on("finish", function() {
-					gulp.src(getSpecGlob('target/server-covered/test/**/')).pipe(jasmine())
-						.pipe(istanbul.writeReports({dir: './target/coverage'})) // Creating the reports after tests runned
-						.on('end', cb);
+					gulp.src(getSpecGlob("target/server-covered/test/**/")).pipe(jasmine())
+						.pipe(istanbul.writeReports({dir: "./target/coverage"})) // Creating the reports after tests runned
+						.on("end", cb);
 				});
 		});
 });
 
 
-gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
+gulp.task("nsp", (cb) => nsp({package: path.resolve("package.json")}, cb));
 
 gulp.task("test", ["jasmine", "eslint", "nsp"]);
 
 gulp.task("jasmine", ["compileServer", "compileClient"], function() {
-
 	return gulp.src(getSpecGlob("target/server/**/__tests__/**/"))
 		.pipe(jasmine(isVerbose() ? {verbose:true, includeStackTrace: true} : {}));
 });
@@ -115,17 +116,7 @@ gulp.task("eslint", [], function() {
 		"!**/*.json",
 	]);
 	return gulp.src(srcMinusTest)
-        // eslint() attaches the lint output to the eslint property
-        // of the file object so it can be used by other modules.
-        .pipe(eslint())
-        // eslint.format() outputs the lint results to the console.
-        // Alternatively use eslint.formatEach() (see Docs).
-        .pipe(eslint.format())
-        // To have the process exit with an error code (1) on
-        // lint error, return the stream and pipe to failOnError last.
-        .pipe(eslint.failAfterError());
+				.pipe(eslint())
+				.pipe(eslint.format())
+				.pipe(eslint.failAfterError());
 });
-
-// todo: where should tests go?
-
-// todo: add clean


### PR DESCRIPTION
Working on #216 
I'm getting a bunch of weird, inconsistent build failures that manifest as `Exit status 1`; I'm trying to get them to log more information.  While I'm at it, I'm also cleaning up some stray comments (copy-pasted from the eslint docs) and standardizing our build scripts on tabs, rather than a mix of tabs and spaces.