### PR TITLE
Add a `/docs/foo` endpoint

### DIFF
--- a/packages/react-server-website/components/doc-body.js
+++ b/packages/react-server-website/components/doc-body.js
@@ -1,0 +1,8 @@
+import {Component} from 'react';
+import ReactMarkdown from 'react-markdown';
+
+export default class DocBody extends Component {
+	render() {
+		return <ReactMarkdown source={ this.props.text } />
+	}
+}

--- a/packages/react-server-website/lib/get-doc-body.js
+++ b/packages/react-server-website/lib/get-doc-body.js
@@ -1,0 +1,7 @@
+import {ReactServerAgent} from "react-server";
+
+export default function getDocBody(path) {
+	return ReactServerAgent
+		.get("/api/docs", {path})
+		.then(res => res.body);
+}

--- a/packages/react-server-website/pages/docs.js
+++ b/packages/react-server-website/pages/docs.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { RootContainer } from "react-server";
+
+import getDocBody from "../lib/get-doc-body";
+import DocBody from "../components/doc-body";
+
+const README = "README.md";
+
+export default class DocsPage {
+	handleRoute(next) {
+		const path = this.getRequest().getRouteParams().path || README;
+		this.bodyPromise = getDocBody(`/docs/${path}.md`);
+		return next();
+	}
+	getElements() {
+		return <RootContainer when={this.bodyPromise}>
+			<DocBody />
+		</RootContainer>
+	}
+}

--- a/packages/react-server-website/routes.js
+++ b/packages/react-server-website/routes.js
@@ -9,6 +9,11 @@ module.exports = {
 			method: 'get',
 			page: './pages/hello-world',
 		},
+		docs: {
+			path: ['/docs/:path'],
+			method: 'get',
+			page: './pages/docs',
+		},
 		DocsApi: {
 			path: ['/api/docs'],
 			method: 'get',


### PR DESCRIPTION
Examples:

/docs/README
/docs/client-transitions