### PR TITLE
Webpack config

### DIFF
--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -97,6 +97,25 @@ files. If there's no config file (or package.json config) in the current
 working directory, then parent directories are searched up to the root of the
 filesystem.  Options passed to the CLI take final precedence.
 
+### Webpack custom options
+
+React Server will take care of the default Webpack options so you don't need to create a webpack.config.js but if you need to customize the built in defaults for example to set up custom loaders, you can do it with a user callback function.  
+
+```javascript
+export default (webpackConfig) => {
+
+	// Insert a new sass and css loader before the default.
+  webpackConfig.module.loaders.splice(0, {
+		test: /\.s(a|c)ss$/,
+		loaders: ["style", "css", "sass", "customloader"],
+	})
+
+  return webpackConfig
+}
+```
+
+In the `.reactserverrc` file add an option for `webpack-config` that points to your file that defines the webpack function and when React Server is constructing Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed.
+
 ### Development mode: making a great DX
 
 Development mode is the default, and its goals are rapid startup and code-test

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -72,7 +72,7 @@ It looks like this:
 	"port": "5000",
 	"env": {
 		"production": {
-			"port": "80"
+			"port": "81"
 		}
 	}
 }
@@ -97,24 +97,31 @@ files. If there's no config file (or package.json config) in the current
 working directory, then parent directories are searched up to the root of the
 filesystem.  Options passed to the CLI take final precedence.
 
-### Webpack custom options
+### Webpack options
 
-React Server will take care of the default Webpack options so you don't need to create a webpack.config.js but if you need to customize the built in defaults for example to set up custom loaders, you can do it with a user callback function.  
+React Server will take care of the default Webpack options but if you need to set up custom loaders for example you can do it with a user callback function.  
 
 ```javascript
 export default (webpackConfig) => {
-
 	// Insert a new sass and css loader before the default.
-  webpackConfig.module.loaders.splice(0, {
+	webpackConfig.module.loaders.splice(0, {
 		test: /\.s(a|c)ss$/,
 		loaders: ["style", "css", "sass", "customloader"],
 	})
-
-  return webpackConfig
+	return webpackConfig
 }
 ```
 
-In the `.reactserverrc` file add an option for `webpack-config` that points to your file that defines the webpack function and when React Server is constructing Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed.
+In the `.reactserverrc` file add an option for `webpack-config` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed.
+
+
+
+There are three ways to pass options to the CLI, through the command line,
+`.reactserverrc` JSON files, or as a `reactServer` entry in `package.json`
+files. If there's no config file (or package.json config) in the current
+working directory, then parent directories are searched up to the root of the
+filesystem.  Options passed to the CLI take final precedence.
+
 
 ### Development mode: making a great DX
 

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -72,7 +72,7 @@ It looks like this:
 	"port": "5000",
 	"env": {
 		"production": {
-			"port": "81"
+			"port": "80"
 		}
 	}
 }

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -40,9 +40,9 @@ export default (opts = {}) => {
 
 	var webpackConfigFunc = (data) => { return data }
 	if (opts['webpack-config']) {
-    	const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
-    	const userWebpackConfigFunc = require(webpackDirAbsolute)
-    	webpackConfigFunc = userWebpackConfigFunc.default
+		const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
+		const userWebpackConfigFunc = require(webpackDirAbsolute)
+		webpackConfigFunc = userWebpackConfigFunc.default
 	}
 
 	const workingDirAbsolute = path.resolve(process.cwd(), workingDir);

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -38,11 +38,11 @@ export default (opts = {}) => {
 		throw new Error("Hot reload cannot be used with long-term caching. Please disable either long-term caching or hot reload.");
 	}
 
-  var webpackConfigFunc = (data) => { return data }
+  const webpackConfigFunc = (data) => { return data }
 	if (opts['webpack-config']) {
 		const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
-		var userWebpackConfigFunc = require(webpackDirAbsolute)
-        webpackConfigFunc = userWebpackConfigFunc.default
+		const userWebpackConfigFunc = require(webpackDirAbsolute)
+    webpackConfigFunc = userWebpackConfigFunc.default
 	}
 
 	const workingDirAbsolute = path.resolve(process.cwd(), workingDir);

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -40,8 +40,8 @@ export default (opts = {}) => {
 
   const webpackConfigFunc = (data) => { return data }
 	if (opts['webpack-config']) {
-		const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
-		const userWebpackConfigFunc = require(webpackDirAbsolute)
+    const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
+    const userWebpackConfigFunc = require(webpackDirAbsolute)
     webpackConfigFunc = userWebpackConfigFunc.default
 	}
 

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -76,7 +76,6 @@ export default (opts = {}) => {
 	// now rewrite the routes file out in a webpack-compatible way.
 	writeWebpackCompatibleRoutesFile(routes, routesDir, workingDirAbsolute, null, true);
 
-
 	// finally, let's pack this up with webpack.
 	const compiler = webpack(webpackConfigFunc(packageCodeForBrowser(entrypoints, outputDirAbsolute, outputUrl, hot, minify, longTermCaching, stats)));
 

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -38,11 +38,11 @@ export default (opts = {}) => {
 		throw new Error("Hot reload cannot be used with long-term caching. Please disable either long-term caching or hot reload.");
 	}
 
-  const webpackConfigFunc = (data) => { return data }
+	const webpackConfigFunc = (data) => { return data }
 	if (opts['webpack-config']) {
-    const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
-    const userWebpackConfigFunc = require(webpackDirAbsolute)
-    webpackConfigFunc = userWebpackConfigFunc.default
+    	const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
+    	const userWebpackConfigFunc = require(webpackDirAbsolute)
+    	webpackConfigFunc = userWebpackConfigFunc.default
 	}
 
 	const workingDirAbsolute = path.resolve(process.cwd(), workingDir);

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -38,7 +38,7 @@ export default (opts = {}) => {
 		throw new Error("Hot reload cannot be used with long-term caching. Please disable either long-term caching or hot reload.");
 	}
 
-	const webpackConfigFunc = (data) => { return data }
+	var webpackConfigFunc = (data) => { return data }
 	if (opts['webpack-config']) {
     	const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
     	const userWebpackConfigFunc = require(webpackDirAbsolute)

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -8,6 +8,7 @@ import crypto from "crypto"
 import StatsPlugin from "webpack-stats-plugin"
 import callerDependency from "./callerDependency"
 
+
 // commented out to please eslint, but re-add if logging is needed in this file.
 // import {logging} from "react-server"
 // const logger = logging.getLogger(__LOGGER__);
@@ -37,7 +38,7 @@ export default (opts = {}) => {
 		throw new Error("Hot reload cannot be used with long-term caching. Please disable either long-term caching or hot reload.");
 	}
 
-    var webpackConfigFunc = (data) => { return data }
+  var webpackConfigFunc = (data) => { return data }
 	if (opts['webpack-config']) {
 		const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
 		var userWebpackConfigFunc = require(webpackDirAbsolute)


### PR DESCRIPTION
To use this you need to add a **webpack-config** setting in your **.reactserverrc** which points to a file that exports a default function.
```
{
  "webpack-config": "./webpack.js"
}
```

The config file function takes a webpack config array from _packageCodeForBrowser_ and can change the data before it's passed to the webpack constructor.

```
export default (webpackConfig) => {

  webpackConfig.resolve.alias = {
  	'myapp': '/abs/project'
  }

  return webpackConfig
}
```
