### PR TITLE
lint react-server-module-tagger

### DIFF
--- a/packages/react-server-module-tagger/package.json
+++ b/packages/react-server-module-tagger/package.json
@@ -4,6 +4,7 @@
   "description": "calculates module level config",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint *.js",
     "test": "ava test.js",
     "clean": "del npm-debug.log*"
   },

--- a/packages/react-server-module-tagger/test.js
+++ b/packages/react-server-module-tagger/test.js
@@ -2,31 +2,31 @@ import test from 'ava';
 import loggerSpec from '.';
 
 test('creates a module tag', t => {
-  const expected = '{\"name\":\"foo.bar\",\"color\":{\"server\":73,\"client\":\"rgb(42,127,127)\"}}';
+	const expected = '{\"name\":\"foo.bar\",\"color\":{\"server\":73,\"client\":\"rgb(42,127,127)\"}}';
 
-  const file = 'foo/bar';
-  const config = {};
-  const actual = loggerSpec.bind({file, config})(file);
+	const file = 'foo/bar';
+	const config = {};
+	const actual = loggerSpec.bind({file, config})(file);
 
-  t.is(expected, actual);
+	t.is(expected, actual);
 });
 
 test('trims prefix from module tag name', t => {
-  const expected = '{\"name\":\"quux\",\"color\":{\"server\":229,\"client\":\"rgb(212,212,127)\"}}';
+	const expected = '{\"name\":\"quux\",\"color\":{\"server\":229,\"client\":\"rgb(212,212,127)\"}}';
 
-  const file = 'baz/quux';
-  const config = { trim: 'baz.' };
-  const actual = loggerSpec.bind({file, config})(file);
+	const file = 'baz/quux';
+	const config = { trim: 'baz.' };
+	const actual = loggerSpec.bind({file, config})(file);
 
-  t.is(expected, actual);
+	t.is(expected, actual);
 });
 
 test('adds labels', t => {
-  const expected = '{\"label\":\"foo\",\"name\":\"has.label.foo\",\"color\":{\"server\":131,\"client\":\"rgb(127,42,42)\"}}';
+	const expected = '{\"label\":\"foo\",\"name\":\"has.label.foo\",\"color\":{\"server\":131,\"client\":\"rgb(127,42,42)\"}}';
 
-  const file = 'has/label';
-  const config = {};
-  const actual = loggerSpec.bind({file, config})(file, '({label: "foo"})');
+	const file = 'has/label';
+	const config = {};
+	const actual = loggerSpec.bind({file, config})(file, '({label: "foo"})');
 
-  t.is(expected, actual);
+	t.is(expected, actual);
 });


### PR DESCRIPTION
Prepare for #314, and unify style by linting react-server-module-tagger.