### PR TITLE
Adding React Server Website port information

### DIFF
--- a/docs/testing-ports.md
+++ b/docs/testing-ports.md
@@ -8,3 +8,6 @@ to update this manifest when adding a test that starts a server.
 
 ## react-server-integration-test
 8771, 8772
+
+## react-server-website
+3010, 3011


### PR DESCRIPTION
Updating the port testing manifest to include the React Server Website ports per [this comment](https://github.com/redfin/react-server/pull/497#issuecomment-237400843).