### PR TITLE
Ensure that if `common` exists in the manifest, we include it.

### DIFF
--- a/packages/react-server-cli/src/coreCssMiddleware.js
+++ b/packages/react-server-cli/src/coreCssMiddleware.js
@@ -10,9 +10,12 @@ export default (pathToStatic, manifest) => {
 			}
 
 			const fileNames = [];
+
+			if (manifest.cssChunksByName.common) {
+				fileNames.push(baseUrl + manifest.cssChunksByName.common);
+			}
+
 			if (manifest.cssChunksByName[routeName]) {
-				// the css file is the second resource in the file array in the manifest;
-				// the js file is the first.
 				fileNames.push(baseUrl + manifest.cssChunksByName[routeName]);
 			}
 


### PR DESCRIPTION
This fixes #155.

I've also removed a comment in the `[routeName]` section that no longer provides context.