### PR TITLE
Changing port back to 3010

### DIFF
--- a/packages/react-server-website/.reactserverrc
+++ b/packages/react-server-website/.reactserverrc
@@ -12,8 +12,7 @@
     "production": {
        "jsUrl": "/assets/",
        "logLevel": "error",
-       "minify": true,
-       "port": "80"
+       "minify": true
     }
   }
 }


### PR DESCRIPTION
We were previously running the service on port 3010. We either needed to update the container and compose files or just change it back. We opted for changing it back.