### PR TITLE
Close mobile doc menu on load complete

### DIFF
--- a/packages/react-server-website/components/doc-contents.js
+++ b/packages/react-server-website/components/doc-contents.js
@@ -38,7 +38,7 @@ export default class DocContents extends React.Component {
 	}
 
 	componentDidMount() {
-		getCurrentRequestContext().navigator.on( "navigateStart", this.closeMenu.bind(this) );
+		getCurrentRequestContext().navigator.on("loadComplete", this.closeMenu.bind(this));
 	}
 
 	render() {


### PR DESCRIPTION
This feels a little nicer.  Waits to close the nav menu until the page has
changed.  Previously the nav menu was closed immediately, and then the page
would change _after_.