### PR TITLE
Issue #317: Add node version to Package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "superagent": "1.2.0",
     "webpack": "1.13.1",
     "zombie": "4.1.0"
+  },
+  "engine": {
+  	"node": ">4.2.1"
   }
 }


### PR DESCRIPTION
While this won't actually enforce that people use a specific Node version, this will at least serve as a reference for users to know what versions of node this was intended to run with.

Original issue: #317.