### PR TITLE
Set the repository correctly in the generator's package.json

### DIFF
--- a/packages/generator-react-server/package.json
+++ b/packages/generator-react-server/package.json
@@ -31,7 +31,7 @@
     "yeoman-assert": "^2.0.0",
     "yeoman-test": "^1.0.0"
   },
-  "repository": "redfin/packages/generator-react-server",
+  "repository": "redfin/react-server",
   "scripts": {
     "test": "ava test --tap && xo && nsp check",
     "clean": "rimraf npm-debug.log*"


### PR DESCRIPTION
I think (guess) this is preventing stars from showing up on http://yeoman.io/generators/

![image](https://cloud.githubusercontent.com/assets/115908/15914262/4e70a7a4-2d94-11e6-87ab-250967d4a7f0.png)
