### PR TITLE
Incrementing Generator default versions.

### DIFF
--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -16,8 +16,8 @@
     "babel-runtime": "^6.6.1",
     "react": "~0.14.2",
     "react-dom": "~0.14.2",
-    "react-server": "^0.2.10",
-    "react-server-cli": "^0.2.10",
+    "react-server": "^0.3.4",
+    "react-server-cli": "^0.4.0",
     "superagent": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The Generator is defaulting people to a fairly old version of `React-Server` and the CLI, so I bumped those to the most recent one.

Is there a more effective way to do this? Where it will auto-update?