### PR TITLE
Don't require CLI users to install webpack locally

### DIFF
--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -15,13 +15,6 @@ const DEPENDENCIES = [
 	"react-dom@~0.14.2",
 ]
 
-const DEV_DEPENDENCIES = [
-
-	// TODO: These, too.
-	"webpack-dev-server@~1.13.0",
-	"webpack@^1.13.1",
-]
-
 const CONFIG = {
 	"routes.json": {
 		middleware: [],
@@ -59,8 +52,6 @@ export default function init(){
 	spawnSync("npm", ["install", "--save", ...DEPENDENCIES], {stdio: "inherit"});
 
 	console.log(chalk.yellow("Installing devDependencies"));
-
-	spawnSync("npm", ["install", "--save-dev", ...DEV_DEPENDENCIES], {stdio: "inherit"});
 
 	_.forEach(CONFIG, (config, fn) => {
 		console.log(chalk.yellow("Generating " + fn));

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -47,7 +47,10 @@ export default (opts = {}) => {
 
 	// for each route, let's create an entrypoint file that includes the page file and the routes file
 	let bootstrapFile = writeClientBootstrapFile(workingDirAbsolute, opts);
-	const entrypointBase = hot ? [`webpack-dev-server/client?${outputUrl}`,"webpack/hot/only-dev-server"] : [];
+	const entrypointBase = hot ? [
+		require.resolve("webpack-dev-server/client") + "?" + outputUrl,
+		require.resolve("webpack/hot/only-dev-server"),
+	] : [];
 	let entrypoints = {};
 	for (let routeName of Object.keys(routes.routes)) {
 		let route = routes.routes[routeName];


### PR DESCRIPTION
We already have everything we need as deps of `react-server-cli`.

Don't make _users_ of the CLI _also_ install that stuff.