### PR TITLE
Using NGINX proxy cache for documentation site

### DIFF
--- a/packages/react-server-website/nginx.conf
+++ b/packages/react-server-website/nginx.conf
@@ -1,7 +1,7 @@
 proxy_cache_path /tmp/nginx levels=1:2 keys_zone=react_server_zone:10m inactive=60m;
 
 server {
-    listen 80 default;
+    listen 80 default_server;
     server_name react-server.io;
 
     proxy_cache react_server_zone;

--- a/packages/react-server-website/nginx.conf
+++ b/packages/react-server-website/nginx.conf
@@ -1,6 +1,11 @@
+proxy_cache_path /tmp/nginx levels=1:2 keys_zone=react_server_zone:10m inactive=60m;
+
 server {
     listen 80 default;
     server_name react-server.io;
+
+    proxy_cache react_server_zone;
+    add_header X-Proxy-Cache $upstream_cache_status;
 
     location / {
         proxy_pass http://docs;


### PR DESCRIPTION
- Using NGINX caching on responses from the documentation site.
- Changing `default` to `default_server`, which is just an update to the current correct directive name.