### PR TITLE
Remove the missing/unused command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ npm install -g generator-react-server
 # make a new react-server project in the CURRENT directory
 yo react-server
 
-# compile and run the new app
-npm run compile
+# run the new app
 npm run start
 # go to http://localhost:3000
 ```


### PR DESCRIPTION
Per the *Getting Started with React Server* steps at [https://react-server.io/](url) when I run `npm run compile`, getting the following error:

```
npm ERR! Darwin 15.6.0
npm ERR! argv "/usr/local/Cellar/node/6.3.1/bin/node" "/usr/local/bin/npm" "run" "compile"
npm ERR! node v6.3.1
npm ERR! npm  v3.10.6

npm ERR! missing script: compile
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>
```

When I proceeded with the next command, `npm run start`, site seems to be up and running.

Looks like the step `npm run compile` is not needed. Documentation at [https://react-server.io/](url) needs to be updated.