### PR TITLE
Just don't mess with `resolve.root` at all

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -165,12 +165,6 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 				},
 			],
 		},
-		resolve: {
-			root: [
-				path.resolve(path.join(process.cwd(), "node_modules")),
-				path.resolve(path.join(__dirname, "../node_modules")),
-			],
-		},
 		resolveLoader: {
 			root: [
 				path.resolve(path.join(__dirname, "../node_modules")),


### PR DESCRIPTION
Don't seem to need anything but loaders from cli's node_modules?