### PR TITLE
Making react-server-cli a relative dependency

### DIFF
--- a/packages/react-server-website/package.json
+++ b/packages/react-server-website/package.json
@@ -15,7 +15,7 @@
     "react": "~0.14.2",
     "react-dom": "~0.14.2",
     "react-server": "^0.3.4",
-    "react-server-cli": "^0.4.0",
+    "react-server-cli": "../react-server-cli",
     "superagent": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue reproduction:

1. In repo root `npm run bootstrap`.
1. `cd packages/react-server`
1. `npm start`

This results in the following:
```
$ npm start

> example@0.0.1 start /Users/david.alber/dev/react-server/packages/react-server-website
> react-server-cli --port 3010 --js-port 3011

sh: react-server-cli: command not found
.
.
.
```

This is fixed by using a relative dependency in react-server-website.