### PR TITLE
Eliminate the top-level react deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
     "minimist": "1.1.0",
     "mkdirp": "^0.5.1",
     "path-to-regexp": "1.0.1",
-    "react": "0.14.2",
-    "react-dom": "0.14.2",
     "react-server-gulp-module-tagger": "^0.3.3",
     "rimraf": "^2.5.3",
     "superagent": "1.2.0",


### PR DESCRIPTION
These don't seem to be used, and GreenKeeper's foaming at the mouth over them.