### PR TITLE
Add .sass support

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -164,7 +164,7 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 					exclude: /node_modules/,
 				},
 				{
-					test: /\.scss$/,
+					test: /\.s(a|c)ss$/,
 					loader: extractTextLoader + "!sass-loader",
 					exclude: /node_modules/,
 				},

--- a/packages/react-server-cli/src/index.js
+++ b/packages/react-server-cli/src/index.js
@@ -5,6 +5,7 @@ const parseCliArgs = require("./parseCliArgs").default;
 require.extensions['.css'] =
 require.extensions['.less'] =
 require.extensions['.scss'] =
+require.extensions['.sass'] =
 function(module, filename) {
 	return module._compile("", filename);
 };

--- a/packages/react-server-test-pages/pages/styles/sass.js
+++ b/packages/react-server-test-pages/pages/styles/sass.js
@@ -1,9 +1,14 @@
 import "./sass.scss"
+import "./sass.sass"
 
 const RedThing = () => <div className="red-thing">This should be red</div>
+const BlueThing = () => <div className="blue-thing">This should be blue</div>
 
 export default class SassPage {
 	getElements() {
-		return <RedThing />
+		return (<div>
+			<RedThing />
+			<BlueThing />
+		</div>);
 	}
 }

--- a/packages/react-server-test-pages/pages/styles/sass.sass
+++ b/packages/react-server-test-pages/pages/styles/sass.sass
@@ -1,0 +1,4 @@
+$blueish: blue
+
+.blue-thing
+	background-color: $blueish


### PR DESCRIPTION
This adds real .sass support, not just the .scss support.
We don't need to add `indentedSyntax` to the sass loader parameters since the sass loader
doesn't require it anymore (https://github.com/jtangelder/sass-loader/pull/196)