### PR TITLE
add body-parser middleware for express

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -17,6 +17,7 @@
     "babel-core": "^6.10.4",
     "babel-loader": "~6.2.2",
     "babel-runtime": "^6.3.19",
+    "body-parser": "^1.15.2",
     "chunk-manifest-webpack-plugin": "0.0.1",
     "compression": "~1.6.2",
     "css-loader": "~0.15.4",

--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -3,6 +3,7 @@ import https from "https"
 import express from "express"
 import pem from "pem"
 import compression from "compression"
+import bodyParser from "body-parser"
 import WebpackDevServer from "webpack-dev-server"
 import compileClient from "../compileClient"
 import handleCompilationErrors from "../handleCompilationErrors";
@@ -83,6 +84,8 @@ const startHtmlServer = (serverRoutes, port, httpsOptions) => {
 			logger.info("Starting HTML server...");
 
 			server.use(compression());
+			server.use(bodyParser.urlencoded({ extended: false }))
+			server.use(bodyParser.json())
 			reactServer.middleware(server, require(serverRoutes));
 
 			httpServer.on('error', (e) => {


### PR DESCRIPTION
Adds the body-parser middleware to make POST requests to `react-server`.