### PR TITLE
Downgrade webpack-dev-server to 1.13.0

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -31,7 +31,7 @@
     "react-hot-loader": "~1.3.0",
     "style-loader": "~0.12.3",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "~1.14.1",
+    "webpack-dev-server": "~1.13.0",
     "yargs": "~3.15.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This is new enough to pass `nsp check`, but old enough to not suffer from [this bug](https://github.com/webpack/webpack-dev-server/pull/515).

This fixes #311.