### PR TITLE
Make the "Get Started" link point to a "Getting Started" doc

### DIFF
--- a/packages/react-server-website/pages/docs.js
+++ b/packages/react-server-website/pages/docs.js
@@ -7,12 +7,15 @@ import DocTitle from "../components/page-title";
 import DocBody from "../components/doc-body";
 import DocContents from "../components/doc-contents";
 import DataBundleCacheManager from '../middleware/DataBundleCache';
+import GetStartedSection from '../components/content/HomeGetStartedSection.md';
 import "./docs.less";
 
 export default class DocsPage {
 	handleRoute(next) {
-		const path = this.getRequest().getRouteParams().path || "README";
-		this.bodyPromise = Repo.getFile(join("/docs", `${path}.md`));
+		const {path} = this.getRequest().getRouteParams();
+		this.bodyPromise = path
+			?Repo.getFile(join("/docs", `${path}.md`))
+			:Promise.resolve({text: GetStartedSection})
 		this.contentsPromise = Repo.getContents()
 			.then(DocContents.setResponse)
 			.then(DataBundleCacheManager.addContents.bind({}, '/docs/'))


### PR DESCRIPTION
This just duplicates the "Getting Started" section from the homepage as the
body of /docs.  It's a simpler intro.

Makes it look like this:

![image](https://cloud.githubusercontent.com/assets/115908/17266013/b3ca63a6-55a8-11e6-8d4f-d1bc83a6df4c.png)


Instead of this:

![image](https://cloud.githubusercontent.com/assets/115908/17266022/cdc6f2a6-55a8-11e6-98ec-8f1c734078a1.png)
