### PR TITLE
Upgrade to lerna-2.0.0-beta.25

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.24",
+  "lerna": "2.0.0-beta.25",
   "version": "0.4.2",
   "changelog": {
     "repo": "redfin/react-server",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jasmine": "2.3.1",
     "jsdom": "9.4.2",
     "jsx-loader": "0.12.2",
-    "lerna": "2.0.0-beta.24",
+    "lerna": "2.0.0-beta.25",
     "lerna-changelog": "^0.2.0",
     "minimist": "1.1.0",
     "mkdirp": "^0.5.1",

--- a/packages/react-server-test-pages/cli.js
+++ b/packages/react-server-test-pages/cli.js
@@ -1,5 +1,0 @@
-require("babel-core/register");
-
-const cli = require("react-server-cli");
-
-cli.run(cli.parseCliArgs());

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -6,9 +6,9 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "gulp build",
-    "start": "node ./cli.js start",
+    "start": "react-server start",
     "test": "gulp test",
-    "debug": "node-debug --debug-brk=0 -p 9000 ./cli.js start",
+    "debug": "node-debug --debug-brk=0 -p 9000 react-server start",
     "clean": "rimraf npm-debug.log* __clientTemp target"
   },
   "author": "Bo Borgerson",

--- a/packages/react-server-website/cli.js
+++ b/packages/react-server-website/cli.js
@@ -1,5 +1,0 @@
-require("babel-core/register");
-
-const cli = require("react-server-cli");
-
-cli.run(cli.parseCliArgs());

--- a/packages/react-server-website/package.json
+++ b/packages/react-server-website/package.json
@@ -5,9 +5,9 @@
   "main": "HelloWorld.js",
   "private": true,
   "scripts": {
-    "build-assets": "npm run docs && NODE_ENV=production node ./cli.js compile",
-    "start-prod": "NODE_ENV=production node ./cli.js start",
-    "start": "node ./cli.js start",
+    "build-assets": "npm run docs && NODE_ENV=production react-server compile",
+    "start-prod": "NODE_ENV=production react-server start",
+    "start": "react-server start",
     "test": "eslint routes.js gulpfile.js pages/ components/ && nsp check",
     "docs": "docco -o docs ./components/*.js ./lib/*.js ./middleware/*.js ./pages/*.js *.js && node build-dir-contents.js"
   },


### PR DESCRIPTION
This picks up https://github.com/lerna/lerna/pull/192 which lets us simplify our use of the CLI within the repo.