### PR TITLE
add dev dependency on babel-cli to babel plugin

### DIFF
--- a/packages/babel-plugin-react-server/package.json
+++ b/packages/babel-plugin-react-server/package.json
@@ -9,6 +9,7 @@
     "react-server-module-tagger": "^0.0.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.10.1",
     "babel-core": "^6.3.17",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",


### PR DESCRIPTION
i caught this doing release testing -- seems i forgot a dev dependency