### PR TITLE
Export default options so other dependent packages can test against changing properties

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -48,6 +48,9 @@
   },
   "devDependencies": {
     "babel-preset-react-server": "^0.4.4",
+    "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
+    "gulp-eslint": "^3.0.1",
     "nsp": "^2.4.0",
     "react-server-gulp-module-tagger": "^0.4.5",
     "rimraf": "^2.5.2"

--- a/packages/react-server-cli/src/index.js
+++ b/packages/react-server-cli/src/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const run = require("./run").default;
 const parseCliArgs = require("./parseCliArgs").default;
+const defaultOptions = require("./defaultOptions").default;
 
 require.extensions['.css'] =
 require.extensions['.less'] =

--- a/packages/react-server-cli/src/index.js
+++ b/packages/react-server-cli/src/index.js
@@ -20,4 +20,5 @@ require.extensions['.md'] =
 module.exports = {
 	parseCliArgs,
 	run,
+	defaultOptions,
 };


### PR DESCRIPTION
See: https://github.com/redfin/react-server/pull/625

I also had questions around dependencies. When I tried to run gulp from react-server-cli package I was getting an error like so:

```
JASONs-Mac-Pro:react-server-cli jason$ npm run prepublish
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received null
    at assertPath (path.js:7:11)
```

What I realized was that because gulp wasn't a part of this package, it was trying to use a globally installed version I had which was out of date. I have always been under the belief that packages should force using local packages by using npm scripts. By adding gulp as a devDep, running npm run prepublish will always work.

Would love to hear your thoughts?

Thanks!