### PR TITLE
Making react-server a relative dependency

### DIFF
--- a/packages/react-server-website/package.json
+++ b/packages/react-server-website/package.json
@@ -14,7 +14,7 @@
     "babel-runtime": "^6.6.1",
     "react": "~0.14.2",
     "react-dom": "~0.14.2",
-    "react-server": "^0.3.4",
+    "react-server": "../react-server",
     "react-server-cli": "../react-server-cli",
     "superagent": "1.2.0"
   },


### PR DESCRIPTION
Issue reproduction:

1. In repo root `npm run bootstrap`.
1. `cd packages/react-server`
1. `npm start`

This results in the example site loading, but assets not being loadable.

I misunderstood [this comment](https://github.com/redfin/react-server/pull/356#issuecomment-233721471) from @gigabo earlier. This PR applies the suggestion from the comment.