### PR TITLE
Better module lookup during client compilation

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -29,6 +29,7 @@
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "lodash": "^4.14.1",
+    "look-up": "^0.8.3",
     "mkdirp": "~0.5.1",
     "node-libs-browser": "~0.5.2",
     "node-sass": "^3.8.0",

--- a/packages/react-server-cli/src/callerDependency.js
+++ b/packages/react-server-cli/src/callerDependency.js
@@ -1,7 +1,7 @@
-import path from "path";
+import lookup from "look-up";
 
 export default function callerDependency(dep) {
 	// TODO: We should grab stuff based on what the routes file would get out
 	// of `require.resolve(dep)`.  Using `process.cwd()` instead for now.
-	return path.resolve(path.join(process.cwd(), "node_modules/" + dep));
+	return lookup("node_modules/" + dep, {cwd: process.cwd()});
 }

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -184,7 +184,7 @@ const packageCodeForBrowser = (entrypoints, outputDir, outputUrl, hot, minify, l
 		},
 		resolveLoader: {
 			root: [
-				path.resolve(path.join(__dirname, "../node_modules")),
+				path.resolve(path.join(path.dirname(require.resolve("webpack")), "../..")),
 			],
 		},
 		plugins: [


### PR DESCRIPTION
Look for webpack loaders relative to where we found webpack.

Look harder (up the tree) for client modules relative to working directory.