### PR TITLE
Updated bike-share example

### DIFF
--- a/packages/react-server-examples/bike-share/components/network-card.js
+++ b/packages/react-server-examples/bike-share/components/network-card.js
@@ -11,7 +11,7 @@ const NetworkCard = ({id, name, location, company}) => {
 };
 
 NetworkCard.propTypes = {
-	company: React.PropTypes.string,
+	company: React.PropTypes.any,
 	href: React.PropTypes.string,
 	id: React.PropTypes.string,
 	location: React.PropTypes.shape({

--- a/packages/react-server-examples/bike-share/package.json
+++ b/packages/react-server-examples/bike-share/package.json
@@ -7,7 +7,7 @@
   "author": "Doug Wade <doug.wade@redfin.com>",
   "scripts": {
     "clean": "rm -rf build __clientTemp",
-    "start": "npm run clean && npm run styles && react-server",
+    "start": "npm run clean && npm run styles && react-server start",
     "styles": "node-sass styles/index.scss build/styles/index.css && node-sass styles/network.scss build/styles/network.css",
     "test": "xo && nsp check"
   },
@@ -16,8 +16,8 @@
     "babel-runtime": "^6.6.1",
     "react": "~0.14.2",
     "react-dom": "~0.14.2",
-    "react-server": "^0.3.3",
-    "react-server-cli": "^0.3.3",
+    "react-server": "^0.4.2",
+    "react-server-cli": "^0.4.2",
     "superagent": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* Fixed bike-share example's npm start command. Gave react-server a start command.
* Changed NetworkCards propType validator for company as API returns various types for this value.
* Updated version of react-server & react-server-cli to v0.4.2.