### PR TITLE
Eliminate a frameback navigation initialization race

### DIFF
--- a/packages/react-server/core/FramebackController.js
+++ b/packages/react-server/core/FramebackController.js
@@ -289,12 +289,15 @@ class FramebackController extends EventEmitter {
 		// If the frame has a client controller we'll listen to when
 		// _it_ tells us it's done loading.
 		//
+		if (clientController && !clientController.__parentIsListening) {
+			clientController.__parentIsListening = true;
+			clientController.context.onLoadComplete(this._handleFrameLoad.bind(this, frame));
+		}
+
 		// It may have finished _before_ we get here, so we'll also check
 		// whether it has already set its `_previouslyRendered` flag.
 		//
-		if (clientController && !clientController.__parentIsListening && !clientController._previouslyRendered) {
-			clientController.__parentIsListening = true;
-			clientController.context.onLoadComplete(this._handleFrameLoad.bind(this, frame));
+		if (clientController && !clientController._previouslyRendered) {
 			return;
 		}
 


### PR DESCRIPTION
During the first frameback navigation forward with `reuseFrame` set, if the
client controller within the frame completes before the frame's load event
fires we were previously failing to wire up our listener to handle subsequent
navigations.