### PR TITLE
Make react a singleton client side with webpack resolve.alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "private": true,
   "scripts": {
     "bootstrap": "npm i && npm run bootstrap-no-i",
-    "bootstrap-no-i": "npm run kill-singletons && lerna bootstrap && npm run make-singletons",
+    "//": "TODO: Drop `kill-singletons`... eventually",
+    "bootstrap-no-i": "npm run kill-singletons && lerna bootstrap",
     "kill-singletons": "lerna exec -- rm -rf node_modules/react",
-    "make-singletons": "npm run kill-singletons && lerna exec -- ln -s ../../node_modules/react node_modules/react",
     "test": "lerna run test",
     "clean": "rimraf lerna-debug.log && lerna run clean",
     "nuke": "lerna clean && rm -r node_modules",

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -165,6 +165,12 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 				},
 			],
 		},
+		resolve: {
+			alias: {
+				// React needs to be a singleton.
+				react: path.resolve(path.join(process.cwd(), "node_modules/react")),
+			},
+		},
 		resolveLoader: {
 			root: [
 				path.resolve(path.join(__dirname, "../node_modules")),


### PR DESCRIPTION
Getting closer to `react-server-cli` working as a global install.