### PR TITLE
Unbreak the build from nsp 118

### DIFF
--- a/packages/generator-react-server/generators/app/templates/_nsprc
+++ b/packages/generator-react-server/generators/app/templates/_nsprc
@@ -1,3 +1,3 @@
 {
-  "exceptions": ["https://nodesecurity.io/advisories/106"]
+  "exceptions": ["https://nodesecurity.io/advisories/106", "https://nodesecurity.io/advisories/118"]
 }

--- a/packages/react-server-cli/.nsprc
+++ b/packages/react-server-cli/.nsprc
@@ -1,3 +1,3 @@
 {
-  "exceptions": ["https://nodesecurity.io/advisories/106"]
+  "exceptions": ["https://nodesecurity.io/advisories/118"]
 }

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "babel-core": "~6.5.1",
+    "babel-core": "^6.9.1",
     "babel-loader": "~6.2.2",
     "babel-runtime": "^6.3.19",
     "chunk-manifest-webpack-plugin": "0.0.1",
@@ -30,7 +30,7 @@
     "q": "~1.4.1",
     "react-hot-loader": "~1.3.0",
     "style-loader": "~0.12.3",
-    "webpack": "~1.12.0",
+    "webpack": "^1.13.1",
     "webpack-dev-server": "~1.14.1",
     "yargs": "~3.15.0"
   },


### PR DESCRIPTION
Resolves this build failure on master

```

Errored while running npm script 'test' in 'react-server-cli'
Error: Command failed: /bin/sh -c npm run test
(+) 2 vulnerabilities found
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ minimatch                                                       │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 2.0.10                                                          │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=3.0.1                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >=3.0.2                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ react-server-cli@0.3.2 > babel-core@6.9.1 > minimatch@2.0.10    │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/118                          │
└───────────────┴─────────────────────────────────────────────────────────────────┘
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ minimatch                                                       │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 2.0.10                                                          │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=3.0.1                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >=3.0.2                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ react-server-cli@0.3.2 > webpack@1.13.1 > watchpack@0.2.9 > ch… │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/118                          │
└───────────────┴─────────────────────────────────────────────────────────────────┘


npm ERR! Darwin 15.4.0
npm ERR! argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "run" "test"
npm ERR! node v4.3.1
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE
npm ERR! react-server-cli@0.3.2 test: `gulp test && nsp check`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-cli@0.3.2 test script 'gulp test && nsp check'.
npm ERR! This is most likely a problem with the react-server-cli package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp test && nsp check
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-server-cli
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/doug.wade/code/react-server/packages/react-server-cli/npm-debug.log

    at ChildProcess.exithandler (child_process.js:213:12)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:821:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
Errored while running RunCommand.execute
Error: Command failed: /bin/sh -c npm run test
(+) 2 vulnerabilities found
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ minimatch                                                       │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 2.0.10                                                          │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=3.0.1                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >=3.0.2                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ react-server-cli@0.3.2 > babel-core@6.9.1 > minimatch@2.0.10    │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/118                          │
└───────────────┴─────────────────────────────────────────────────────────────────┘
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ minimatch                                                       │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 2.0.10                                                          │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=3.0.1                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >=3.0.2                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ react-server-cli@0.3.2 > webpack@1.13.1 > watchpack@0.2.9 > ch… │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/118                          │
└───────────────┴─────────────────────────────────────────────────────────────────┘


npm ERR! Darwin 15.4.0
npm ERR! argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "run" "test"
npm ERR! node v4.3.1
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE
npm ERR! react-server-cli@0.3.2 test: `gulp test && nsp check`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-cli@0.3.2 test script 'gulp test && nsp check'.
npm ERR! This is most likely a problem with the react-server-cli package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp test && nsp check
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-server-cli
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/doug.wade/code/react-server/packages/react-server-cli/npm-debug.log

    at ChildProcess.exithandler (child_process.js:213:12)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:821:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
```