### PR TITLE
Making development compose file more similar to production

### DIFF
--- a/packages/react-server-website/docker-compose.yml
+++ b/packages/react-server-website/docker-compose.yml
@@ -1,18 +1,27 @@
 version: '2'
 services:
-  node:
+  docs:
     build:
       context: .
       dockerfile: Dockerfile
+  slackin:
+    image: davidalber/slackin
+    environment:
+     - SLACK_COC=https://github.com/redfin/react-server/blob/master/CODE_OF_CONDUCT.md
+     - SLACK_SUBDOMAIN=react-server
+     - SLACK_API_TOKEN
   nginx:
     image: nginx:1.10.1
     depends_on:
-     - node
+     - docs
+     - slackin
     links:
-     - node:react-server-docs
+     - docs:react-server-docs
+     - slackin:slackin
     ports:
      - "8080:80"
+     - "8443:443"
     volumes_from:
-     - node:ro
+     - docs:ro
     volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION
This change makes it possible to use the Docker Compose file in development again. I will document how to use this in a future PR.