### PR TITLE
Making development compose file more similar to production

### DIFF
--- a/packages/react-server-website/README.md
+++ b/packages/react-server-website/README.md
@@ -16,3 +16,9 @@ $ npm start
 ```
 
 Then visit http://localhost:3010.
+
+## Running with Docker Compose
+
+See [Running with Docker Compose](running-with-docker-compose.md) to
+learn how to run the full fleet of services locally in a way that is
+similar to production.

--- a/packages/react-server-website/docker-compose.yml
+++ b/packages/react-server-website/docker-compose.yml
@@ -1,3 +1,9 @@
+# This Docker Compose file enables launching the constellation of
+# services in a way that is very similar to how we deploy this in
+# production.
+#
+# See running-with-docker-compose.md for details.
+
 version: '2'
 services:
   docs:

--- a/packages/react-server-website/docker-compose.yml
+++ b/packages/react-server-website/docker-compose.yml
@@ -1,18 +1,27 @@
 version: '2'
 services:
-  node:
+  docs:
     build:
       context: .
       dockerfile: Dockerfile
+  slackin:
+    image: davidalber/slackin
+    environment:
+     - SLACK_COC=https://github.com/redfin/react-server/blob/master/CODE_OF_CONDUCT.md
+     - SLACK_SUBDOMAIN=react-server
+     - SLACK_API_TOKEN
   nginx:
     image: nginx:1.10.1
     depends_on:
-     - node
+     - docs
+     - slackin
     links:
-     - node:react-server-docs
+     - docs:react-server-docs
+     - slackin:slackin
     ports:
      - "8080:80"
+     - "8443:443"
     volumes_from:
-     - node:ro
+     - docs:ro
     volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro

--- a/packages/react-server-website/running-with-docker-compose.md
+++ b/packages/react-server-website/running-with-docker-compose.md
@@ -1,0 +1,64 @@
+# Introduction
+The Docker Compose file in this directory enables launching the
+constellation of services in a way that is very similar to how we
+deploy in production.
+
+# Usage
+There are a few tricky points in order to use this.
+
+## Making Slackin Work
+First, if you do not have a valid token in the `SLACK_API_TOKEN`
+environment variable when bringing up the services the slackin service
+will exit quickly. When NGINX tries to start it will fail because the
+link to the slackin service will not work. This will, in turn, cause
+NGINX to fail to start, and then you won't have anything useful
+running.
+
+Solution: follow the instructions on getting a Slack API key at
+https://github.com/rauchg/slackin. You may not end up with an
+administrator token, which Slackin needs to work properly, but the
+service will still run.
+
+## Using the Development Slackin
+Once you get the services running, you won't be able to use the local
+Slackin service unless you update your /etc/hosts file to have
+"slack.react-server.io" on the 127.0.0.1 line.
+
+You don't need to do this unless you are trying to test the Slackin service
+locally.
+
+## Launching
+Once you have worked out the details above you can launch the services
+with Docker Compose. You will need Docker Engine and Docker Compose
+installed on your machine for this to work.
+
+Steps:
+
+1. Build the reactserver/react-server Docker image if it is not up to
+date. Note: I usually do this in a clean repository. From the root of
+the repository do: `docker build -t reactserver/react-server .`
+1. Launch the services using the docker-compose.yml file. From inside
+of this directory do: `SLACK_API_TOKEN=YOUR_SLACK_TOKEN docker-compose
+up --build -d`.
+
+Now you can navigate to
+[http://localhost:8443](http://localhost:8443). Going to port 8443 is
+important. If you go to port 8080 NGINX will redirect you to
+https://react-server.io, and then you won't be looking at your
+development service. You could avoid this if you put react-server.io
+on the 127.0.0.1 line of your /etc/hosts.
+
+## Iterating
+A pitfall to avoid when iterating is the docs service volume
+persisting. If the volume is not removed, the JS and CSS assets served
+by NGINX will not update when you launch an updated version of the
+docs service.
+
+When removing a container, Docker only removes associated anonymous
+volumes when explicitly asked. You want to explicitly ask.
+
+Here is your workflow if you are modifying the docs service:
+```
+docker-compose stop docs && docker-compose rm -vf docs
+SLACK_API_TOKEN=YOUR_SLACK_TOKEN docker-compose up --build -d
+```


### PR DESCRIPTION
_This is an improved version of #493._

- Makes it possible to use the Docker Compose file in development again.
- Documents how to launch the services locally using Docker Compose.