### PR TITLE
Updating .dockerignore and changing Slack interval

### DIFF
--- a/packages/react-server-website/.dockerignore
+++ b/packages/react-server-website/.dockerignore
@@ -1,2 +1,3 @@
+**/docker-compose.yml
 node_modules
-provisioning
+deployment

--- a/packages/react-server-website/deployment/docker-compose.yml
+++ b/packages/react-server-website/deployment/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
      - SLACK_COC=https://github.com/redfin/react-server/blob/master/CODE_OF_CONDUCT.md
      - SLACK_SUBDOMAIN=react-server
+     - SLACK_INTERVAL=30000
      - SLACK_API_TOKEN
   nginx:
     image: nginx:1.10.1

--- a/packages/react-server-website/docker-compose.yml
+++ b/packages/react-server-website/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
      - SLACK_COC=https://github.com/redfin/react-server/blob/master/CODE_OF_CONDUCT.md
      - SLACK_SUBDOMAIN=react-server
+     - SLACK_INTERVAL=30000
      - SLACK_API_TOKEN
   nginx:
     image: nginx:1.10.1


### PR DESCRIPTION
- Updating .dockerignore with deployment directory and ignoring docker-compose.yml files.
- Increasing Slack fetch interval from five seconds to thirty seconds.