### PR TITLE
Use ava tap output for generator tests

### DIFF
--- a/packages/generator-react-server/package.json
+++ b/packages/generator-react-server/package.json
@@ -33,7 +33,7 @@
   },
   "repository": "redfin/packages/generator-react-server",
   "scripts": {
-    "test": "ava test && xo && nsp check",
+    "test": "ava test --tap && xo && nsp check",
     "clean": "rimraf npm-debug.log*"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This is kind of hilarious, actually. The default ava reporter was filling up
the `lerna run` input buffer by erasing and re-drawing its spinner while it
waited for the test to complete.

This patch just switches to the tap reporter, which doesn't do that.