### PR TITLE
Redirecting requests to www.react-server.io to react-server.io

### DIFF
--- a/packages/react-server-website/nginx.conf
+++ b/packages/react-server-website/nginx.conf
@@ -1,11 +1,17 @@
 proxy_cache_path /tmp/nginx levels=1:2 keys_zone=react_server_zone:10m inactive=60m;
 
-# Redirect requests to port 80 to HTTPS.
 server {
     listen 80 default_server;
     server_name react-server.io;
 
     return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443;
+    server_name *.react-server.io;
+
+    return 301 https://react-server.io$request_uri;
 }
 
 server {

--- a/packages/react-server-website/nginx.conf
+++ b/packages/react-server-website/nginx.conf
@@ -1,6 +1,10 @@
 proxy_cache_path /tmp/nginx levels=1:2 keys_zone=react_server_zone:10m inactive=60m;
 
+##############################################################################
+# Redirects
+##############################################################################
 server {
+    # Redirect requests to port 80 to HTTPS.
     listen 80 default_server;
     server_name react-server.io;
 
@@ -8,12 +12,18 @@ server {
 }
 
 server {
+    # Redirect requests to https://*.react-server.io to
+    # https://react-server.io, except slack.react-server.io, which is handled
+    # separately below.
     listen 443;
     server_name *.react-server.io;
 
     return 301 https://react-server.io$request_uri;
 }
 
+##############################################################################
+# react-server.io
+##############################################################################
 server {
     listen 443 default_server;
     server_name react-server.io;
@@ -32,8 +42,11 @@ server {
     }
 }
 
-# Redirect requests to port 80 to HTTPS.
+##############################################################################
+# slack.react-server.io
+##############################################################################
 server {
+    # Redirect requests to port 80 to HTTPS.
     listen 80;
     server_name slack.react-server.io;
 
@@ -49,6 +62,9 @@ server {
     }
 }
 
+##############################################################################
+# Upstream services
+##############################################################################
 upstream docs {
     server react-server-docs:3010;
 }


### PR DESCRIPTION
Additionally, I added some comments to the NGINX configuration to help organize it.

The PR diff isn't too clear. The commit that changes NGINX behavior is 	9d3d5ec.