### PR TITLE
Fix #12 Support configurable tokens for the gulp module tagger

### DIFF
--- a/packages/react-server-gulp-module-tagger/index.js
+++ b/packages/react-server-gulp-module-tagger/index.js
@@ -6,13 +6,19 @@ var replace = require("gulp-replace")
 //   - "__LOGGER__"
 //   - "__LOGGER__({ /* options */ })"
 var isWindows = ('win32' === process.platform)
-,   REPLACE_TOKEN = /(?:__LOGGER__|__CHANNEL__|__CACHE__)(?:\(\s*(\{[\s\S]*?\})\s*\))?/g
+,   DEFAULT_REPLACE_TOKEN = tokenToRegExp("__LOGGER__|__CHANNEL__|__CACHE__")
 ,   THIS_MODULE   = isWindows
 	? /(?:[^\\]+\\node_modules\\)?react-server-gulp-module-tagger\\index\.js$/
 	: /(?:[^\/]+\/node_modules\/)?react-server-gulp-module-tagger\/index\.js$/
 
 module.exports = function(config) {
 	config || (config = {});
+	var REPLACE_TOKEN;
+	if (config.token) {
+		REPLACE_TOKEN = tokenToRegExp(config.token);
+	} else {
+		REPLACE_TOKEN = DEFAULT_REPLACE_TOKEN;
+	}
 	config.basePath = module.filename.replace(THIS_MODULE,'');
 	return forEach(function(stream, file){
 		return stream.pipe(replace(REPLACE_TOKEN, (match, optString) => {
@@ -23,4 +29,8 @@ module.exports = function(config) {
 			});
 		}));
 	});
+}
+
+function tokenToRegExp(token) {
+	return new RegExp("(?:" + token + ")(?:\\(\\s*(\\{[\\s\\S]*?\\})\\s*\\))?", 'g');
 }

--- a/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/actual.js
+++ b/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/actual.js
@@ -1,0 +1,3 @@
+var logger = require('react-server').logging.getLogger(__OZZIE_ALONSO__);
+var fooLogger = logging.getLogger(__OZZIE_ALONSO__({ label: "foo" }));
+var barLogger = logging.getLogger(__OZZIE_ALONSO__({ label: "bar" }));

--- a/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/expected.js
+++ b/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/expected.js
@@ -1,3 +1,3 @@
 var logger = require('react-server').logging.getLogger({"name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual","color":{"server":219,"client":"rgb(212,127,212)"}});
-var fooLogger = logging.getLogger({"label":"foo","name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual.foo","color":{"server":219,"client":"rgb(212,127,212)"}});
-var barLogger = logging.getLogger({"label":"bar","name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual.bar","color":{"server":219,"client":"rgb(212,127,212)"}});
+var fooLogger = logging.getLogger({"label":"foo","name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual.foo","color":{"server":83,"client":"rgb(42,212,42)"}});
+var barLogger = logging.getLogger({"label":"bar","name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual.bar","color":{"server":71,"client":"rgb(42,127,42)"}});

--- a/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/expected.js
+++ b/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/expected.js
@@ -1,0 +1,3 @@
+var logger = require('react-server').logging.getLogger({"name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual","color":{"server":219,"client":"rgb(212,127,212)"}});
+var fooLogger = logging.getLogger({"label":"foo","name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual.foo","color":{"server":219,"client":"rgb(212,127,212)"}});
+var barLogger = logging.getLogger({"label":"bar","name":"react-server-gulp-module-tagger.test.fixtures.custom-token.actual.bar","color":{"server":219,"client":"rgb(212,127,212)"}});

--- a/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/gulpfile.js
+++ b/packages/react-server-gulp-module-tagger/test/fixtures/custom-token/gulpfile.js
@@ -1,0 +1,10 @@
+const gulp = require('gulp');
+const tagger = require('../../..');
+
+gulp.task('default', () => {
+	gulp.src('actual.js')
+		.pipe(tagger({
+			token: "__OZZIE_ALONSO__",
+		}))
+		.pipe(gulp.dest('build'));
+});


### PR DESCRIPTION
Support configurable tokens for the gulp module tagger.  Fixes #12 