### PR TITLE
Declare chalk dependency

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "~6.2.2",
     "babel-runtime": "^6.3.19",
     "body-parser": "^1.15.2",
+    "chalk": "^1.1.3",
     "chunk-manifest-webpack-plugin": "0.0.1",
     "compression": "~1.6.2",
     "css-loader": "~0.15.4",


### PR DESCRIPTION
There's an [undeclared dependency on chalk](https://github.com/redfin/react-server/blob/c3533db335279b4c4ace585fb1bfdd6745afd7fa/packages/react-server-cli/src/run.js#L2) in react-server-cli.  Add it to package.json.