### PR TITLE
Cat npm-debug.logs on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ addons:
 
 before_script:
   - npm run bootstrap
+
+after_failure:
+  - npm run debug

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "bootstrap": "npm i; lerna bootstrap",
     "test": "lerna run test",
     "clean": "rimraf lerna-debug.log && lerna run clean",
-    "nuke": "lerna clean && rm -r node_modules"
+    "nuke": "lerna clean && rm -r node_modules",
+    "debug": "cat lerna-debug.log && for d in packages/*/npm-debug.log*; do echo $d; cat $d; done"
   },
   "devDependencies": {
     "babel-plugin-react-require": "^2.1.0",


### PR DESCRIPTION
#280 and #294 are plagued by failures that I can't repro locally.  Dump every `npm-debug.log` in the monorepo to stdout so they're available in the travis logs.