### PR TITLE
Cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yo react-server
 # compile and run the new app
 npm run compile
 npm run start
-# go to http://localhost:3010
+# go to http://localhost:3000
 ```
 
 That hooks you up with [`react-server-cli`](packages/react-server-cli), which

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -4,7 +4,6 @@ To get started:
 
 ```bash
 $ npm install -g react-server-cli
-$ npm init
 $ react-server init
 $ react-server add-page '/' Homepage
 $ react-server start

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -142,7 +142,7 @@ In this case you'll want to specify a `jsUrl` key in your production config:
 ```json
 {
 	...
-	env: {
+	"env": {
 		"production": {
 			...
 			"jsUrl": "http://mystaticfileserver.com/somedirectory/"
@@ -153,7 +153,7 @@ In this case you'll want to specify a `jsUrl` key in your production config:
 
 ### Commands
 
-#### init
+#### `init`
 
 Generate:
 - `routes.json`
@@ -163,15 +163,15 @@ Generate:
 Install:
 - `react-server`
 
-#### add-page PATH CLASSNAME
+#### `add-page <urlPath> <ClassName>`
 
 Add a stub of a new page class.
 
-#### start
+#### `start`
 
 Start the server.  If running with local client assets, build those.
 
-#### compile
+#### `compile`
 
 Compile the client JavaScript only, and don't start any servers. This is what
 you want to do if you are building the client JavaScript to be hosted on a CDN

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -299,7 +299,7 @@ named export, `run`, which takes has the following signature:
 ```javascript
 import {run} from "react-server-cli"
 
