### PR TITLE
#314 Pass parameters to module tagger explicitly, rather than in function context

### DIFF
--- a/packages/babel-plugin-react-server/src/index.js
+++ b/packages/babel-plugin-react-server/src/index.js
@@ -8,13 +8,12 @@ module.exports = function() {
 				const {node} = p;
 				const {name} = node;
 
-				const config = { trim: state.opts.trim };
+				const trim = state.opts.trim;
 				const parent = path.resolve(path.join(process.cwd(), '..')) + path.sep;
-				const fp = this.file.opts.filename.replace(parent, '');
-				const file =  { path: fp };
+				const filePath = this.file.opts.filename.replace(parent, '');
 
 				//TODO: Support labels
-				const moduleTag = loggerSpec.bind({ file, config })(fp);
+				const moduleTag = loggerSpec({ filePath, trim });
 
 				let tokens;
 				if (state.opts.tokens) {

--- a/packages/react-server-gulp-module-tagger/index.js
+++ b/packages/react-server-gulp-module-tagger/index.js
@@ -15,6 +15,12 @@ module.exports = function(config) {
 	config || (config = {});
 	config.basePath = module.filename.replace(THIS_MODULE,'');
 	return forEach(function(stream, file){
-		return stream.pipe(replace(REPLACE_TOKEN, loggerSpec.bind({file, config})));
+		return stream.pipe(replace(REPLACE_TOKEN, (match, optString) => {
+			return loggerSpec({
+				filePath: file.path,
+				basePath: config.basePath,
+				trim: config.trim, optString,
+			});
+		}));
 	});
 }

--- a/packages/react-server-module-tagger/README.md
+++ b/packages/react-server-module-tagger/README.md
@@ -10,14 +10,13 @@ To transpile your source for use with
 npm i -D gulp react-server-module-tagger
 ```
 
-Then require and call the function.  The tagger expects to have config and file
-data on its prototype, so use `.bind`.
+Then require and call the function.
 
 ```javascript
 const tagger = require('react-server-module-tagger');
-const filepath = 'path/to/my/output.js';
+const filePath = 'path/to/my/output.js';
 const optString = '({label:"foo"})'
-const moduleTag = tagger.bind({ file: { path: filepath }, config: { trim: 'path/to'} })(filepath, optString));
+const moduleTag = tagger({ filePath, trim: 'path/to', optString });
 ```
 
 returns a logger instance that will have consistent coloring on the server and

--- a/packages/react-server-module-tagger/index.js
+++ b/packages/react-server-module-tagger/index.js
@@ -1,27 +1,19 @@
 var isWindows = ('win32' === process.platform);
 
 /**
- * A util function for tagging modules.  Expects to find data on its prototype
- * as follows
- *     {
- *         file: {
- *             path: the path to the file to tag
- *         }
- *         config: {
- *             trim: the string to trim off the front of the logger name
- *         }
- *     }
+ * A util function for tagging modules.
  * @example
- *     const file = '/path/to/my/file.js';
- *     loggerSpec.bind({file, { trim: 'path.to.' }})(file, '({label: "foo"})')
+ *     tagger({filePath: '/path/to/my/file.js', trim: 'path.to.', optString: '({label: "foo"})')
  *     // returns '{\"label\":\"foo\",\"name\":\"my.file\",\"color\":{\"server\":87,\"client\":\"rgb(42,212,212)\"}}'
- * @param  {String} fullMatch May also be provided as this.file.path, the path to the file
+ * @param  {String} filePath  The path to the file
  * @param  {String} optString The label to add to the module tag, in the form '({label:"$label"})'
+ * @param  {String} trim      The prefix to remove from the logger name
+ * @param  {String} basePath  The path to the root of the project
  * @return {String}           A json object containing a module identifier
  */
 module.exports = function(arg){
 	var optString = arg.optString
-	,   fn   = arg.filePath ? arg.filePath : arg.fullMatch
+	,   fn   = arg.filePath
 	,   trim = arg.trim || ''
 	,   basePath = arg.basePath || ''
 	,   opts = {}

--- a/packages/react-server-module-tagger/index.js
+++ b/packages/react-server-module-tagger/index.js
@@ -19,10 +19,11 @@ var isWindows = ('win32' === process.platform);
  * @param  {String} optString The label to add to the module tag, in the form '({label:"$label"})'
  * @return {String}           A json object containing a module identifier
  */
-module.exports = function(fullMatch, optString){
-	var fn   = this.file && this.file.path ? this.file.path : fullMatch
-	,   trim = this.config.trim || ''
-	,   basePath = this.config.basePath || ''
+module.exports = function(arg){
+	var optString = arg.optString
+	,   fn   = arg.filePath ? arg.filePath : arg.fullMatch
+	,   trim = arg.trim || ''
+	,   basePath = arg.basePath || ''
 	,   opts = {}
 
 	if (fn.indexOf(basePath) !== 0) {

--- a/packages/react-server-module-tagger/test.js
+++ b/packages/react-server-module-tagger/test.js
@@ -4,9 +4,8 @@ import loggerSpec from '.';
 test('creates a module tag', t => {
 	const expected = '{\"name\":\"foo.bar\",\"color\":{\"server\":73,\"client\":\"rgb(42,127,127)\"}}';
 
-	const file = 'foo/bar';
-	const config = {};
-	const actual = loggerSpec.bind({file, config})(file);
+	const filePath = 'foo/bar';
+	const actual = loggerSpec({filePath});
 
 	t.is(expected, actual);
 });
@@ -14,9 +13,9 @@ test('creates a module tag', t => {
 test('trims prefix from module tag name', t => {
 	const expected = '{\"name\":\"quux\",\"color\":{\"server\":229,\"client\":\"rgb(212,212,127)\"}}';
 
-	const file = 'baz/quux';
-	const config = { trim: 'baz.' };
-	const actual = loggerSpec.bind({file, config})(file);
+	const filePath = 'baz/quux';
+	const trim = 'baz.';
+	const actual = loggerSpec({filePath, trim});
 
 	t.is(expected, actual);
 });
@@ -24,9 +23,9 @@ test('trims prefix from module tag name', t => {
 test('adds labels', t => {
 	const expected = '{\"label\":\"foo\",\"name\":\"has.label.foo\",\"color\":{\"server\":131,\"client\":\"rgb(127,42,42)\"}}';
 
-	const file = 'has/label';
-	const config = {};
-	const actual = loggerSpec.bind({file, config})(file, '({label: "foo"})');
+	const filePath = 'has/label';
+	const optString = '({label: "foo"})';
+	const actual = loggerSpec({filePath, optString});
 
 	t.is(expected, actual);
 });


### PR DESCRIPTION
Smooth out the rough edges of the module tagger interface