### PR TITLE
Redirecting HTTP to HTTPS

### DIFF
--- a/packages/react-server-website/nginx.conf
+++ b/packages/react-server-website/nginx.conf
@@ -1,7 +1,15 @@
 proxy_cache_path /tmp/nginx levels=1:2 keys_zone=react_server_zone:10m inactive=60m;
 
+# Redirect requests to port 80 to HTTPS.
 server {
     listen 80 default_server;
+    server_name react-server.io;
+
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 default_server;
     server_name react-server.io;
 
     proxy_cache react_server_zone;
@@ -16,8 +24,16 @@ server {
     }
 }
 
+# Redirect requests to port 80 to HTTPS.
 server {
     listen 80;
+    server_name slack.react-server.io;
+
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443;
     server_name slack.react-server.io;
 
     location / {

--- a/packages/react-server-website/provisioning/docker-compose.yml
+++ b/packages/react-server-website/provisioning/docker-compose.yml
@@ -18,6 +18,7 @@ services:
      - slackin:slackin
     ports:
      - "80:80"
+     - "443:443"
     volumes_from:
      - docs:ro
     volumes:


### PR DESCRIPTION
- Modifying the NGINX configuration to redirect requests arriving on port 80 to HTTPS. Note the load balancer has been configured to send HTTPS requests to port 443 in the services using the HTTP.
- Opening port 443 in the NGINX service section of the Docker Compose file.