### PR TITLE
Unbreak the links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,17 +10,17 @@ scope for our documentation, but come swing by our gitter if you'd like to talk
 about it.
 
 If you still aren't convinced on React Server, check out our
-[Why React Server](/why-react-server.md) doc, which explains why you might want
-to use React Server, and the [Design Doc](/design.md), which explains why we
+[Why React Server](/docs/why-react-server.md) doc, which explains why you might want
+to use React Server, and the [Design Doc](/docs/design.md), which explains why we
 built React Server and some of the decisions we made along the way.
 
 To get started working with a new React Server project, you'll probably want to
-check out the [Writing pages guide](/writing-pages.md) first, which details how
+check out the [Writing pages guide](/docs/writing-pages.md) first, which details how
 to create a new web page in a React Server app.  You'll also want to check out
-the [Page API](/page-api.md), and you may want to also check out
-[Writing Middleware](/writing-middleware.md), which explains how to write code
+the [Page API](/docs/page-api.md), and you may want to also check out
+[Writing Middleware](/docs/writing-middleware.md), which explains how to write code
 that runs for every route.
 
 To dig deeper into understanding React Server, you may want to learn about
-[how logging works](/logging.md), [client transitions](/client-transitions.md),
-and [understanding rendering](/understanding-rendering.md).
+[how logging works](/docs/logging.md), [client transitions](docs/client-transitions.md),
+and [understanding rendering](/docs/understanding-rendering.md).


### PR DESCRIPTION
Not sure how relative links in github markdown works but it was broken, maybe cuz this README file got moved?