### PR TITLE
Removing the old container and volume during deployment

### DIFF
--- a/packages/react-server-website/deployment/deploy.yml
+++ b/packages/react-server-website/deployment/deploy.yml
@@ -12,15 +12,15 @@
       copy: src=../nginx.conf dest=/home/ubuntu/nginx.conf mode=0644
 
     - name: Pull images
-      shell: docker-compose pull
+      command: docker-compose pull
       become: true
 
     - name: Stop services
-      shell: docker-compose stop
+      command: docker-compose stop
       become: true
 
     - name: Remove docs container and volume
-      shell: docker-compose rm -vf docs
+      command: docker-compose rm -vf docs
       become: true
 
     - name: Restart services

--- a/packages/react-server-website/deployment/deploy.yml
+++ b/packages/react-server-website/deployment/deploy.yml
@@ -11,10 +11,18 @@
     - name: Copy NGINX configuration
       copy: src=../nginx.conf dest=/home/ubuntu/nginx.conf mode=0644
 
-    - name: Pull containers
-      shell: docker-compose pull && docker-compose build
+    - name: Pull images
+      shell: docker-compose pull
+      become: true
+
+    - name: Stop services
+      shell: docker-compose stop
+      become: true
+
+    - name: Remove docs container and volume
+      shell: docker-compose rm -vf docs
       become: true
 
     - name: Restart services
-      shell: docker-compose stop && SLACK_API_TOKEN=`cat slack-api-token | tr -d '\n'` docker-compose up -d
+      shell: SLACK_API_TOKEN=`cat slack-api-token | tr -d '\n'` docker-compose up -d
       become: true


### PR DESCRIPTION
- Removing the old docs service container and volume during deployment. This fixes #511.
- Using Ansible's `command` module, instead of `shell`, when possible.