### PR TITLE
Exempt nsp 130

### DIFF
--- a/packages/react-server-cli/.nsprc
+++ b/packages/react-server-cli/.nsprc
@@ -1,0 +1,5 @@
+{
+  "exceptions": [
+      "https://nodesecurity.io/advisories/130"
+  ]
+}


### PR DESCRIPTION
We'll have to exempt https://nodesecurity.io/advisories/130 until https://github.com/webpack/webpack/issues/2795 is fixed