### PR TITLE
Trim dangling root nodes with `reuseDom`

### DIFF
--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -9,6 +9,10 @@ module.exports = {
 		entry: "/root/attributes",
 		description: "Attributes on root elements and containers",
 	},
+	RootReuseTrim: {
+		entry: "/root/reuse-trim",
+		description: "Dangling nodes should be trimmed with `reuseDom`",
+	},
 	RootWhen: {
 		entry: "/root/when",
 		description: "<RootElement when={...}>",

--- a/packages/react-server-test-pages/pages/root/reuse-trim.js
+++ b/packages/react-server-test-pages/pages/root/reuse-trim.js
@@ -1,0 +1,15 @@
+import {Link} from "react-server";
+
+export default class RootReuseTrimPage {
+	getElements() {
+		const {trim} = this.getRequest().getQuery();
+		const ret = [
+			<Link reuseDom={true} path="/root/reuse-trim?trim=1">trim</Link>,
+			<div>There should{trim?<em> not</em>:''} be an element below this one.</div>,
+		];
+		if (!trim) {
+			ret.push(<div>Here I am!</div>);
+		}
+		return ret;
+	}
+}

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -662,6 +662,13 @@ class ClientController extends EventEmitter {
 
 		return retval.promise.then(() => {
 
+			if (this._reuseDom) {
+
+				// Clean up any dangling nodes if the previous page had more
+				// than we do.
+				this._cleanupPreviousRender(elementPromises.length);
+			}
+
 			// This first one is just for historical continuity.
 			logger.time('render', new Date - t0);
 


### PR DESCRIPTION
A `reuseDom` transition to a page with fewer root elements leaves root elements from the previous page hanging out in the DOM.  This patch cleans them up.

Addresses #127.