### PR TITLE
Add test port manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ npm test
 
 That will, among other things, run [`eslint`](/.eslintrc).
 
+If you add a new test that starts a server, make sure to update the
+testing port registry to make sure there aren't any conflicts.  Our
+CI test target runs many packages' tests simultaneously, so its
+important that every server starts on a unique port.  You can find
+the manifest in the docs.
+
 ## Contributor License Agreement
 
 To get started, please [sign the Contributor License

--- a/docs/testing-ports.md
+++ b/docs/testing-ports.md
@@ -1,0 +1,10 @@
+We need to be certain there aren't any packages that run tests on
+the same port, as our CI test target runs many packages' tests 
+simultaneously, so port conflicts will fail the tests.  Make sure
+to update this manifest when adding a test that starts a server.
+
+## generator-react-server 
+3010, 3011
+
+## react-server-integration-test
+8770, 3001

--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -5,7 +5,7 @@
   "main": "HelloWorld.js",
   "scripts": {
     "compile": "gulp",
-    "start": "react-server-cli --routes build/routes.js",
+    "start": "react-server-cli --port 3010 --js-port 3011 --routes build/routes.js",
     "test": "xo && nsp check && ava test.js"
   },
   "license": "Apache-2.0",

--- a/packages/generator-react-server/generators/app/templates/test.js
+++ b/packages/generator-react-server/generators/app/templates/test.js
@@ -39,7 +39,7 @@ function getResponseCode(url) {
 	return new Promise((resolve, reject) => {
 		const req = http.get({
 			hostname: 'localhost',
-			port: 3000,
+			port: 3010,
 			path: url
 		}, res => {
 			resolve(res.statusCode);


### PR DESCRIPTION
As suggested in https://github.com/redfin/react-server/pull/282#issuecomment-225273000
Note: the manifest may be incomplete or out-and-out wrong, as my test target is currently throwing