### PR TITLE
Adding http response header hook to page lifecyle

### DIFF
--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
@@ -1,0 +1,12 @@
+var Q = require("Q");
+
+class AsyncHttpHeadersPage {
+
+	getHeaders() {
+		return Q([
+			["Content-Security-Policy", "example.com"],
+		]);
+	}
+}
+
+module.exports = AsyncHttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
@@ -7,10 +7,6 @@ class AsyncHttpHeadersPage {
 			["Content-Security-Policy", "example.com"],
 		]);
 	}
-
-	getContentType() {
-		return "application/example";
-	}
 }
 
 module.exports = AsyncHttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
@@ -7,6 +7,10 @@ class AsyncHttpHeadersPage {
 			["Content-Security-Policy", "example.com"],
 		]);
 	}
+
+	getContentType() {
+		return Q("application/example");
+	}
 }
 
 module.exports = AsyncHttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
@@ -9,7 +9,7 @@ class AsyncHttpHeadersPage {
 	}
 
 	getContentType() {
-		return Q("application/example");
+		return "application/example";
 	}
 }
 

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/AsyncHttpHeadersPage.js
@@ -1,4 +1,4 @@
-var Q = require("Q");
+var Q = require("q");
 
 class AsyncHttpHeadersPage {
 

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
@@ -5,10 +5,6 @@ class HttpHeadersPage {
 			["Content-Security-Policy", "example.com"],
 		];
 	}
-
-	getContentType() {
-		return "application/example";
-	}
 }
 
 module.exports = HttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
@@ -1,0 +1,10 @@
+class HttpHeadersPage {
+
+	getHeaders() {
+		return [
+			["Content-Security-Policy", "example.com"],
+		];
+	}
+}
+
+module.exports = HttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
@@ -5,6 +5,10 @@ class HttpHeadersPage {
 			["Content-Security-Policy", "example.com"],
 		];
 	}
+
+	getContentType() {
+		return "application/example";
+	}
 }
 
 module.exports = HttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
@@ -9,7 +9,7 @@ describe('A page with custom http headers', () => {
 
 	helper.stopServerAfterAll();
 
-	fdescribe('has sync rendered headers', () => {
+	describe('has sync rendered headers', () => {
 		helper.testWithBrowser('/httpHeaders', (browser, isTransition) => {
 			expectSecurityPolicyHeaderExists(browser, isTransition);
 		});

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
@@ -1,0 +1,35 @@
+var helper = require('../../specRuntime/testHelper');
+
+describe('A page with custom http headers', () => {
+
+	helper.startServerBeforeAll(__filename, [
+		'./HttpHeadersPage',
+		'./AsyncHttpHeadersPage',
+	]);
+
+	helper.stopServerAfterAll();
+
+	fdescribe('has sync rendered headers', () => {
+		helper.testWithBrowser('/httpHeaders', (browser, isTransition) => {
+			expectSecurityPolicyHeaderExists(browser, isTransition);
+		});
+	});
+
+	describe('has async rendered headers', () => {
+		helper.testWithBrowser('/asyncHttpHeaders', (browser, isTransition) => {
+			expectSecurityPolicyHeaderExists(browser, isTransition);
+		});
+	});
+
+	const expectSecurityPolicyHeaderExists = (browser, isTransition) => {
+		// Client transition execute their renders on the client. That means we don't have an opportunity to send over
+		// headers
+		if(isTransition) return;
+
+		const numCspHeaders = browser.resources[isTransition ? '4' : '0'].response.headers
+			._headers
+			.filter(header => header[0] === 'content-security-policy')
+			.length;
+		expect(numCspHeaders).toBe(1);
+	}
+});

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
@@ -22,14 +22,15 @@ describe('A page with custom http headers', () => {
 	});
 
 	const expectSecurityPolicyHeaderExists = (browser, isTransition) => {
-		// Client transition execute their renders on the client. That means we don't have an opportunity to send over
+		// Client transition renders execute on the client. That means we don't have an opportunity to send over
 		// headers
 		if(isTransition) return;
 
-		const numCspHeaders = browser.resources[isTransition ? '4' : '0'].response.headers
-			._headers
-			.filter(header => header[0] === 'content-security-policy')
-			.length;
-		expect(numCspHeaders).toBe(1);
+		const headers = browser.resources['0'].response.headers._headers;
+		const csp = headers.find(header => header[0] === 'content-security-policy');
+		const contentType = headers.find(header => header[0] === 'content-type');
+
+		expect(csp[1]).toBe("example.com");
+		expect(contentType[1]).toBe("application/example");
 	}
 });

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
@@ -28,9 +28,7 @@ describe('A page with custom http headers', () => {
 
 		const headers = browser.resources['0'].response.headers._headers;
 		const csp = headers.find(header => header[0] === 'content-security-policy');
-		const contentType = headers.find(header => header[0] === 'content-type');
 
 		expect(csp[1]).toBe("example.com");
-		expect(contentType[1]).toBe("application/example");
 	}
 });

--- a/packages/react-server-integration-tests/src/__tests__/rawResponse/RawResponsePage.js
+++ b/packages/react-server-integration-tests/src/__tests__/rawResponse/RawResponsePage.js
@@ -1,0 +1,10 @@
+class RawResponsePage {
+
+	setConfigValues(){ return { isRawResponse: true } }
+
+	getContentType() {
+		return "application/example";
+	}
+}
+
+module.exports = RawResponsePage;

--- a/packages/react-server-integration-tests/src/__tests__/rawResponse/RawResponseSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/rawResponse/RawResponseSpec.js
@@ -1,0 +1,27 @@
+var helper = require('../../specRuntime/testHelper');
+
+describe('A raw response page', () => {
+
+	helper.startServerBeforeAll(__filename, [
+		'./RawResponsePage',
+	]);
+
+	helper.stopServerAfterAll();
+
+	describe('sends correct content types', () => {
+		helper.testWithBrowser('/rawResponse', (browser, isTransition) => {
+			expectSecurityPolicyHeaderExists(browser, isTransition);
+		});
+	});
+
+	const expectSecurityPolicyHeaderExists = (browser, isTransition) => {
+		// Client transition renders execute on the client. That means we don't have an opportunity to send over
+		// headers
+		if(isTransition) return;
+
+		const headers = browser.resources['0'].response.headers._headers;
+		const contentType = headers.find(header => header[0] === 'content-type');
+
+		expect(contentType[1]).toBe("application/example");
+	}
+});

--- a/packages/react-server-integration-tests/src/specRuntime/testHelper.js
+++ b/packages/react-server-integration-tests/src/specRuntime/testHelper.js
@@ -1,3 +1,4 @@
+
 /* eslint-disable no-process-env */
 var	fs = require("fs"),
 	mkdirp = require("mkdirp"),
@@ -239,7 +240,34 @@ var testWithDocument = function (url, testFn) {
 			callback(document, done);
 		});
 	});
