### PR TITLE
Fix react-server-cli module tags

### DIFF
--- a/packages/react-server-cli/gulpfile.babel.js
+++ b/packages/react-server-cli/gulpfile.babel.js
@@ -5,7 +5,7 @@ import logging from "react-server-gulp-module-tagger";
 
 gulp.task("default", () => {
 	return gulp.src("src/**/*.js")
-		.pipe(logging({trim: 'react-server/packages/'}))
+		.pipe(logging())
 		.pipe(babel())
 		.pipe(gulp.dest("target"));
 });


### PR DESCRIPTION
Previously

<img width="1435" alt="screen shot 2016-08-17 at 6 15 28 pm" src="https://cloud.githubusercontent.com/assets/3477707/17758732/c04481cc-64a6-11e6-9f71-a0c288512423.png">

Now

<img width="718" alt="screen shot 2016-08-17 at 6 16 14 pm" src="https://cloud.githubusercontent.com/assets/3477707/17758734/c475a2f8-64a6-11e6-8943-b557a7438cb5.png">

I don't dig that we're tagging the modules with their _source_ -- it seems like it would be much more elegant to tag them with their _destination_ (in this case, `react-server-cli.commands.start` instead of `react-server-cli.src.commands.start`).  I think the easiest way will be to trim the `react-server-cli.src` with the existing `trim` option, and add a `prefix` option, but there may be a more elegant way.