### PR TITLE
Using reactserver organization's Slackin image

### DIFF
--- a/packages/react-server-website/deployment/docker-compose.yml
+++ b/packages/react-server-website/deployment/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   docs:
     image: reactserver/react-server-website
   slackin:
-    image: davidalber/slackin
+    image: reactserver/react-server-website-slackin
     environment:
      - SLACK_COC=https://github.com/redfin/react-server/blob/master/CODE_OF_CONDUCT.md
      - SLACK_SUBDOMAIN=react-server

--- a/packages/react-server-website/docker-compose.yml
+++ b/packages/react-server-website/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       context: .
       dockerfile: Dockerfile
   slackin:
-    image: davidalber/slackin
+    image: reactserver/react-server-website-slackin
     environment:
      - SLACK_COC=https://github.com/redfin/react-server/blob/master/CODE_OF_CONDUCT.md
      - SLACK_SUBDOMAIN=react-server


### PR DESCRIPTION
- Created a [react-server-website-slackin repository in Docker Hub](https://hub.docker.com/r/reactserver/react-server-website-slackin/) (independent of this PR).
- Changed our Docker Compose files to use the image from that repository, which fixes #498.