### PR TITLE
Fire a "pageview" event from the client controller

### DIFF
--- a/packages/react-server-website/middleware/Analytics.js
+++ b/packages/react-server-website/middleware/Analytics.js
@@ -8,19 +8,22 @@ ga('create', 'UA-81160060-1', 'auto');
 ga('send', 'pageview');
 `.replace(/\s*\n\s*/g, '');
 
+let alreadyListening = 0;
+
 export default class AnalyticsMiddleware {
 
-	// This only gets called after client transitions in the browser.  It's
-	// not called for the initial page view (since the title was set by the
-	// server).
-	getTitle(next) {
-		return next().then(title => {
-			if (typeof window !== "undefined") {
-				const page = location.pathname;
-				window.ga('send', 'pageview', { page, title });
-			}
-			return title;
-		});
+	handleRoute(next) {
+
+		if (typeof window !== "undefined" && !alreadyListening++) {
+
+			// Only need to do this once, since the client controller lives
+			// across page views.
+			window.__reactServerClientController.on("pageview", pageview => {
+				window.ga('send', 'pageview', pageview);
+			});
+		}
+
+		return next();
 	}
 	getScripts(next) {
 		return next().concat({text});

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -439,6 +439,13 @@ class ClientController extends EventEmitter {
 			if (newTitle && newTitle !== document.title) {
 				document.title = newTitle;
 			}
+
+			// This is the earliest we have everything we need for
+			// an analytics pageview event.
+			this.emit("pageview", {
+				page  : getHistoryPathname(),
+				title : newTitle,
+			});
 		})
 		.catch(err => { logger.error("Error while setting the document title", err) })
 		.done();


### PR DESCRIPTION
Analytics virtual pageviews need path and page title, so fire an event with
those as soon as they're available on client transition.

Note that on frameback navigation the event will fire _in the frame_.

This closes #502.

Also updated the website's analytics middleware to use the new event.

Next step: Pull the website's analytics middleware out into a dedicated
package and make it public. :rocket: