### PR TITLE
Standardize routes file configuration (and rename `--routes` => `--routes-file`)

### DIFF
--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -15,4 +15,4 @@ if (argv.httpsKey || argv.httpsCert || argv.httpsCa || argv.httpsPfx || argv.htt
 	}
 }
 
-start(argv.routes, argv);
+start(argv);

--- a/packages/react-server-cli/src/defaultOptions.js
+++ b/packages/react-server-cli/src/defaultOptions.js
@@ -23,7 +23,7 @@ export default {
 	gaugeLogLevel: "ok",
 	https: false,
 	longTermCaching: false,
-	routes: "./routes.js",
+	routesFile: "./routes.js",
 	env: {
 		production: {
 			hot: false,

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -3,8 +3,8 @@ import yargs from "yargs"
 export default (args = process.argv) => {
 	var parsedArgs = yargs(args)
 		.usage('Usage: $0 [options]')
-		.option("routes", {
-			describe: "The routes file to load.",
+		.option("routes-file", {
+			describe: "The routes file to load. Default is 'routes.js'.",
 		})
 		.option("p", {
 			alias: "port",

--- a/packages/react-server-cli/src/startServer.js
+++ b/packages/react-server-cli/src/startServer.js
@@ -17,7 +17,7 @@ const logger = logging.getLogger(__LOGGER__);
 // stop. started is a promise that resolves when all necessary servers have been
 // started. stop is a method to stop all servers. It takes no arguments and
 // returns a promise that resolves when the server has stopped.
-export default (routesRelativePath, options = {}) => {
+export default (options = {}) => {
 	// for the option properties that weren't sent in, look for a config file
 	// (either .reactserverrc or a reactServer section in a package.json). for
 	// options neither passed in nor in a config file, use the defaults.
@@ -26,10 +26,11 @@ export default (routesRelativePath, options = {}) => {
 	setupLogging(options.logLevel, options.timingLogLevel, options.gaugeLogLevel);
 	logProductionWarnings(options);
 
-	return startImpl(routesRelativePath, options);
+	return startImpl(options);
 }
 
-const startImpl = (routesRelativePath, {
+const startImpl = ({
+		routesFile,
 		host,
 		port,
 		jsPort,
@@ -44,7 +45,7 @@ const startImpl = (routesRelativePath, {
 		throw new Error("If you set https.pfx, you can't set https.key, https.cert, or https.ca.");
 	}
 
-	const routesPath = path.resolve(process.cwd(), routesRelativePath);
+	const routesPath = path.resolve(process.cwd(), routesFile);
 	const routes = require(routesPath);
 
 	const outputUrl = jsUrl || `${httpsOptions ? "https" : "http"}://${host}:${jsPort}/`;

--- a/packages/react-server-integration-tests/src/specRuntime/testHelper.js
+++ b/packages/react-server-integration-tests/src/specRuntime/testHelper.js
@@ -97,7 +97,8 @@ var startServer = function (specFile, routes) {
 
 	var routesFile = writeRoutesFile(specFile, routes, testTempDir);
 
-	return start(routesFile, {
+	return start({
+		routesFile: routesFile,
 		hot: false,
 		port: PORT,
 		logLevel: "emergency",


### PR DESCRIPTION
Previously the routes file took a special path through function calls that
prevented it from receiving values from the normal configuration sieve
(defaults => config file => cli).

When the (redundant) CLI default was removed in #206 this meant that a routes
file _must be specified on the command line_.

This patch standardizes handling of routes file configuration.  It also
changes the name of the `--routes` option to `--routes-file` to more
accurately reflect what it is (and to avoid a name conflict with an existing
`const` in `startServer.js`).  As such this is a breaking change.