### PR TITLE
Compressing static assets

### DIFF
--- a/packages/react-server-website/nginx.conf
+++ b/packages/react-server-website/nginx.conf
@@ -21,6 +21,8 @@ server {
 
     location /assets/ {
         root /www/data;
+        gzip on;
+        gzip_types application/javascript text/css;
     }
 }
 


### PR DESCRIPTION
Enabling ngx_http_gzip_module to compress assets on the way out.

This fixes #491.