### PR TITLE
Make `react-server-cli` work as a global install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "private": true,
   "scripts": {
     "bootstrap": "npm i && npm run bootstrap-no-i",
-    "bootstrap-no-i": "npm run kill-singletons && lerna bootstrap && npm run make-singletons",
+    "//": "TODO: Drop `kill-singletons`... eventually",
+    "bootstrap-no-i": "npm run kill-singletons && lerna bootstrap",
     "kill-singletons": "lerna exec -- rm -rf node_modules/react",
-    "make-singletons": "npm run kill-singletons && lerna exec -- ln -s ../../node_modules/react node_modules/react",
     "test": "lerna run test",
     "clean": "rimraf lerna-debug.log && lerna run clean",
     "nuke": "lerna clean && rm -r node_modules",

--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -4,7 +4,7 @@
   "description": "A react-server instance",
   "main": "HelloWorld.js",
   "scripts": {
-    "start": "react-server --port 3010 --js-port 3011",
+    "start": "react-server-cli --port 3010 --js-port 3011",
     "test": "xo && nsp check && ava test.js"
   },
   "license": "Apache-2.0",

--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -4,7 +4,7 @@
   "description": "A react-server instance",
   "main": "HelloWorld.js",
   "scripts": {
-    "start": "react-server-cli --port 3010 --js-port 3011",
+    "start": "react-server --port 3010 --js-port 3011",
     "test": "xo && nsp check && ava test.js"
   },
   "license": "Apache-2.0",

--- a/packages/generator-react-server/test/app.js
+++ b/packages/generator-react-server/test/app.js
@@ -81,7 +81,15 @@ function installDeps() {
 			if (error) {
 				reject(error);
 			} else {
-				resolve();
+				const localDeps = ['react-server-cli', 'react-server']
+					.map(dep => path.resolve(path.join(__dirname, '../..', dep)));
+				cp.exec('npm install ' + localDeps.join(' '), (error) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve();
+					}
+				});
 			}
 		});
 	});

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -40,9 +40,6 @@
     "webpack-stats-plugin": "^0.1.3",
     "yargs": "~3.15.0"
   },
-  "peerDependencies": {
-    "react-server": "^0.3.4"
-  },
   "devDependencies": {
     "nsp": "^2.4.0",
     "rimraf": "^2.5.2"

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -10,7 +10,6 @@
   },
   "author": "Sasha Aickin",
   "bin": {
-    "react-server-cli": "./bin/react-server-cli",
     "react-server": "./bin/react-server-cli"
   },
   "license": "Apache-2.0",

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -10,7 +10,7 @@
   },
   "author": "Sasha Aickin",
   "bin": {
-    "react-server-cli": "./bin/react-server-cli"
+    "react-server": "./bin/react-server-cli"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -10,6 +10,7 @@
   },
   "author": "Sasha Aickin",
   "bin": {
+    "react-server-cli": "./bin/react-server-cli",
     "react-server": "./bin/react-server-cli"
   },
   "license": "Apache-2.0",

--- a/packages/react-server-cli/src/callerDependency.js
+++ b/packages/react-server-cli/src/callerDependency.js
@@ -1,0 +1,7 @@
+import path from "path";
+
+export default function callerDependency(dep) {
+	// TODO: We should grab stuff based on what the routes file would get out
+	// of `require.resolve(dep)`.  Using `process.cwd()` instead for now.
+	return path.resolve(path.join(process.cwd(), "node_modules/" + dep));
+}

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -6,6 +6,7 @@ import ExtractTextPlugin from "extract-text-webpack-plugin"
 import ChunkManifestPlugin from "chunk-manifest-webpack-plugin"
 import crypto from "crypto"
 import StatsPlugin from "webpack-stats-plugin"
+import callerDependency from "./callerDependency"
 
 
 // commented out to please eslint, but re-add if logging is needed in this file.
@@ -167,8 +168,9 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 		},
 		resolve: {
 			alias: {
-				// React needs to be a singleton.
-				react: path.resolve(path.join(process.cwd(), "node_modules/react")),
+				// These need to be singletons.
+				"react"        : callerDependency("react"),
+				"react-server" : callerDependency("react-server"),
 			},
 		},
 		resolveLoader: {

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -165,6 +165,12 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 				},
 			],
 		},
+		resolve: {
+			alias: {
+				// React needs to be a singleton.
+				react: path.resolve(path.join(process.cwd(), "node_modules/react")),
+			},
+		},
 		resolveLoader: {
 			root: [
 				path.resolve(path.join(__dirname, "../node_modules")),

--- a/packages/react-server-cli/src/startServer.js
+++ b/packages/react-server-cli/src/startServer.js
@@ -1,4 +1,3 @@
-import reactServer, { logging } from "react-server"
 import http from "http"
 import https from "https"
 import express from "express"
@@ -10,8 +9,11 @@ import WebpackDevServer from "webpack-dev-server"
 import compileClient from "./compileClient"
 import mergeOptions from "./mergeOptions"
 import findOptionsInFiles from "./findOptionsInFiles"
+import callerDependency from "./callerDependency";
 
-const logger = logging.getLogger(__LOGGER__);
+const reactServer = require(callerDependency("react-server"));
+
+const logger = reactServer.logging.getLogger(__LOGGER__);
 
 // if used to start a server, returns an object with two properties, started and
 // stop. started is a promise that resolves when all necessary servers have been
@@ -305,9 +307,9 @@ const serverToStopPromise = (server) => {
 }
 
 const setupLogging = (logLevel, timingLogLevel, gaugeLogLevel) => {
-	logging.setLevel('main',  logLevel);
-	logging.setLevel('time',  timingLogLevel);
-	logging.setLevel('gauge', gaugeLogLevel);
+	reactServer.logging.setLevel('main',  logLevel);
+	reactServer.logging.setLevel('time',  timingLogLevel);
+	reactServer.logging.setLevel('gauge', gaugeLogLevel);
 }
 
 const logProductionWarnings = ({hot, minify, jsUrl, longTermCaching}) => {

--- a/packages/react-server-examples/bike-share/package.json
+++ b/packages/react-server-examples/bike-share/package.json
@@ -7,7 +7,7 @@
   "author": "Doug Wade <doug.wade@redfin.com>",
   "scripts": {
     "clean": "rm -rf build __clientTemp",
-    "start": "npm run clean && npm run styles && react-server-cli",
+    "start": "npm run clean && npm run styles && react-server",
     "styles": "node-sass styles/index.scss build/styles/index.css && node-sass styles/network.scss build/styles/network.css",
     "test": "xo && nsp check"
   },

--- a/packages/react-server-examples/hello-world/package.json
+++ b/packages/react-server-examples/hello-world/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "HelloWorld.js",
   "scripts": {
-    "start": "react-server-cli",
+    "start": "react-server",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Sasha Aickin",


### PR DESCRIPTION
Use the _caller's_ `react-server`.  Also, rename the binary to `react-server`.

```bash
$ npm i -g react-server-cli
$ react-server --port 3010 --js-port 3011
```

This supersedes #482.