### PR TITLE
Lint the generator with eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "debug": "cat lerna-debug.log && for d in packages/*/npm-debug.log*; do echo $d; cat $d; done"
   },
   "devDependencies": {
+    "babel-eslint": "^6.1.2",
     "babel-plugin-react-require": "^2.1.0",
     "babel-plugin-react-server": "^0.3.3",
     "babel-plugin-transform-runtime": "~6.12.0",

--- a/packages/generator-react-server/.gitignore
+++ b/packages/generator-react-server/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+_eslintrc

--- a/packages/generator-react-server/.npmignore
+++ b/packages/generator-react-server/.npmignore
@@ -1,0 +1,1 @@
+coverage

--- a/packages/generator-react-server/generators/app/index.js
+++ b/packages/generator-react-server/generators/app/index.js
@@ -1,4 +1,3 @@
-'use strict';
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var yosay = require('yosay');
@@ -25,12 +24,12 @@ module.exports = yeoman.Base.extend({
 				}
 
 				return warnings.concat(errors).join('\n');
-			}
+			},
 		}, {
 			type: 'confirm',
 			name: 'dockerCfg',
 			message: 'Do you want to generate a Docker file and Docker Compose file?',
-			default: false
+			default: false,
 		}];
 
 		return this.prompt(prompts).then(function (props) {
@@ -45,7 +44,7 @@ module.exports = yeoman.Base.extend({
 			'_nsprc',
 			'_babelrc',
 			'_gitignore',
-			'_reactserverrc'
+			'_reactserverrc',
 		].forEach(function (filename) {
 			var fn = filename.replace('_', '.');
 			_this.fs.copyTpl(
@@ -61,7 +60,7 @@ module.exports = yeoman.Base.extend({
 			'package.json',
 			'README.md',
 			'routes.js',
-			'test.js'
+			'test.js',
 		];
 
 		if (this.props.dockerCfg) {
@@ -80,5 +79,5 @@ module.exports = yeoman.Base.extend({
 
 	install: function () {
 		this.npmInstall();
-	}
+	},
 });

--- a/packages/generator-react-server/generators/app/index.js
+++ b/packages/generator-react-server/generators/app/index.js
@@ -43,6 +43,7 @@ module.exports = yeoman.Base.extend({
 		[
 			'_nsprc',
 			'_babelrc',
+			'_eslintrc',
 			'_gitignore',
 			'_reactserverrc',
 		].forEach(function (filename) {

--- a/packages/generator-react-server/generators/app/templates/README.md
+++ b/packages/generator-react-server/generators/app/templates/README.md
@@ -37,11 +37,11 @@ There are three tests called by the testing target; to run them independently
 you'll likely want to install some dependencies globally
 
 ```shell
-npm i -g xo ava nsp
+npm i -g eslint eslint-plugin-react babel-eslint ava nsp
 ```
 
 The first test is a linter, which checks for common bugs and code style; you can
-run it with `xo`.
+run it with `eslint <file-or-directory>`.
 
 The second test is a security auditing test, which checks for known security
 issues with the installed dependencies; you can run it with `nsp check`.

--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -5,7 +5,8 @@
   "main": "HelloWorld.js",
   "scripts": {
     "start": "react-server start",
-    "test": "xo && nsp check && ava test.js"
+    "lint": "eslint routes.js test.js pages",
+    "test": "npm run lint && nsp check && ava test.js"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -19,15 +20,9 @@
   },
   "devDependencies": {
     "ava": "^0.15.1",
-    "eslint-config-xo-react": "^0.8.0",
-    "eslint-plugin-react": "^5.1.1",
-    "nsp": "^2.3.3",
-    "xo": "^0.16.0"
-  },
-  "xo": {
-    "esnext": true,
-    "extends": "xo-react",
-    "globals": ["__LOGGER__"],
-    "ignores": ["__clientTemp/**/*", "build/**/*"]
+    "babel-eslint": "^6.1.2",
+    "eslint": "3.2.2",
+    "eslint-plugin-react": "6.0.0",
+    "nsp": "^2.3.3"
   }
 }

--- a/packages/generator-react-server/generators/app/templates/pages/hello-world.js
+++ b/packages/generator-react-server/generators/app/templates/pages/hello-world.js
@@ -12,7 +12,7 @@ export default class SimplePage {
 			{'http-equiv': 'x-ua-compatible', 'content': 'ie=edge'},
 			{name: 'viewport', content: 'width=device-width, initial-scale=1'},
 			{name: 'description', content: 'hello world, powered by React Server'},
-			{name: 'generator', content: 'React Server'}
+			{name: 'generator', content: 'React Server'},
 		];
 	}
 }

--- a/packages/generator-react-server/generators/app/templates/routes.js
+++ b/packages/generator-react-server/generators/app/templates/routes.js
@@ -4,7 +4,7 @@ module.exports = {
 		HelloWorld: {
 			path: ['/'],
 			method: 'get',
-			page: './pages/hello-world'
-		}
-	}
+			page: './pages/hello-world',
+		},
+	},
 };

--- a/packages/generator-react-server/generators/app/templates/test.js
+++ b/packages/generator-react-server/generators/app/templates/test.js
@@ -24,7 +24,7 @@ function getResponseCode(url) {
 		const req = http.get({
 			hostname: 'localhost',
 			port: 3000,
-			path: url
+			path: url,
 		}, res => {
 			resolve(res.statusCode);
 		});

--- a/packages/generator-react-server/package.json
+++ b/packages/generator-react-server/package.json
@@ -30,35 +30,15 @@
   },
   "devDependencies": {
     "ava": "^0.14.0",
-    "eslint-config-xo-react": "^0.7.0",
-    "eslint-plugin-react": "^5.1.1",
     "nsp": "^2.3.3",
     "rimraf": "^2.5.2",
-    "xo": "^0.15.1",
     "yeoman-assert": "^2.0.0",
     "yeoman-test": "^1.0.0"
   },
   "repository": "redfin/react-server",
   "scripts": {
-    "test": "ava test --tap && xo && nsp check",
+    "test": "ava test --tap && eslint generators/ && nsp check",
     "clean": "rimraf npm-debug.log*"
   },
-  "license": "Apache-2.0",
-  "xo": {
-    "envs": [
-      "node"
-    ],
-    "extends": "xo-react",
-    "globals": [
-      "__LOGGER__"
-    ],
-    "ignores": [
-      "test/**/*"
-    ],
-    "rules": {
-      "ava/no-ignored-test-files": [
-        0
-      ]
-    }
-  }
+  "license": "Apache-2.0"
 }

--- a/packages/generator-react-server/package.json
+++ b/packages/generator-react-server/package.json
@@ -37,7 +37,13 @@
   },
   "repository": "redfin/react-server",
   "scripts": {
-    "test": "ava test --tap && eslint generators/ && nsp check",
+
+    "//": "Keep these in sync",
+    "prepublish": "cp ../../.eslintrc generators/app/templates/_eslintrc",
+
+    "test": "npm run ava && npm run lint && nsp check",
+    "ava": "ava test --tap",
+    "lint": "eslint generators/ test/",
     "clean": "rimraf npm-debug.log*"
   },
   "license": "Apache-2.0"

--- a/packages/generator-react-server/test/app.js
+++ b/packages/generator-react-server/test/app.js
@@ -68,8 +68,13 @@ function exists(filename, dir) {
 function runsSuccessfully(command, dir) {
 	return new Promise((resolve) => {
 		cp.exec(command, {
-			cwd: dir
-		}, (error) => {
+			cwd: dir,
+		}, (error, stdout, stderr) => {
+			if (error) {
+				console.error(error);
+				console.error(stdout);
+				console.error(stderr);
+			}
 			resolve(!error);
 		});
 	});


### PR DESCRIPTION
Use consistent rules with the rest of the repo.

Note that this required changing to babel's eslint parser to handle the async
functions in the generator tests.