### PR TITLE
Get react-server-cli link on the homepage working

### DIFF
--- a/packages/react-server-website/components/Markdown.js
+++ b/packages/react-server-website/components/Markdown.js
@@ -49,7 +49,7 @@ export default class Markdown extends React.Component {
 
 		[].slice.call(document.querySelectorAll('.dangerous-markdown a')).forEach(a => {
 			if (isInternal(a)) {
-				addOnClickHandler(a);
+				addOnClickHandler(a, this.props);
 			} else {
 				addTargetBlank(a);
 			}
@@ -57,21 +57,30 @@ export default class Markdown extends React.Component {
 	}
 }
 
+Markdown.propTypes = {
+	source     : React.PropTypes.string,
+	reuseDom   : React.PropTypes.bool,
+	bundleData : React.PropTypes.bool,
+}
+
+Markdown.defaultProps = {
+	reuseDom   : false,
+	bundleData : true,
+}
+
 function isInternal(a) {
 	const href = a.getAttribute('href');
 	return href.startsWith('/');
 }
 
-function addOnClickHandler(a) {
+// TODO: Let's make this available as a helper from React Server core.
+function addOnClickHandler(a, {reuseDom, bundleData}) {
 	a.onclick = function (e) {
 		// See Link.jsx in react-server/core/Link
 		if (!e.metaKey) {
 			e.preventDefault();
 			e.stopPropagation();
-			navigateTo(a.getAttribute('href'), {
-				reuseDom: true,
-				bundleData: true,
-			});
+			navigateTo(a.getAttribute('href'), {reuseDom, bundleData});
 		} else {
 			// do normal browser navigate
 		}

--- a/packages/react-server-website/components/content/HomeGetStartedSection.md
+++ b/packages/react-server-website/components/content/HomeGetStartedSection.md
@@ -19,4 +19,4 @@ npm run start
 # go to http://localhost:3010
 ```
 
-That hooks you up with [react-server-cli](/react-server-cli), which will take care of the server part and get you up and running right away.
+That hooks you up with [react-server-cli](/docs/guides/react-server-cli), which will take care of the server part and get you up and running right away.

--- a/packages/react-server-website/components/content/HomeGetStartedSection.md
+++ b/packages/react-server-website/components/content/HomeGetStartedSection.md
@@ -19,4 +19,4 @@ npm run start
 # go to http://localhost:3010
 ```
 
-That hooks you up with [react-server-cli](/docs/guides/react-server-cli), which will take care of the server part and get you up and running right away.
+That hooks you up with [react-server-cli](/docs/guides/react-server-cli), which will get you up and running right away.

--- a/packages/react-server-website/components/doc-body.js
+++ b/packages/react-server-website/components/doc-body.js
@@ -12,7 +12,7 @@ export default class DocBody extends Component {
 	render() {
 		return (
 			<article className="DocBody">
-				<Markdown source={this.props.text} />
+				<Markdown source={this.props.text} reuseDom />
 			</article>
 		);
 	}


### PR DESCRIPTION
Link was broken.

Also, can't `reuseDom` between homepage and docs section.