### PR TITLE
Faster integration test teardown

### DIFF
--- a/packages/react-server-integration-tests/src/specRuntime/testHelper.js
+++ b/packages/react-server-integration-tests/src/specRuntime/testHelper.js
@@ -11,6 +11,8 @@ var	fs = require("fs"),
 // these during a top-level `npm test`.
 var PORT = process.env.PORT || 8770;
 
+process.env.NODE_ENV = "test";
+
 var stopFns = [];
 
 function getBrowser(opts) {


### PR DESCRIPTION
The integration test process was hanging around after completion, sometimes
for a long time.  Turns out zombie was holding a keep-alive connection open to
the static asset server.  This patch destroys the socket on teardown which
lets the server shut down.

This addresses #262.