### PR TITLE
Upgrade superagent to 1.8.4

### DIFF
--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -16,7 +16,7 @@
     "react-dom": "~0.14.2",
     "react-server": "^0.4.6",
     "react-server-cli": "^0.4.6",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "devDependencies": {
     "ava": "^0.15.1",

--- a/packages/react-server-cli/src/commands/init.js
+++ b/packages/react-server-cli/src/commands/init.js
@@ -10,7 +10,7 @@ const DEPENDENCIES = [
 	"babel-preset-react-server",
 
 	// TODO: Modernize our peer deps and remove versions here.
-	"superagent@1.2.0",
+	"superagent@1.8.4",
 	"react@~0.14.2",
 	"react-dom@~0.14.2",
 ]

--- a/packages/react-server-examples/bike-share/package.json
+++ b/packages/react-server-examples/bike-share/package.json
@@ -15,7 +15,7 @@
     "react-dom": "~0.14.2",
     "react-server": "^0.4.5",
     "react-server-cli": "^0.4.5",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "devDependencies": {
     "babel-preset-react-server": "^0.4.4"

--- a/packages/react-server-examples/hello-world/package.json
+++ b/packages/react-server-examples/hello-world/package.json
@@ -19,6 +19,6 @@
     "react-dom": "~0.14.2",
     "react-server": "~0.4.5",
     "react-server-cli": "~0.4.5",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   }
 }

--- a/packages/react-server-examples/redux-basic/package.json
+++ b/packages/react-server-examples/redux-basic/package.json
@@ -18,7 +18,7 @@
     "react-server": "^0.4.5",
     "react-server-cli": "^0.4.5",
     "redux": "^3.5.2",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "devDependencies": {
     "babel-preset-react-server": "^0.4.4"

--- a/packages/react-server-integration-tests/package.json
+++ b/packages/react-server-integration-tests/package.json
@@ -14,7 +14,7 @@
     "react-server": "^0.4.6",
     "react-server-cli": "^0.4.6",
     "rimraf": "^2.5.2",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "version": "0.4.6"
 }

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -21,7 +21,7 @@
     "react-server": "^0.4.6",
     "react-server-cli": "^0.4.6",
     "react-server-data-bundle-cache": "^0.4.6",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "devDependencies": {
     "node-inspector": "^0.12.8",

--- a/packages/react-server-website/package.json
+++ b/packages/react-server-website/package.json
@@ -22,7 +22,7 @@
     "react-server-cli": "^0.4.6",
     "react-server-data-bundle-cache": "^0.4.6",
     "remarkable": "^1.6.2",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "devDependencies": {
     "babel-preset-react-server": "^0.4.4",

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "react": "~0.14.2",
     "react-dom": "~0.14.2",
-    "superagent": "1.2.0"
+    "superagent": "1.8.4"
   },
   "devDependencies": {
     "react-server-gulp-module-tagger": "^0.4.5",


### PR DESCRIPTION
Pull in bug fixes from superagent, most notably the fix to [250](https://github.com/visionmedia/superagent/issues/250), which was released in [1.5.0](https://github.com/visionmedia/superagent/releases/tag/v1.5.0). I could upgrade to 2.2.0, but I'll save the major version bump for another day.