### PR TITLE
gh-pages: npm run compile does not exist

### DIFF
--- a/packages/react-server-website/components/content/HomeGetStartedSection.md
+++ b/packages/react-server-website/components/content/HomeGetStartedSection.md
@@ -12,8 +12,7 @@ npm install -g generator-react-server
 # make a new react-server project in the CURRENT directory
 yo react-server
 
-# compile and run the new app
-npm run compile
+# run the new app
 npm run start
 
 # go to http://localhost:3000


### PR DESCRIPTION
Looks like this was not removed after some changes