+}
 
+// Used to test test browser state on server, client and on page-to-page transitions
+var testWithBrowser = function (url, testFn) {
+	var callback = (browser, done, isTransition=false) => {
+		if (testFn.length >= 3) {
+			testFn(browser, isTransition, done);
+		} else {
+			// the client doesn't want the done function, so we should call it.
+			testFn(browser, isTransition);
+			done();
+		}
+	}
+	it ("on server", function(done) {
+		getServerBrowser(url, (browser) => {
+			callback(browser, done);
+		});
+	});
+	it ("on client", function(done) {
+		getClientBrowser(url, (browser) => {
+			callback(browser, done);
+		});
+	});
+	it ("on client transition", function(done) {
+		getTransitionBrowser(url, (browser) => {
+			callback(browser, done, true);
+		});
+	});
 }
 
 // Factor out some boilerplate if when just looking for an element.
@@ -308,6 +336,7 @@ module.exports = {
 	getTransitionDocument,
 	testWithDocument,
 	testWithElement,
+	testWithBrowser,
 	getServerBrowser,
 	getClientBrowser,
 	getTransitionBrowser,

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -295,9 +295,11 @@ function setHttpHeaders(req, res, context, start, pageObject) {
 	// Write out custom page-defined http headers. Headers may be overwritten later on in the render chain
 	// (e.g. transfer encoding, content type)
 	const handler = header => res.set(header[0], header[1]);
-	return Q(pageObject.getHeaders()).then(headers => headers
-		.concat(['Content-Type', pageObject.getContentType()])
-		.forEach(handler));
+
+	return Q(pageObject.getHeaders()).then(headers => {
+		headers.push(['Content-Type', pageObject.getContentType()]);
+		headers.forEach(handler);
+	});
 }
 
 function writeHeader(req, res, context, start, pageObject) {

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -276,6 +276,7 @@ function dataBundleLifecycle () {
 function pageLifecycle() {
 	return [
 		Q(), // This is just a NOOP lead-in to prime the reduction.
+		setHeaders,
 		setContentType,
 		writeHeader,
 		startBody,
@@ -293,6 +294,13 @@ function setContentType(req, res, context, start, pageObject) {
 
 function setDataBundleContentType(req, res) {
 	res.set('Content-Type', 'application/json');
+}
+
+function setHeaders(req, res, context, start, pageObject) {
+	// Write out custom page-defined http headers. Not to be confused with writeHeader(), which is responsible for
+	// the html header. Headers may be overwritten later on in the render chain (e.g. transfer encoding, content type)
+	const handler = header => res.set(header[0], header[1]);
+	return Q(pageObject.getHeaders()).then(headers => headers.forEach(handler));
 }
 
 function writeHeader(req, res, context, start, pageObject) {

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -246,6 +246,7 @@ function rawResponseLifecycle () {
 	return [
 		Q(), // NOOP lead-in to prime the reduction
 		setHttpHeaders,
+		setContentType,
 		writeResponseData,
 		handleResponseComplete,
 		endResponse,
@@ -296,10 +297,11 @@ function setHttpHeaders(req, res, context, start, pageObject) {
 	// (e.g. transfer encoding, content type)
 	const handler = header => res.set(header[0], header[1]);
 
-	return Q(pageObject.getHeaders()).then(headers => {
-		headers.push(['Content-Type', pageObject.getContentType()]);
-		headers.forEach(handler);
-	});
+	return Q(pageObject.getHeaders()).then(headers => headers.forEach(handler));
+}
+
+function setContentType(req, res, context, start, pageObject) {
+	res.set('Content-Type', pageObject.getContentType());
 }
 
 function writeHeader(req, res, context, start, pageObject) {

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -51,6 +51,7 @@ var PAGE_MIXIN = {
 var PAGE_METHODS = {
 	handleRoute        : [() => ({code: 200}), Q],
 	getContentType     : [() => "text/html; charset=utf-8", _ => _],
+	getHeaders         : [() => [], Q],
 	getTitle           : [() => "", Q],
 	getScripts         : [() => [], standardizeScripts],
 	getSystemScripts   : [() => [], standardizeScripts],


### PR DESCRIPTION
This PR provides another lifecycle method to allow page chains to specify their own http headers.

Some things:
- Subsequent lifecycle methods that set http headers will override those that the user has specified (e.g. Transfer-Encoding in writeHeader() )
- This doesn't really work for client transitions, because in that case no page request is issued.