-start({
+run({
     command         : "start",
     routes          : "./routes.json",
     port            : 3000,
@@ -318,5 +318,5 @@ your own CLI:
 ```javascript
 import {run, parseCliArgs} from "react-server-cli"
 
-start(parseCliArgs());
+run(parseCliArgs());
 ```

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -1,71 +1,77 @@
-A simple command line app that will compile a routes file for the client and start up express. To use:
+## A simple command line tool to build and run React Server sites
 
-1. `npm install --save react-server-cli react-server`
-2. Add `./node_modules/react-server-cli/bin/react-server-cli` as the value for `scripts.start` in package.json.
-3. `npm start` from the directory that has your routes.js file.
+To get started:
 
-## Routes Format
-
-Note that the routes file needs to be in a bit different format than what we have used in the past in `react-server`. Rather than `routes.route.page` being a function, it needs to be a path to a file that exports a page class. Middleware also needs to be an array of file paths. For example:
-
-```javascript
-module.exports = {
-	// these will be applied to every page in the site.
-	middleware: ["./FooMiddleware", "./BarMiddleware"],
-
-	// this maps URLs to modules that export a Page class.
-	routes: {
-		BazRoute: {
-			path: ["/"],
-			method: "get", // optional
-			page: "./BazPage"
-		},
-		BakRoute: {
-			path: ["/bak"],
-			page: "./BakPage"
-		}
-	}
-};
+```bash
+$ npm install -g react-server-cli
+$ npm init
+$ react-server init
+$ react-server add-page '/' Homepage
+$ react-server start
 ```
 
 ## What It Does
 
-The CLI builds and runs a `react-server` project, using Express. It compiles JS(X) and CSS into efficiently loadable bundles with code splitting using webpack, and it supports hot reloading of React components on the client-side during development.
+The CLI builds and runs a React Server project, using Express. It compiles
+JS(X) and CSS into efficiently loadable bundles with code splitting using
+webpack, and it supports hot reloading of React components on the client-side
+during development.
 
 ## Built-in Features
 
 ### Babel Compilation
-It's rare to see a project these days in the JavaScript world that isn't at least experimenting with ES2015 and ES7. To make this easier, all code in your project will be run through Babel, and source maps will be generated back to the original file.
+It's rare to see a project these days in the JavaScript world that isn't at
+least experimenting with ES2015 and ES7. To make this easier, all code in your
+project will be run through Babel, and source maps will be generated back to
+the original file.
 
-To take advantage of the Babel compilation, you need to install the Babel plugins and presets you want and reference them in a `.babelrc` file in your code directory. For more on the `.babelrc` format, see [its documentation here](https://babeljs.io/docs/usage/babelrc/).
+To take advantage of the Babel compilation, you need to install the Babel
+plugins and presets you want and reference them in a `.babelrc` file in your
+code directory. For more on the `.babelrc` format, see [its documentation
+here](https://babeljs.io/docs/usage/babelrc/).
 
-## Options
-Smart defaults are the goal, and `react-server-cli` has two base modes: **development** and **production**. `react-server-cli` will determine which base mode it's in by looking at the NODE_ENV environment variable. If it's not "production", then `react-server-cli` will assume we are in development mode.
+## Configuration
 
-### Ways to add options
+### Routes
 
-There are three ways to pass options to the CLI, through the command line, `.reactserverrc` JSON files, or as a `reactServer` entry in `package.json` files. It searches for options this way:
+This is where URLs are mapped to pages.  It's also where global middleware
+(applied to all pages in the site) is defined.
 
-1. If there are any options arguments on the command line, they are used. For the options which aren't specified:
-1. `react-server-cli` looks at the current directory.
- 1. If there is a JSON file named `.reactserverrc` in the directory, its settings are used and we skip to step #4. Otherwise:
- 1. If there is a `package.json` file in the current directory with an entry named `reactServer`, its settings are used and we skip to step #4. Otherwise:
-1. Go back to step 2 in the parent of the current directory. Repeat until you either find a config or hit the root directory.
-1. If there are any options that still aren't specified, the defaults are used.
-
-Note that the programmatic API also searches for config files, although options sent in explicitly to the API function override the config file.
-
-### JSON options can be set per environment
-
-If you are using either `.reactserverrc` or `package.json` to set your react-server options, you can provide environment-specific values in a sub-object at the key `env`. It looks like this:
+By default this is created at the site's root directory as `routes.json`.
 
 ```json
 {
+	"middleware": [
+		"middleware/FooMiddleware",
+		"middleware/BarMiddleware"
+	],
+	"routes": {
+		"BazPage": {
+			"path": ["/"],
+			"page": "pages/BazPage"
+		},
+		"BakPage": {
+			"path": ["/bak"],
+			"page": "pages/BakPage"
+		}
+	}
+}
+```
+
+## Server config
+
+You can define JSON options either in a `.reactserverrc` or in a
+`reactServer` object in your `package.json`.
+
+You can provide environment-specific values in a sub-object at the key `env`.
+
+It looks like this:
+
+```json
+{
+	"routes": "routes.json",
 	"port": "5000",
 	"env": {
-		"staging": {
-			"port": "4000"
-		},
 		"production": {
 			"port": "80"
 		}
@@ -73,33 +79,111 @@ If you are using either `.reactserverrc` or `package.json` to set your react-ser
 }
 ```
 
-The values in a particular environment override the main settings. In this example configuration `port` will be set to 80 if `process.env.NODE_ENV` is `production`, 4000 if `process.env.NODE_ENV` is `staging`, and 5000 for any other situation.
+The values in a particular environment override the main settings. In this
+example configuration `port` will be set to 80 if `process.env.NODE_ENV` is
+`production`, and 5000 otherwise.
+
+
+## Options
+Smart defaults are the goal, and `react-server-cli` has two base modes:
+**development** and **production**. `react-server-cli` will determine which
+base mode it's in by looking at the NODE_ENV environment variable. If it's not
+"production", then `react-server-cli` will assume we are in development mode.
+
+### Ways to add options
+
+There are three ways to pass options to the CLI, through the command line,
+`.reactserverrc` JSON files, or as a `reactServer` entry in `package.json`
+files. If there's no config file (or package.json config) in the current
+working directory, then parent directories are searched up to the root of the
+filesystem.  Options passed to the CLI take final precedence.
 
 ### Development mode: making a great DX
 
-Development mode is the default, and its goals are rapid startup and code-test loops. Hot mode is enabled for all code, although at this time, editing the routes file or modules that export a Page class still requires a browser reload to see changes. Modules that export a React component should reload without a browser refresh.
+Development mode is the default, and its goals are rapid startup and code-test
+loops. Hot mode is enabled for all code, although at this time, editing the
+routes file or modules that export a Page class still requires a browser
+reload to see changes. Modules that export a React component should reload
+without a browser refresh.
 
-In development mode, code is not minified in order to speed up startup time, so please do not think that the sizes of bundles in development mode is indicative of how big they will be in production. In fact, it's really best not to do any kind of perf testing in development mode; it will just lead you astray.
+In development mode, code is not minified in order to speed up startup time,
+so please do not think that the sizes of bundles in development mode is
+indicative of how big they will be in production. In fact, it's really best
+not to do any kind of perf testing in development mode; it will just lead you
+astray.
 
-We are also considering completely getting rid of server-side rendering in development mode by default to speed startup.
+We are also considering completely getting rid of server-side rendering in
+development mode by default to speed startup.
 
 ### Production mode: optimizing delivery
 
-Production mode's priority is optimization at the expense of startup time. A separate code bundle is generated for every entry point into your app so that there is at most just one JS and one CSS file loaded by the framework. All code is minified, and hot reloading is turned off.
+Production mode's priority is optimization at the expense of startup time. A
+separate code bundle is generated for every entry point into your app so that
+there is at most just one JS and one CSS file loaded by the framework. All
+code is minified, and hot reloading is turned off.
 
 #### Building static files for production use
 
-In many production configurations, you may not want `react-server-cli` to serve up your static JavaScript and CSS files. Typically, this is because you have a more performant static file server already set up or because you upload all your static files to a CDN server.
+In many production configurations, you may not want `react-server-cli` to
+serve up your static JavaScript and CSS files. Typically, this is because you
+have a more performant static file server already set up or because you upload
+all your static files to a CDN server.
 
-To use `react-server-cli` in this sort of production setup, follow these steps:
+To use `react-server-cli` in this sort of production setup, use `react-server
+compile` to generate static assets.
 
-1. `react-server-cli --production --compile-only` compiles the JavaScript and CSS files into the directory `__clientTemp/build`.
-1. Upload the contents of `__clientTemp/build` to your static file server.
-1. `react-server-cli --production --js-url="http://mystaticfileserver.com/somedirectory/"` to start your HTML server depending on JavaScript and CSS files from your static file server.
+```bash
+$ NODE_ENV=production react-server compile
+$ # Upload `__clientTemp/build` to static file server
+$ NODE_ENV=production react-server start
+```
 
-### Setting Options Manually
+In this case you'll want to specify a `jsUrl` key in your production config:
 
-While development and production mode are good starting points, you can of course choose to override any of the setup by setting the following options:
+```json
+{
+	...
+	env: {
+		"production": {
+			...
+			"jsUrl": "http://mystaticfileserver.com/somedirectory/"
+		}
+	}
+}
+```
+
+### Commands
+
+#### init
+
+Generate:
+- `routes.json`
+- `.reactserverrc`
+- `.babelrc`
+
+Install:
+- `react-server`
+
+#### add-page PATH CLASSNAME
+
+Add a stub of a new page class.
+
+#### start
+
+Start the server.  If running with local client assets, build those.
+
+#### compile
+
+Compile the client JavaScript only, and don't start any servers. This is what
+you want to do if you are building the client JavaScript to be hosted on a CDN
+or separate server. Unless you have a very specific reason, it's almost always
+a good idea to only do this in production mode.
+
+### Options
+
+The following options are available.  Note that options on the command-line
+are dash-separated (e.g. `--js-port`), but options in config files are
+camel-cased (e.g. `jsPort`). (TODO: Support dash-separated options in config)
 
 #### --routes
 The routes file to load.
@@ -107,7 +191,8 @@ The routes file to load.
 Defaults to **"./routes.js"**.
 
 #### --host
-The hostname to use when starting up the server. If `jsUrl` is set, then this argument is ignored, and any host name can be used.
+The hostname to use when starting up the server. If `jsUrl` is set, then this
+argument is ignored, and any host name can be used.
 
 Defaults to **localhost**.
 
@@ -122,7 +207,9 @@ The port to use when `react-server-cli` is serving up the client JavaScript.
 Defaults to **3001**.
 
 #### --hot, -h
-Use hot reloading of client JavaScript. Modules that export React components will reload without refreshing the browser. This option is incompatible with --long-term-caching.
+Use hot reloading of client JavaScript. Modules that export React components
+will reload without refreshing the browser. This option is incompatible with
+--long-term-caching.
 
 Defaults to **true** in development mode and **false** in production mode.
 
@@ -132,58 +219,72 @@ Minify client JavaScript and CSS.
 Defaults to **false** in development mode and **true** in production.
 
 #### --long-term-caching
-Adds hashes to all JavaScript and CSS file names output by the build, allowing for the static files to be served with far-future expires headers. This option is incompatible with --hot.
+Adds hashes to all JavaScript and CSS file names output by the build, allowing
+for the static files to be served with far-future expires headers. This option
+is incompatible with --hot.
 
 Defaults to **false** in development mode and **true** in production.
 
-#### --compile-only
-Compile the client JavaScript only, and don't start any servers. This is what you want to do if you are building the client JavaScript to be hosted on a CDN or separate server. Unless you have a very specific reason, it's almost always a good idea to only do this in production mode.
-
-Defaults to **false**.
-
 #### --js-url
-A URL base for the pre-compiled client JavaScript; usually this is a base URL on a CDN or separate server. Setting a value for js-url means that react-server-cli will not compile the client JavaScript at all, and it will not serve up any of the client JavaScript. Obviously, this means that --js-url overrides and ignores all of the options related to JavaScript compilation and serving: --hot, --js-port, and --minify.
+A URL base for the pre-compiled client JavaScript; usually this is a base URL
+on a CDN or separate server. Setting a value for js-url means that
+react-server-cli will not compile the client JavaScript at all, and it will
+not serve up any of the client JavaScript. Obviously, this means that --js-url
+overrides and ignores all of the options related to JavaScript compilation and
+serving: --hot, --js-port, and --minify.
 
 Defaults to **null**.
 
 #### --https
 
-If true, the server will start up using https with a self-signed certificate. Note that browsers do not trust self-signed certificates by default, so you will have to click through some warning screens. This is a quick and dirty way to test HTTPS, but it has some limitations and should never be used in production. Requires OpenSSL to be installed.
+If true, the server will start up using https with a self-signed certificate.
+Note that browsers do not trust self-signed certificates by default, so you
+will have to click through some warning screens. This is a quick and dirty way
+to test HTTPS, but it has some limitations and should never be used in
+production. Requires OpenSSL to be installed.
 
 Defaults to **false**.
 
 #### --https-key
 
-Start the server using HTTPS with this private key file in PEM format. Requires `https-cert` to be set as well.
+Start the server using HTTPS with this private key file in PEM format.
+Requires `https-cert` to be set as well.
 
  Default is **none**.
 
 #### --https-cert
 
-Start the server using HTTPS with this cert file in PEM format. Requires `https-key` to be set as well.
+Start the server using HTTPS with this cert file in PEM format. Requires
+`https-key` to be set as well.
 
 Default is **none**.
 
 #### --https-ca
 
-Start the server using HTTPS with this certificate authority file in PEM format. Also requires `https-key` and `https-cert` to start the server.
+Start the server using HTTPS with this certificate authority file in PEM
+format. Also requires `https-key` and `https-cert` to start the server.
 
 Default is **none**.
 
 #### --https-pfx
 
-Start the server using HTTPS with this file containing the private key, certificate and CA certs of the server in PFX or PKCS12 format. Mutually exclusive with `https-key`, `https-cert`, and `https-ca`.
+Start the server using HTTPS with this file containing the private key,
+certificate and CA certs of the server in PFX or PKCS12 format. Mutually
+exclusive with `https-key`, `https-cert`, and `https-ca`.
 
 Default is **none**.
 
 #### --https-passphrase
 
-A passphrase for the private key or pfx file. Requires `https-key` or `https-pfx` to be set.
+A passphrase for the private key or pfx file. Requires `https-key` or
+`https-pfx` to be set.
 
 Default is **none**.
 
 #### --log-level
-Sets the severity level for the logs being reported. Values are, in ascending order of severity: 'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'.
+Sets the severity level for the logs being reported. Values are, in ascending
+order of severity: 'debug', 'info', 'notice', 'warning', 'error', 'critical',
+'alert', 'emergency'.
 
 Default is **'debug'** in development mode and **'notice'** in production.
 
@@ -192,20 +293,30 @@ Shows command line options.
 
 ## API
 
-You can also call `react-server-cli` programmatically. The module has a single named export, `start`, which takes has the following signature:
+You can also call `react-server-cli` programmatically. The module has a
+named export, `run`, which takes has the following signature:
 
 ```javascript
-import {start} from `react-server-cli`
+import {run} from "react-server-cli"
 
-start(routesRelativePath, {
-		port: 3000,
-		jsPort: 3001,
-		hot: true,
-		minify: false,
-		compileOnly: false,
-		jsUrl: null,
-		longTermCaching: true,
-})
+start({
+    command         : "start",
+    routes          : "./routes.json",
+    port            : 3000,
+    jsPort          : 3001,
+    hot             : true,
+    minify          : false,
+    compileOnly     : false,
+    jsUrl           : null,
+    longTermCaching : true,
+});
 ```
 
-All of the values in the second argument are optional, and they have the same defaults as the corresponding CLI arguments explained above. (Also note that if an option isn't present, the programmatic API will search for a config file in the same way as the CLI.)
+The module also exports a `parseCliArgs` function that will let you implement
+your own CLI:
+
+```javascript
+import {run, parseCliArgs} from "react-server-cli"
+
+start(parseCliArgs());
+```

--- a/docs/testing-ports.md
+++ b/docs/testing-ports.md
@@ -4,7 +4,7 @@ simultaneously, so port conflicts will fail the tests.  Make sure
 to update this manifest when adding a test that starts a server.
 
 ## generator-react-server 
-3010, 3011
+3000, 3001
 
 ## react-server-integration-test
 8771, 3001

--- a/docs/testing-ports.md
+++ b/docs/testing-ports.md
@@ -7,4 +7,4 @@ to update this manifest when adding a test that starts a server.
 3000, 3001
 
 ## react-server-integration-test
-8771, 3001
+8771, 8772

--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -4,7 +4,7 @@
   "description": "A react-server instance",
   "main": "HelloWorld.js",
   "scripts": {
-    "start": "react-server --port 3010 --js-port 3011",
+    "start": "react-server start",
     "test": "xo && nsp check && ava test.js"
   },
   "license": "Apache-2.0",

--- a/packages/generator-react-server/generators/app/templates/test.js
+++ b/packages/generator-react-server/generators/app/templates/test.js
@@ -23,7 +23,7 @@ function getResponseCode(url) {
 	return new Promise((resolve, reject) => {
 		const req = http.get({
 			hostname: 'localhost',
-			port: 3010,
+			port: 3000,
 			path: url
 		}, res => {
 			resolve(res.statusCode);

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -26,6 +26,7 @@
     "json-loader": "^0.5.4",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
+    "lodash": "^4.14.1",
     "mkdirp": "~0.5.1",
     "node-libs-browser": "~0.5.2",
     "null-loader": "~0.1.1",

--- a/packages/react-server-cli/src/ConfigurationError.js
+++ b/packages/react-server-cli/src/ConfigurationError.js
@@ -1,0 +1,13 @@
+// Can't use `instanceof` with babel-ified subclasses of builtins.
+//
+//   https://phabricator.babeljs.io/T3083
+//
+// Gotta do this the old-fashioned way. :p
+//
+export default function ConfigurationError(message) {
+	this.name = 'ConfigurationError';
+	this.message = message;
+	this.stack = (new Error()).stack;
+}
+ConfigurationError.prototype = Object.create(Error.prototype);
+ConfigurationError.prototype.constructor = ConfigurationError;

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -1,5 +1,5 @@
 require("babel-core/register");
 
-const {start, parseCliArgs} = require(".");
+const {run, parseCliArgs} = require(".");
 
-start(parseCliArgs());
+run(parseCliArgs());

--- a/packages/react-server-cli/src/commands/add-page.js
+++ b/packages/react-server-cli/src/commands/add-page.js
@@ -1,0 +1,53 @@
+import _ from "lodash";
+import fs from "fs";
+import {join} from "path";
+import chalk from "chalk";
+import mkdirp from "mkdirp";
+import fileExists from "../fileExists";
+import ConfigurationError from "../ConfigurationError";
+
+const PAGE_SOURCE = _.template(`
+import React from "react";
+
+export default class <%= className %> {
+	handleRoute(next) {
+		// Kick off data requests here.
+		return next();
+	}
+
+	getElements() {
+		return <div>This is <%= className %>.</div>
+	}
+}
+`);
+
+export default function addPage(options){
+	const {routesFile, routesPath, routes} = options;
+
+	const path = options._[3];
+	const className = options._[4];
+
+	if (!path || !className) {
+		throw new ConfigurationError("Usage: react-server add-page <urlPath> <ClassName>");
+	}
+
+	const page = join("pages", className + ".js");
+
+	if (fileExists(page)) {
+		throw new ConfigurationError(`Found a pre-existing ${page}.  Aborting.`);
+	}
+
+	mkdirp("pages");
+
+	console.log(chalk.yellow("Generating " + page));
+
+	fs.writeFileSync(page, PAGE_SOURCE({className}));
+
+	routes.routes[className] = { path, page };
+
+	console.log(chalk.yellow("Updating " + routesFile));
+
+	fs.writeFileSync(routesPath, JSON.stringify(routes, null, "  ") + "\n");
+
+	console.log(chalk.green("All set!"));
+}

--- a/packages/react-server-cli/src/commands/compile.js
+++ b/packages/react-server-cli/src/commands/compile.js
@@ -2,8 +2,9 @@ import compileClient from "../compileClient"
 import handleCompilationErrors from "../handleCompilationErrors";
 import setupLogging from "../setupLogging";
 import logProductionWarnings from "../logProductionWarnings";
+import {logging} from "../react-server";
 
-const logger = require("react-server").logging.getLogger(__LOGGER__);
+const logger = logging.getLogger(__LOGGER__);
 
 export default function compile(options){
 	setupLogging(options);

--- a/packages/react-server-cli/src/commands/compile.js
+++ b/packages/react-server-cli/src/commands/compile.js
@@ -1,9 +1,14 @@
 import compileClient from "../compileClient"
 import handleCompilationErrors from "../handleCompilationErrors";
+import setupLogging from "../setupLogging";
+import logProductionWarnings from "../logProductionWarnings";
 
 const logger = require("react-server").logging.getLogger(__LOGGER__);
 
 export default function compile(options){
+	setupLogging(options);
+	logProductionWarnings(options);
+
 	const {compiler} = compileClient(options);
 
 	logger.notice("Starting compilation of client JavaScript...");

--- a/packages/react-server-cli/src/commands/compile.js
+++ b/packages/react-server-cli/src/commands/compile.js
@@ -1,10 +1,7 @@
 import compileClient from "../compileClient"
-import callerDependency from "../callerDependency";
 import handleCompilationErrors from "../handleCompilationErrors";
 
-const reactServer = require(callerDependency("react-server"));
-
-const logger = reactServer.logging.getLogger(__LOGGER__);
+const logger = require("react-server").logging.getLogger(__LOGGER__);
 
 export default function compile(options){
 	const {compiler} = compileClient(options);

--- a/packages/react-server-cli/src/commands/compile.js
+++ b/packages/react-server-cli/src/commands/compile.js
@@ -1,0 +1,21 @@
+import compileClient from "../compileClient"
+import callerDependency from "../callerDependency";
+import handleCompilationErrors from "../handleCompilationErrors";
+
+const reactServer = require(callerDependency("react-server"));
+
+const logger = reactServer.logging.getLogger(__LOGGER__);
+
+export default function compile(options){
+	const {compiler} = compileClient(options);
+
+	logger.notice("Starting compilation of client JavaScript...");
+	compiler.run((err, stats) => {
+		const error = handleCompilationErrors(err, stats);
+		if (!error) {
+			logger.notice("Successfully compiled client JavaScript.");
+		} else {
+			logger.error(error);
+		}
+	});
+}

--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -1,8 +1,4 @@
-import callerDependency from "../callerDependency";
-
-const reactServer = require(callerDependency("react-server"));
-
-const logger = reactServer.logging.getLogger(__LOGGER__);
+const logger = require("react-server").logging.getLogger(__LOGGER__);
 
 export default function compile(){
 	logger.notice("Coming soon!");

--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -1,0 +1,9 @@
+import callerDependency from "../callerDependency";
+
+const reactServer = require(callerDependency("react-server"));
+
+const logger = reactServer.logging.getLogger(__LOGGER__);
+
+export default function compile(){
+	logger.notice("Coming soon!");
+}

--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -44,7 +44,8 @@ const CONFIG = {
 export default function init(){
 
 	if (!fileExists("package.json")) {
-		throw new ConfigurationError("Missing package.json.  Please run `npm init` first.");
+		console.log(chalk.yellow("No package.json found.  Running `npm init --yes`"));
+		spawnSync("npm", ["init", "--yes"], {stdio: "inherit"});
 	}
 
 	Object.keys(CONFIG).forEach(fn => {

--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -2,6 +2,7 @@ import _ from "lodash";
 import fs from "fs";
 import {spawnSync} from "child_process";
 import chalk from "chalk";
+import fileExists from "../fileExists";
 import ConfigurationError from "../ConfigurationError";
 
 const DEPENDENCIES = [
@@ -14,10 +15,17 @@ const DEPENDENCIES = [
 	"react-dom@~0.14.2",
 ]
 
+const DEV_DEPENDENCIES = [
+
+	// TODO: These, too.
+	"webpack-dev-server@~1.13.0",
+	"webpack@^1.13.1",
+]
+
 const CONFIG = {
 	"routes.json": {
 		middleware: [],
-		routes: [],
+		routes: {},
 	},
 	".reactserverrc": {
 		routesFile: "routes.json",
@@ -33,19 +41,8 @@ const CONFIG = {
 	},
 }
 
-export default function init(options){
-	try {
-		_init(options);
-	} catch (e) {
-		if (e instanceof ConfigurationError) {
-			console.error(chalk.red(e.message));
-		} else {
-			throw e;
-		}
-	}
-}
+export default function init(){
 
-function _init() {
 	if (!fileExists("package.json")) {
 		throw new ConfigurationError("Missing package.json.  Please run `npm init` first.");
 	}
@@ -60,6 +57,10 @@ function _init() {
 
 	spawnSync("npm", ["install", "--save", ...DEPENDENCIES], {stdio: "inherit"});
 
+	console.log(chalk.yellow("Installing devDependencies"));
+
+	spawnSync("npm", ["install", "--save-dev", ...DEV_DEPENDENCIES], {stdio: "inherit"});
+
 	_.forEach(CONFIG, (config, fn) => {
 		console.log(chalk.yellow("Generating " + fn));
 
@@ -67,13 +68,4 @@ function _init() {
 	});
 
 	console.log(chalk.green("All set!"));
-}
-
-function fileExists(fn) {
-	try {
-		fs.statSync(fn);
-		return true;
-	} catch (e) {
-		return false;
-	}
 }

--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -1,5 +1,79 @@
-const logger = require("react-server").logging.getLogger(__LOGGER__);
+import _ from "lodash";
+import fs from "fs";
+import {spawnSync} from "child_process";
+import chalk from "chalk";
+import ConfigurationError from "../ConfigurationError";
 
-export default function compile(){
-	logger.notice("Coming soon!");
+const DEPENDENCIES = [
+	"react-server",
+	"babel-preset-react-server",
+
+	// TODO: Modernize our peer deps and remove versions here.
+	"superagent@1.2.0",
+	"react@~0.14.2",
+	"react-dom@~0.14.2",
+]
+
+const CONFIG = {
+	"routes.json": {
+		middleware: [],
+		routes: [],
+	},
+	".reactserverrc": {
+		routesFile: "routes.json",
+		port: 3000,
+		env: {
+			production: {
+				port: 80,
+			},
+		},
+	},
+	".babelrc": {
+		presets: ["react-server"],
+	},
+}
+
+export default function init(options){
+	try {
+		_init(options);
+	} catch (e) {
+		if (e instanceof ConfigurationError) {
+			console.error(chalk.red(e.message));
+		} else {
+			throw e;
+		}
+	}
+}
+
+function _init() {
+	if (!fileExists("package.json")) {
+		throw new ConfigurationError("Missing package.json.  Please run `npm init` first.");
+	}
+
+	Object.keys(CONFIG).forEach(fn => {
+		if (fileExists(fn)) {
+			throw new ConfigurationError(`Found a pre-existing ${fn}.  Aborting.`);
+		}
+	});
+
+	console.log(chalk.yellow("Installing dependencies"));
+
+	spawnSync("npm", ["install", "--save", ...DEPENDENCIES], {stdio: "inherit"});
+
+	_.forEach(CONFIG, (config, fn) => {
+		console.log(chalk.yellow("Generating " + fn));
+
+		fs.writeFileSync(fn, JSON.stringify(config, null, "  ") + "\n");
+	});
+
+	console.log(chalk.green("All set!"));
+}
+
+function fileExists(fn) {
+	try {
+		fs.statSync(fn);
+		return true;
+	} catch (e) {
+		return false;
+	}
 }

--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -7,6 +7,8 @@ import WebpackDevServer from "webpack-dev-server"
 import compileClient from "../compileClient"
 import handleCompilationErrors from "../handleCompilationErrors";
 import reactServer from "../react-server";
+import setupLogging from "../setupLogging";
+import logProductionWarnings from "../logProductionWarnings";
 
 const logger = reactServer.logging.getLogger(__LOGGER__);
 
@@ -15,6 +17,9 @@ const logger = reactServer.logging.getLogger(__LOGGER__);
 // started. stop is a method to stop all servers. It takes no arguments and
 // returns a promise that resolves when the server has stopped.
 export default function start(options){
+	setupLogging(options);
+	logProductionWarnings(options);
+
 	const {
 		port,
 		jsPort,

--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -5,10 +5,8 @@ import pem from "pem"
 import compression from "compression"
 import WebpackDevServer from "webpack-dev-server"
 import compileClient from "../compileClient"
-import callerDependency from "../callerDependency";
 import handleCompilationErrors from "../handleCompilationErrors";
-
-const reactServer = require(callerDependency("react-server"));
+import reactServer from "../react-server";
 
 const logger = reactServer.logging.getLogger(__LOGGER__);
 

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -20,8 +20,9 @@ import callerDependency from "./callerDependency"
 // once the compiler has been run. The file path returned from the promise
 // can be required and passed in to reactServer.middleware().
 // TODO: add options for sourcemaps.
-export default (routes, opts = {}) => {
+export default (opts = {}) => {
 	const {
+		routes,
 		workingDir = "./__clientTemp",
 		routesDir = ".",
 		outputDir = workingDir + "/build",
@@ -343,9 +344,9 @@ const writeClientBootstrapFile = (outputDir, opts) => {
 		}
 		var reactServer = require("react-server");
 		window.rfBootstrap = function() {
-			reactServer.logging.setLevel('main',  ${opts.logLevel});
-			reactServer.logging.setLevel('time',  ${opts.timingLogLevel});
-			reactServer.logging.setLevel('gauge', ${opts.gaugeLogLevel});
+			reactServer.logging.setLevel('main',  ${JSON.stringify(opts.logLevel)});
+			reactServer.logging.setLevel('time',  ${JSON.stringify(opts.timingLogLevel)});
+			reactServer.logging.setLevel('gauge', ${JSON.stringify(opts.gaugeLogLevel)});
 			new reactServer.ClientController({routes: require("./routes_client")}).init();
 		}`
 	);

--- a/packages/react-server-cli/src/fileExists.js
+++ b/packages/react-server-cli/src/fileExists.js
@@ -1,0 +1,10 @@
+import fs from "fs";
+
+export default function fileExists(fn) {
+	try {
+		fs.statSync(fn);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}

--- a/packages/react-server-cli/src/handleCompilationErrors.js
+++ b/packages/react-server-cli/src/handleCompilationErrors.js
@@ -1,6 +1,4 @@
-import callerDependency from "./callerDependency";
-
-const reactServer = require(callerDependency("react-server"));
+import reactServer from "./react-server";
 
 const logger = reactServer.logging.getLogger(__LOGGER__);
 

--- a/packages/react-server-cli/src/handleCompilationErrors.js
+++ b/packages/react-server-cli/src/handleCompilationErrors.js
@@ -1,0 +1,30 @@
+import callerDependency from "./callerDependency";
+
+const reactServer = require(callerDependency("react-server"));
+
+const logger = reactServer.logging.getLogger(__LOGGER__);
+
+// takes in the err and stats object returned by a webpack compilation and returns
+// an error object if something serious happened, or null if things are ok.
+export default function handleCompilationErrors (err, stats){
+	if (err) {
+		logger.error("Error during webpack build.");
+		logger.error(err);
+		return new Error(err);
+		// TODO: inspect stats to see if there are errors -sra.
+	} else if (stats.hasErrors()) {
+		console.error("There were errors in the JavaScript compilation.");
+		stats.toJson().errors.forEach((error) => {
+			console.error(error);
+		});
+		return new Error("There were errors in the JavaScript compilation.");
+	} else if (stats.hasWarnings()) {
+		logger.warning("There were warnings in the JavaScript compilation. Note that this is normal if you are minifying your code.");
+		// for now, don't enumerate warnings; they are absolutely useless in minification mode.
+		// TODO: handle this more intelligently, perhaps with a --reportwarnings flag or with different
+		// behavior based on whether or not --minify is set.
+	}
+	return null;
+}
+
+

--- a/packages/react-server-cli/src/handleCompilationErrors.js
+++ b/packages/react-server-cli/src/handleCompilationErrors.js
@@ -1,6 +1,6 @@
-import reactServer from "./react-server";
+import {logging} from "./react-server";
 
-const logger = reactServer.logging.getLogger(__LOGGER__);
+const logger = logging.getLogger(__LOGGER__);
 
 // takes in the err and stats object returned by a webpack compilation and returns
 // an error object if something serious happened, or null if things are ok.

--- a/packages/react-server-cli/src/index.js
+++ b/packages/react-server-cli/src/index.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const run = require("./run").default;
+const parseCliArgs = require("./parseCliArgs").default;
 
 require.extensions['.css'] =
 require.extensions['.less'] =
@@ -14,6 +16,6 @@ require.extensions['.md'] =
 	};
 
 module.exports = {
-	start: require("./startServer").default,
-	parseCliArgs: require("./parseCliArgs").default,
+	parseCliArgs,
+	run,
 };

--- a/packages/react-server-cli/src/logProductionWarnings.js
+++ b/packages/react-server-cli/src/logProductionWarnings.js
@@ -1,0 +1,25 @@
+import reactServer from "./react-server";
+
+const logger = reactServer.logging.getLogger(__LOGGER__);
+
+export default function logProductionWarnings({hot, minify, jsUrl, longTermCaching}){
+	// if the server is being launched with some bad practices for production mode, then we
+	// should output a warning. if arg.jsurl is set, then hot and minify are moot, since
+	// we aren't serving JavaScript & CSS at all.
+	if ((!jsUrl && (hot || !minify)) ||  process.env.NODE_ENV !== "production" || !longTermCaching) { //eslint-disable-line no-process-env
+		logger.warning("PRODUCTION WARNING: the following current settings are discouraged in production environments. (If you are developing, carry on!):");
+		if (hot) {
+			logger.warning("-- Hot reload is enabled. To disable, set hot to false (--hot=false at the command-line) or set NODE_ENV=production.");
+		}
+
+		if (!minify) {
+			logger.warning("-- Minification is disabled. To enable, set minify to true (--minify at the command-line) or set NODE_ENV=production.");
+		}
+
+		if (!longTermCaching) {
+			logger.warning("-- Long-term caching is disabled. To enable, set longTermCaching to true (--long-term-caching at the command-line) or set NODE_ENV=production to turn on.");
+		}
+		logger.info(`NODE_ENV is set to ${process.env.NODE_ENV}`); //eslint-disable-line no-process-env
+	}
+
+}

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -2,7 +2,7 @@ import yargs from "yargs"
 import fs from "fs"
 
 export default (args = process.argv) => {
-	var parsedArgs = yargs(args)
+	var argsDefinition = yargs(args)
 		.usage('Usage: $0 [options]')
 		.option("routes-file", {
 			describe: "The routes file to load. Default is 'routes.js'.",
@@ -94,7 +94,27 @@ export default (args = process.argv) => {
 		.help('?')
 		.alias('?', 'help')
 		.demand(0)
-		.argv;
+
+	const commands = {
+		"start"   : "Start the server",
+		"compile" : "Compile static assets",
+		"init"    : "Create a routes file and a .reactserverrc",
+	}
+
+	Object.keys(commands)
+		.forEach(k => argsDefinition = argsDefinition.command(k, commands[k]));
+
+	var parsedArgs = argsDefinition.argv;
+
+	parsedArgs.command = parsedArgs._[2];
+
+	if (!commands[parsedArgs.command]) {
+		argsDefinition.showHelp();
+		if (parsedArgs.command) {
+			console.log("Invalid command: " + parsedArgs.command);
+		}
+		process.exit(1); // eslint-disable-line no-process-exit
+	}
 
 	if (parsedArgs.https && (parsedArgs.httpsKey || parsedArgs.httpsCert || parsedArgs.httpsCa || parsedArgs.httpsPfx || parsedArgs.httpsPassphrase)) {
 		throw new Error("If you set https to true, you must not set https-key, https-cert, https-ca, https-pfx, or https-passphrase.");

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -3,7 +3,7 @@ import fs from "fs"
 
 export default (args = process.argv) => {
 	var argsDefinition = yargs(args)
-		.usage('Usage: $0 [options]')
+		.usage('Usage: $0 <command> [options]')
 		.option("routes-file", {
 			describe: "The routes file to load. Default is 'routes.js'.",
 		})

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -126,7 +126,7 @@ export default (args = process.argv) => {
 const sslize = argv => {
 
 	if (argv.httpsKey || argv.httpsCert || argv.httpsCa || argv.httpsPfx || argv.httpsPassphrase) {
-		argv.https = {
+		argv.httpsOptions = {
 			key: argv.httpsKey ? fs.readFileSync(argv.httpsKey) : undefined,
 			cert: argv.httpsCert ? fs.readFileSync(argv.httpsCert) : undefined,
 			ca: argv.httpsCa ? fs.readFileSync(argv.httpsCa) : undefined,

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -96,9 +96,10 @@ export default (args = process.argv) => {
 		.demand(0)
 
 	const commands = {
-		"start"   : "Start the server",
-		"compile" : "Compile static assets",
-		"init"    : "Create a routes file and a .reactserverrc",
+		"start"    : "Start the server",
+		"compile"  : "Compile static assets",
+		"init"     : "Initialize a React Server site",
+		"add-page" : "Add a page to an existing site",
 	}
 
 	Object.keys(commands)

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -116,10 +116,6 @@ export default (args = process.argv) => {
 		process.exit(1); // eslint-disable-line no-process-exit
 	}
 
-	if (parsedArgs.https && (parsedArgs.httpsKey || parsedArgs.httpsCert || parsedArgs.httpsCa || parsedArgs.httpsPfx || parsedArgs.httpsPassphrase)) {
-		throw new Error("If you set https to true, you must not set https-key, https-cert, https-ca, https-pfx, or https-passphrase.");
-	}
-
 	// we remove all the options that have undefined as their value; those are the
 	// ones that weren't on the command line, and we don't want them to override
 	// defaults or config files.
@@ -137,6 +133,14 @@ const sslize = argv => {
 			pfx: argv.httpsPfx ? fs.readFileSync(argv.httpsPfx) : undefined,
 			passphrase: argv.httpsPassphrase,
 		}
+	}
+
+	if (argv.https && (argv.httpsKey || argv.httpsCert || argv.httpsCa || argv.httpsPfx || argv.httpsPassphrase)) {
+		throw new Error("If you set https to true, you must not set https-key, https-cert, https-ca, https-pfx, or https-passphrase.");
+	}
+
+	if ((argv.key || argv.cert || argv.ca) && argv.pfx) {
+		throw new Error("If you set https.pfx, you can't set https.key, https.cert, or https.ca.");
 	}
 
 	return argv;

--- a/packages/react-server-cli/src/react-server.js
+++ b/packages/react-server-cli/src/react-server.js
@@ -1,0 +1,4 @@
+import callerDependency from "./callerDependency";
+
+// We need react-server to be a singleton, and we want our caller's copy.
+module.exports = require(callerDependency("react-server"));

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -2,9 +2,7 @@ import path from "path";
 import mergeOptions from "./mergeOptions"
 import findOptionsInFiles from "./findOptionsInFiles"
 import defaultOptions from "./defaultOptions"
-import callerDependency from "./callerDependency";
-
-const reactServer = require(callerDependency("react-server"));
+import reactServer from "./react-server";
 
 const logger = reactServer.logging.getLogger(__LOGGER__);
 

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -5,6 +5,7 @@ import findOptionsInFiles from "./findOptionsInFiles"
 import defaultOptions from "./defaultOptions"
 import ConfigurationError from "./ConfigurationError"
 
+/* eslint-disable consistent-return */
 export default function run(options = {}) {
 
 	// for the option properties that weren't sent in, look for a config file
@@ -32,7 +33,7 @@ export default function run(options = {}) {
 	options.outputUrl = jsUrl || `${httpsOptions ? "https" : "http"}://${host}:${jsPort}/`;
 
 	try {
-		require("./" + path.join("commands", options.command)).default(options);
+		return require("./" + path.join("commands", options.command)).default(options);
 	} catch (e) {
 		if (e instanceof ConfigurationError) {
 			console.error(chalk.red(e.message));

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -1,7 +1,9 @@
 import path from "path";
+import chalk from "chalk";
 import mergeOptions from "./mergeOptions"
 import findOptionsInFiles from "./findOptionsInFiles"
 import defaultOptions from "./defaultOptions"
+import ConfigurationError from "./ConfigurationError"
 
 export default function run(options = {}) {
 
@@ -29,5 +31,13 @@ export default function run(options = {}) {
 
 	options.outputUrl = jsUrl || `${httpsOptions ? "https" : "http"}://${host}:${jsPort}/`;
 
-	return require("./" + path.join("commands", options.command)).default(options);
+	try {
+		require("./" + path.join("commands", options.command)).default(options);
+	} catch (e) {
+		if (e instanceof ConfigurationError) {
+			console.error(chalk.red(e.message));
+		} else {
+			throw e;
+		}
+	}
 }

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -2,9 +2,6 @@ import path from "path";
 import mergeOptions from "./mergeOptions"
 import findOptionsInFiles from "./findOptionsInFiles"
 import defaultOptions from "./defaultOptions"
-import reactServer from "./react-server";
-
-const logger = reactServer.logging.getLogger(__LOGGER__);
 
 export default function run(options = {}) {
 
@@ -12,9 +9,6 @@ export default function run(options = {}) {
 	// (either .reactserverrc or a reactServer section in a package.json). for
 	// options neither passed in nor in a config file, use the defaults.
 	options = mergeOptions(defaultOptions, findOptionsInFiles() || {}, options);
-
-	setupLogging(options.logLevel, options.timingLogLevel, options.gaugeLogLevel);
-	logProductionWarnings(options);
 
 	const {
 		routesFile,
@@ -36,32 +30,4 @@ export default function run(options = {}) {
 	options.outputUrl = jsUrl || `${httpsOptions ? "https" : "http"}://${host}:${jsPort}/`;
 
 	return require("./" + path.join("commands", options.command)).default(options);
-}
-
-const setupLogging = (logLevel, timingLogLevel, gaugeLogLevel) => {
-	reactServer.logging.setLevel('main',  logLevel);
-	reactServer.logging.setLevel('time',  timingLogLevel);
-	reactServer.logging.setLevel('gauge', gaugeLogLevel);
-}
-
-const logProductionWarnings = ({hot, minify, jsUrl, longTermCaching}) => {
-	// if the server is being launched with some bad practices for production mode, then we
-	// should output a warning. if arg.jsurl is set, then hot and minify are moot, since
-	// we aren't serving JavaScript & CSS at all.
-	if ((!jsUrl && (hot || !minify)) ||  process.env.NODE_ENV !== "production" || !longTermCaching) { //eslint-disable-line no-process-env
-		logger.warning("PRODUCTION WARNING: the following current settings are discouraged in production environments. (If you are developing, carry on!):");
-		if (hot) {
-			logger.warning("-- Hot reload is enabled. To disable, set hot to false (--hot=false at the command-line) or set NODE_ENV=production.");
-		}
-
-		if (!minify) {
-			logger.warning("-- Minification is disabled. To enable, set minify to true (--minify at the command-line) or set NODE_ENV=production.");
-		}
-
-		if (!longTermCaching) {
-			logger.warning("-- Long-term caching is disabled. To enable, set longTermCaching to true (--long-term-caching at the command-line) or set NODE_ENV=production to turn on.");
-		}
-		logger.info(`NODE_ENV is set to ${process.env.NODE_ENV}`); //eslint-disable-line no-process-env
-	}
-
 }

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -1,0 +1,69 @@
+import path from "path";
+import mergeOptions from "./mergeOptions"
+import findOptionsInFiles from "./findOptionsInFiles"
+import defaultOptions from "./defaultOptions"
+import callerDependency from "./callerDependency";
+
+const reactServer = require(callerDependency("react-server"));
+
+const logger = reactServer.logging.getLogger(__LOGGER__);
+
+export default function run(options = {}) {
+
+	// for the option properties that weren't sent in, look for a config file
+	// (either .reactserverrc or a reactServer section in a package.json). for
+	// options neither passed in nor in a config file, use the defaults.
+	options = mergeOptions(defaultOptions, findOptionsInFiles() || {}, options);
+
+	setupLogging(options.logLevel, options.timingLogLevel, options.gaugeLogLevel);
+	logProductionWarnings(options);
+
+	const {
+		routesFile,
+		jsUrl,
+		jsPort,
+		host,
+		httpsOptions,
+	} = options;
+
+	options.routesPath = path.resolve(process.cwd(), routesFile);
+	options.routesDir = path.dirname(options.routesPath);
+
+	try {
+		options.routes = require(options.routesPath);
+	} catch (e) {
+		// Pass. Commands need to check for routes themselves.
+	}
+
+	options.outputUrl = jsUrl || `${httpsOptions ? "https" : "http"}://${host}:${jsPort}/`;
+
+	return require("./" + path.join("commands", options.command)).default(options);
+}
+
+const setupLogging = (logLevel, timingLogLevel, gaugeLogLevel) => {
+	reactServer.logging.setLevel('main',  logLevel);
+	reactServer.logging.setLevel('time',  timingLogLevel);
+	reactServer.logging.setLevel('gauge', gaugeLogLevel);
+}
+
+const logProductionWarnings = ({hot, minify, jsUrl, longTermCaching}) => {
+	// if the server is being launched with some bad practices for production mode, then we
+	// should output a warning. if arg.jsurl is set, then hot and minify are moot, since
+	// we aren't serving JavaScript & CSS at all.
+	if ((!jsUrl && (hot || !minify)) ||  process.env.NODE_ENV !== "production" || !longTermCaching) { //eslint-disable-line no-process-env
+		logger.warning("PRODUCTION WARNING: the following current settings are discouraged in production environments. (If you are developing, carry on!):");
+		if (hot) {
+			logger.warning("-- Hot reload is enabled. To disable, set hot to false (--hot=false at the command-line) or set NODE_ENV=production.");
+		}
+
+		if (!minify) {
+			logger.warning("-- Minification is disabled. To enable, set minify to true (--minify at the command-line) or set NODE_ENV=production.");
+		}
+
+		if (!longTermCaching) {
+			logger.warning("-- Long-term caching is disabled. To enable, set longTermCaching to true (--long-term-caching at the command-line) or set NODE_ENV=production to turn on.");
+		}
+		logger.info(`NODE_ENV is set to ${process.env.NODE_ENV}`); //eslint-disable-line no-process-env
+	}
+
+}

--- a/packages/react-server-cli/src/setupLogging.js
+++ b/packages/react-server-cli/src/setupLogging.js
@@ -1,0 +1,7 @@
+import reactServer from "./react-server";
+
+export default function setupLogging({logLevel, timingLogLevel, gaugeLogLevel}){
+	reactServer.logging.setLevel("main",  logLevel);
+	reactServer.logging.setLevel("time",  timingLogLevel);
+	reactServer.logging.setLevel("gauge", gaugeLogLevel);
+}

--- a/packages/react-server-cli/src/startServer.js
+++ b/packages/react-server-cli/src/startServer.js
@@ -41,7 +41,7 @@ const startImpl = ({
 		compileOnly,
 		jsUrl,
 		stats,
-		https: httpsOptions,
+		httpsOptions,
 		longTermCaching,
 }) => {
 	const routesPath = path.resolve(process.cwd(), routesFile);

--- a/packages/react-server-cli/src/startServer.js
+++ b/packages/react-server-cli/src/startServer.js
@@ -44,10 +44,6 @@ const startImpl = ({
 		https: httpsOptions,
 		longTermCaching,
 }) => {
-	if ((httpsOptions.key || httpsOptions.cert || httpsOptions.ca) && httpsOptions.pfx) {
-		throw new Error("If you set https.pfx, you can't set https.key, https.cert, or https.ca.");
-	}
-
 	const routesPath = path.resolve(process.cwd(), routesFile);
 	const routes = require(routesPath);
 

--- a/packages/react-server-integration-tests/src/specRuntime/testHelper.js
+++ b/packages/react-server-integration-tests/src/specRuntime/testHelper.js
@@ -3,7 +3,7 @@ var	fs = require("fs"),
 	mkdirp = require("mkdirp"),
 	path = require("path"),
 	Browser = require('zombie'),
-	start = require('react-server-cli').start,
+	CLI = require('react-server-cli'),
 	crypto = require('crypto');
 
 // This needs to be different from the port used by the tests that still live
@@ -101,7 +101,8 @@ var startServer = function (specFile, routes) {
 
 	var routesFile = writeRoutesFile(specFile, routes, testTempDir);
 
-	return start({
+	return CLI.run({
+		command: "start",
 		routesFile: routesFile,
 		hot: false,
 		port: PORT,

--- a/packages/react-server-integration-tests/src/specRuntime/testHelper.js
+++ b/packages/react-server-integration-tests/src/specRuntime/testHelper.js
@@ -106,6 +106,7 @@ var startServer = function (specFile, routes) {
 		routesFile: routesFile,
 		hot: false,
 		port: PORT,
+		jsPort: +PORT+1,
 		logLevel: "emergency",
 		timingLogLevel: "none",
 		gaugeLogLevel: "no",

--- a/packages/react-server-test-pages/cli.js
+++ b/packages/react-server-test-pages/cli.js
@@ -1,5 +1,5 @@
 require("babel-core/register");
 
-const {start, parseCliArgs} = require("react-server-cli");
+const {run, parseCliArgs} = require("react-server-cli");
 
-start(parseCliArgs());
+run(parseCliArgs());

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -6,9 +6,9 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "gulp build",
-    "start": "node ./cli.js",
+    "start": "node ./cli.js start",
     "test": "gulp test",
-    "debug": "node-debug --debug-brk=0 -p 9000 react-server-cli",
+    "debug": "node-debug --debug-brk=0 -p 9000 ./cli.js start",
     "clean": "rimraf npm-debug.log* __clientTemp target"
   },
   "author": "Bo Borgerson",

--- a/packages/react-server-website/.reactserverrc
+++ b/packages/react-server-website/.reactserverrc
@@ -1,19 +1,18 @@
 {
   "routes": "./routes.js",
   "host": "localhost",
-  "port": 3000,
-  "js-port": 3001,
+  "port": 3010,
+  "jsPort": 3011,
   "hot": false,
   "minify": false,
-  "long-term-caching": false,
-  "compile-only": false,
+  "longTermCaching": false,
   "https": false,
-  "log-level": "debug",
+  "logLevel": "debug",
   "env": {
-    "staging": {
-      "port": "4000"
-    },
     "production": {
+       "jsUrl": "/assets/",
+       "logLevel": "error",
+       "minify": true,
        "port": "80"
     }
   }

--- a/packages/react-server-website/cli.js
+++ b/packages/react-server-website/cli.js
@@ -1,5 +1,5 @@
 require("babel-core/register");
 
-const {start, parseCliArgs} = require("react-server-cli");
+const {run, parseCliArgs} = require("react-server-cli");
 
-start(parseCliArgs());
+run(parseCliArgs());

--- a/packages/react-server-website/components/content/HomeGetStartedSection.md
+++ b/packages/react-server-website/components/content/HomeGetStartedSection.md
@@ -16,7 +16,7 @@ yo react-server
 npm run compile
 npm run start
 
-# go to http://localhost:3010
+# go to http://localhost:3000
 ```
 
 That hooks you up with [react-server-cli](/docs/guides/react-server-cli), which will get you up and running right away.

--- a/packages/react-server-website/package.json
+++ b/packages/react-server-website/package.json
@@ -5,9 +5,9 @@
   "main": "HelloWorld.js",
   "private": true,
   "scripts": {
-    "build-assets": "npm run docs && node ./cli.js --compile-only --minify",
-    "start-prod": "node ./cli.js --port 3010 --minify --js-url /assets/",
-    "start": "node ./cli.js --port 3010 --js-port 3011",
+    "build-assets": "npm run docs && NODE_ENV=production node ./cli.js compile",
+    "start-prod": "NODE_ENV=production node ./cli.js start",
+    "start": "node ./cli.js start",
     "test": "eslint routes.js gulpfile.js pages/ components/ && nsp check",
     "docs": "docco -o docs ./components/*.js ./lib/*.js ./middleware/*.js ./pages/*.js *.js && node build-dir-contents.js"
   },

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -36,7 +36,7 @@ yo react-server
 # compile and run the new app
 npm run compile
 npm run start
-# go to http://localhost:3010
+# go to http://localhost:3000
 ```
 
 That hooks you up with [`react-server-cli`](packages/react-server-cli), which


### PR DESCRIPTION
Now that the CLI can be [installed globally](https://github.com/redfin/react-server/pull/484) it can be used to bootstrap a React Server site.

This is totally new functionality that's only tangentially related to the previous "start server" behavior.  So... I've added "commands".

```
$ react-server
Usage: react-server <command> [options]

Commands:
  start     Start the server
  compile   Compile static assets
  init      Initialize a React Server site
  add-page  Add a page to an existing site

Options:
  --routes-file        The routes file to load. Default is 'routes.js'.
  -p, --port           Port to start listening for react-server. Default is 3000.
...
```

The new quick start in the CLI doc looks like:

```bash
$ npm install -g react-server-cli
$ react-server init
$ react-server add-page '/' Homepage
$ react-server start
```

This is a pretty big change to the interface of `react-server-cli`.

@aickin - How does this look to you?