### PR TITLE
Restarting the Slackin container unless it is explicitly stopped

### DIFF
--- a/packages/react-server-website/deployment/docker-compose.yml
+++ b/packages/react-server-website/deployment/docker-compose.yml
@@ -9,6 +9,7 @@ services:
      - SLACK_SUBDOMAIN=react-server
      - SLACK_INTERVAL=30000
      - SLACK_API_TOKEN
+    restart: unless-stopped
   nginx:
     image: nginx:1.10.1
     depends_on:

--- a/packages/react-server-website/docker-compose.yml
+++ b/packages/react-server-website/docker-compose.yml
@@ -17,6 +17,7 @@ services:
      - SLACK_SUBDOMAIN=react-server
      - SLACK_INTERVAL=30000
      - SLACK_API_TOKEN
+    restart: unless-stopped
   nginx:
     image: nginx:1.10.1
     depends_on:


### PR DESCRIPTION
The Slackin container crashed a couple weeks ago due to an ECONNRESET, presumably while making a request to Slack. Although that hasn't happened again, I want to avoid a similar situation
and alarm. This commit instructs Docker to keep restarting the slackin service container until it is explicitly stopped.