### PR TITLE
Tell webpack to look for _our_ deps first

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -167,6 +167,7 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 		},
 		resolve: {
 			root: [
+				path.resolve(path.join(process.cwd(), "node_modules")),
 				path.resolve(path.join(__dirname, "../node_modules")),
 			],
 		},


### PR DESCRIPTION
This lets us pick up `path-to-regexp@1.5.3` as required by `routr` instead of
`path-to-regexp@0.1.7` as required by `express`.  This, in turn, unhorks
react-server.io.

This is using `process.cwd()`, which is not good.  Couldn't quickly think of a
way to avoid that, though, and we're already doing it all over the place in
`compileClient`, so... :grimacing: