### PR TITLE
some docs headings are redundant

### DIFF
--- a/docs/guides/client-transitions.md
+++ b/docs/guides/client-transitions.md
@@ -1,5 +1,3 @@
-# Client Transitions
-
 React-server provides blazing fast server-side render of web pages.  This is
 important for landing experience and for web crawlers, but it's only part of
 the picture!  The great strength of `react-server` is that the _same code_

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -1,5 +1,3 @@
-# react-server-cli
-
 A simple command line app that will compile a routes file for the client and start up express. To use:
 
 1. `npm install --save react-server-cli react-server`

--- a/docs/guides/understanding-rendering.md
+++ b/docs/guides/understanding-rendering.md
@@ -1,5 +1,3 @@
-# Understanding Rendering
-
 Given that react-server is about using universal JavaScript to make server-
 and client-side rendering as similar as possible, it can be hard to understand
 which part of a large react-server application is rendering any given part of

--- a/docs/intro/design.md
+++ b/docs/intro/design.md
@@ -1,5 +1,3 @@
-# Design Principles
-
 1. **Best practices for data flow in React are (still) changing fast**. When
    Facebook announced Flux as a design pattern, it took them some time to
    release an implementation, and when they did, it had some definite rough

--- a/docs/intro/why-react-server.md
+++ b/docs/intro/why-react-server.md
@@ -1,5 +1,3 @@
-# react-server
-
 React is an amazing library for client-side user interface, and it has the
 added benefit of being able to be rendered on the server, which is crucial for
 SEO, SEM, and user experience. However, server-side rendering in practice is


### PR DESCRIPTION
This cleans up the first heading of several files, when it's the same as the document's title.