### PR TITLE
Force Linguist to exclude `.md` and `.py` files from our stats.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+*.py linguist-vendored
+*.md linguist-documentation


### PR DESCRIPTION
After changes, here's what Linguist spits out locally:

```
48.06%  JavaScript  
44.40%  CSS  
5.33%   Nginx  
2.22%   Shell
```