### PR TITLE
Normalize httpsOptions from parseCli

### DIFF
--- a/packages/react-server-cli/.babelrc
+++ b/packages/react-server-cli/.babelrc
@@ -1,3 +1,4 @@
 {
-	"presets": ["react-server"]
+	"presets": ["react-server"],
+	"plugins": ["add-module-exports"]
 }

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -5,7 +5,8 @@
   "main": "target/index.js",
   "scripts": {
     "prepublish": "gulp",
-    "test": "gulp test && nsp check",
+    "test": "npm run ava && gulp test && nsp check",
+    "ava": "ava test --tap --require babel-register",
     "clean": "rimraf target npm-debug.log*"
   },
   "author": "Sasha Aickin",
@@ -47,6 +48,8 @@
     "yargs": "~3.15.0"
   },
   "devDependencies": {
+    "ava": "^0.16.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-react-server": "^0.4.7",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -1,7 +1,4 @@
 require("babel-core/register");
 
 const cli = require(".");
-
-cli.parseCliArgs().then(args => {
-	cli.run(args);
-});
+cli.parseCliArgs().then(cli.run);

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -2,4 +2,6 @@ require("babel-core/register");
 
 const cli = require(".");
 
-cli.run(cli.parseCliArgs());
+cli.parseCliArgs().then(args => {
+	cli.run(args);
+});

--- a/packages/react-server-cli/src/index.js
+++ b/packages/react-server-cli/src/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
-const run = require("./run").default;
-const parseCliArgs = require("./parseCliArgs").default;
-const defaultOptions = require("./defaultOptions").default;
+const run = require("./run");
+const parseCliArgs = require("./parseCliArgs");
+const defaultOptions = require("./defaultOptions");
 
 require.extensions['.css'] =
 require.extensions['.less'] =

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -153,11 +153,11 @@ const sslize = async argv => {
 			};
 		} else {
 			argv.httpsOptions = await new Promise((resolve, reject) => {
-				pem.createCertificate({ days:1, selfSigned:true }, (err, keys) => {
+				pem.createCertificate({ days: 1, selfSigned: true }, (err, keys) => {
 					if (err) {
 						reject(err);
 					}
-					resolve({key: keys.serviceKey, cert:keys.certificate});
+					resolve({ key: keys.serviceKey, cert: keys.certificate });
 				});
 			});
 		}

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -1,10 +1,13 @@
 import yargs from "yargs"
 import fs from "fs"
+import pem from "pem"
 
 export default (args = process.argv) => {
 	var argsDefinition = yargs(args)
 		.usage('Usage: $0 <command> [options]')
 		.option("routes-file", {
+			default: "routes.js",
+			type: "string",
 			describe: "The routes file to load. Default is 'routes.js'.",
 		})
 		.option("p", {
@@ -124,27 +127,45 @@ export default (args = process.argv) => {
 	// we remove all the options that have undefined as their value; those are the
 	// ones that weren't on the command line, and we don't want them to override
 	// defaults or config files.
-	return sslize(camelize(removeUndefinedValues(parsedArgs)));
+	return sslize(removeUndefinedValues(parsedArgs));
 
 }
 
-const sslize = argv => {
+const sslize = async argv => {
 
-	if (argv.httpsKey || argv.httpsCert || argv.httpsCa || argv.httpsPfx || argv.httpsPassphrase) {
-		argv.httpsOptions = {
-			key: argv.httpsKey ? fs.readFileSync(argv.httpsKey) : undefined,
-			cert: argv.httpsCert ? fs.readFileSync(argv.httpsCert) : undefined,
-			ca: argv.httpsCa ? fs.readFileSync(argv.httpsCa) : undefined,
-			pfx: argv.httpsPfx ? fs.readFileSync(argv.httpsPfx) : undefined,
-			passphrase: argv.httpsPassphrase,
+	const {
+		https,
+		httpsKey,
+		httpsCert,
+		httpsCa,
+		httpsPfx,
+		httpsPassphrase,
+	} = argv;
+
+	if (https || (httpsKey && httpsCert) || httpsPfx) {
+		if ((httpsKey && httpsCert) || httpsPfx) {
+			argv.httpsOptions = {
+				key: httpsKey ? fs.readFileSync(httpsKey) : undefined,
+				cert: httpsCert ? fs.readFileSync(httpsCert) : undefined,
+				ca: httpsCa ? fs.readFileSync(httpsCa) : undefined,
+				pfx: httpsPfx ? fs.readFileSync(httpsPfx) : undefined,
+				passphrase: httpsPassphrase,
+			};
+		} else {
+			argv.httpsOptions = await new Promise((resolve, reject) => {
+				pem.createCertificate({ days:1, selfSigned:true }, (err, keys) => {
+					if (err) {
+						reject(err);
+					}
+					resolve({key: keys.serviceKey, cert:keys.certificate});
+				});
+			});
 		}
+	} else {
+		argv.httpsOptions = false;
 	}
 
-	if (argv.https && (argv.httpsKey || argv.httpsCert || argv.httpsCa || argv.httpsPfx || argv.httpsPassphrase)) {
-		throw new Error("If you set https to true, you must not set https-key, https-cert, https-ca, https-pfx, or https-passphrase.");
-	}
-
-	if ((argv.key || argv.cert || argv.ca) && argv.pfx) {
+	if ((httpsKey || httpsCert || httpsCa) && httpsPfx) {
 		throw new Error("If you set https.pfx, you can't set https.key, https.cert, or https.ca.");
 	}
 
@@ -161,19 +182,4 @@ const removeUndefinedValues = (input) => {
 	}
 
 	return result;
-}
-
-const camelize = (input) => {
-	const inputCopy = Object.assign({}, input)
-
-	const replaceFn = (match, character) => { return character.toUpperCase() }
-	for (let key in Object.keys(inputCopy)) {
-		if (key.indexOf("-") !== -1) {
-			const newKey = key.replace(/-(.)/g, replaceFn);
-			inputCopy[newKey] = inputCopy[key];
-			delete inputCopy[key];
-		}
-	}
-
-	return inputCopy;
 }

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -33,7 +33,7 @@ export default function run(options = {}) {
 	options.outputUrl = jsUrl || `${httpsOptions ? "https" : "http"}://${host}:${jsPort}/`;
 
 	try {
-		return require("./" + path.join("commands", options.command)).default(options);
+		return require("./" + path.join("commands", options.command))(options);
 	} catch (e) {
 		if (e instanceof ConfigurationError) {
 			console.error(chalk.red(e.message));

--- a/packages/react-server-cli/test/parseCliArgs.js
+++ b/packages/react-server-cli/test/parseCliArgs.js
@@ -1,0 +1,326 @@
+import test from 'ava';
+import defaultOptions from '../src/defaultOptions';
+import parseCliArgs from '../src/parseCliArgs';
+
+const defaultArgs = ['/usr/local/bin/node', '/usr/local/bin/react-server'];
+
+// **** routesFile ****
+// routesFile path always exists in parsed cli arguments and is the same key as we expect in defaultOptions.
+test('react-server-cli:parseCliArgs::routesFile defaults to routes.js', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.routesFile, 'routes.js', 'Default routesFile is routes.js');
+  	t.true(Object.keys(defaultOptions).indexOf('routesFile') > -1, 'routesFile key exists in defaultOptions');
+});
+
+// routesFile options can be modified using --routes-file argument
+test('react-server-cli:parseCliArgs::routesFile can be modified using --routes-file flag', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--routes-file',
+  		'customRoutes.js'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.routesFile, 'customRoutes.js', 'routesFile option is customRoutes.js');
+});
+
+// routesFile options can be modified using --routesFile argument
+test('react-server-cli:parseCliArgs::routesFile can be modified using --routesFile flag', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--routesFile',
+  		'customRoutes.js'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.routesFile, 'customRoutes.js', 'routesFile option is customRoutes.js');
+});
+
+
+// **** port ****
+// port will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::port will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.port, undefined, 'port is undefined if no argument is provided');
+});
+
+// port option can be modified using --port argument
+test('react-server-cli:parseCliArgs::port option can be modified using --port argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--port',
+  		'8080'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.port, 'number', 'port is a number');
+  	t.is(parsedArgs.port, 8080, 'port is 8080');
+  	t.true(Object.keys(defaultOptions).indexOf('port') > -1, 'port key exists in defaultOptions');
+});
+
+// port option can be modified using -p argument
+test('react-server-cli:parseCliArgs::port option can be modified using -p argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'-p',
+  		'8080'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.port, 'number', 'port is a number');
+  	t.is(parsedArgs.port, 8080, 'port is 8080');
+  	t.true(Object.keys(defaultOptions).indexOf('port') > -1, 'port key exists in defaultOptions');
+});
+
+
+// **** host ****
+// host will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::host will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.host, undefined, 'host is undefined if no argument is provided');
+});
+
+// host option can be modified using --host argument
+test('react-server-cli:parseCliArgs::host option can be modified using --host argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--host',
+  		'www.myhost.dev'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.host, 'www.myhost.dev', 'host is www.myhost.dev');
+  	t.true(Object.keys(defaultOptions).indexOf('host') > -1, 'host key exists in defaultOptions');
+});
+
+
+// **** js-port ****
+// jsPort will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::jsPort will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.jsPort, undefined, 'jsPort is undefined if no argument is provided');
+});
+
+// jsPort options can be modified using --js-port argument
+test('react-server-cli:parseCliArgs::jsPort can be modified using --js-port flag', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--js-port',
+  		'8081'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.jsPort, 'number', 'jsPort is a number');
+  	t.is(parsedArgs.jsPort, 8081, 'jsPort option is 8081');
+  	t.true(Object.keys(defaultOptions).indexOf('jsPort') > -1, 'jsPort key exists in defaultOptions');
+});
+
+// jsPort options can be modified using --jsPort argument
+test('react-server-cli:parseCliArgs::jsPort can be modified using --jsPort flag', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--jsPort',
+  		'8081'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.jsPort, 'number', 'jsPort is a number');
+  	t.is(parsedArgs.jsPort, 8081, 'jsPort option is 8081');
+  	t.true(Object.keys(defaultOptions).indexOf('jsPort') > -1, 'jsPort key exists in defaultOptions');
+});
+
+
+// **** httpsOptions ****
+// httpsOptions always exists in parsed cli arguments
+test('react-server-cli:parseCliArgs::httpsOptions defaults to false', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.httpsOptions, false, 'Default httpsOptions is false');
+});
+
+// httpsOptions will be false if https is false
+test('react-server-cli:parseCliArgs::httpsOptions will be false if https is false', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--https',
+  		'false'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.httpsOptions, false, 'httpsOptions is false if https is false');
+});
+
+// httpsOptions will be an object with two keys; key and cert, if option flag https is set
+test('react-server-cli:parseCliArgs::httpsOptions will be an object with two keys; key and cert', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--https',
+  		'true'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.httpsOptions, 'object', 'httpsOptions is an object');
+  	t.is(typeof parsedArgs.httpsOptions.key, 'string', 'httpsOptions property key is a string');
+  	t.is(typeof parsedArgs.httpsOptions.cert, 'string', 'httpsOptions property cert is a string');
+  	t.is(parsedArgs.httpsOptions.key.slice(0,31), '-----BEGIN RSA PRIVATE KEY-----', 'httpsOptions property key is a RSA private key');
+  	t.is(parsedArgs.httpsOptions.cert.slice(0,27), '-----BEGIN CERTIFICATE-----', 'httpsOptions property cert is a https certificate');
+});
+
+// httpsOptions will be an object containing key, cert, ca, pfx, and passphrase if --https-key and --https-cert is provided as an argument
+test('react-server-cli:parseCliArgs::httpsOptions will be an object containing key, cert, ca, pfx, and passphrase if --https-key and --https-cert is provided as an argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--https-key',
+  		'../.babelrc',
+  		'--https-cert',
+  		'../.babelrc'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.httpsKey, '../.babelrc', 'httpsKey is ../.babelrc');
+  	t.is(parsedArgs.httpsCert, '../.babelrc', 'httpsCert is ../.babelrc');
+
+  	t.is(typeof parsedArgs.httpsOptions, 'object', 'httpsOptions is an object');
+  	t.true(Buffer.isBuffer(parsedArgs.httpsOptions.key), 'httpsOptions property key is a buffer from reading a file');
+  	t.true(Buffer.isBuffer(parsedArgs.httpsOptions.cert), 'httpsOptions property cert is a buffer from reading a file');
+  	t.is(typeof parsedArgs.httpsOptions.ca, 'undefined', 'httpsOptions property ca is undefined');
+  	t.is(typeof parsedArgs.httpsOptions.pfx, 'undefined', 'httpsOptions property pfx is undefined');
+  	t.is(typeof parsedArgs.httpsOptions.passphrase, 'undefined', 'httpsOptions property passphrase is undefined');
+});
+
+
+// **** hot ****
+// hot will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::hot will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.hot, undefined, 'hot is undefined if no argument is provided');
+});
+
+// hot option can be turned on using --hot argument
+test('react-server-cli:parseCliArgs::hot option can be turned on using --hot argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--hot'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.hot, 'boolean', 'hot is true');
+  	t.is(parsedArgs.hot, true, 'hot is true');
+  	t.true(Object.keys(defaultOptions).indexOf('hot') > -1, 'hot key exists in defaultOptions');
+});
+
+// hot option can be turned on using -h argument
+test('react-server-cli:parseCliArgs::hot option can be turned on using -h argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'-h'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.hot, 'boolean', 'hot is true');
+  	t.is(parsedArgs.hot, true, 'hot is true');
+  	t.true(Object.keys(defaultOptions).indexOf('hot') > -1, 'hot key exists in defaultOptions');
+});
+
+
+// **** minify ****
+// minify will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::minify will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.minify, undefined, 'minify is undefined if no argument is provided');
+});
+
+// minify option can be turned on using --minify argument
+test('react-server-cli:parseCliArgs::minify option can be turned on using --minify argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--minify'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.minify, 'boolean', 'minify is true');
+  	t.is(parsedArgs.minify, true, 'minify is true');
+  	t.true(Object.keys(defaultOptions).indexOf('minify') > -1, 'minify key exists in defaultOptions');
+});
+
+// minify option can be turned on using -m argument
+test('react-server-cli:parseCliArgs::minify option can be turned on using -m argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'-m'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.minify, 'boolean', 'minify is true');
+  	t.is(parsedArgs.minify, true, 'minify is true');
+  	t.true(Object.keys(defaultOptions).indexOf('minify') > -1, 'minify key exists in defaultOptions');
+});
+
+
+// **** longTermCaching ****
+// longTermCaching will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::longTermCaching will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(parsedArgs.longTermCaching, undefined, 'longTermCaching is undefined if no argument is provided');
+});
+
+// longTermCaching option can be turned on using --longTermCaching argument
+test('react-server-cli:parseCliArgs::longTermCaching option can be turned on using --longTermCaching argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--longTermCaching'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.longTermCaching, 'boolean', 'longTermCaching is true');
+  	t.is(parsedArgs.longTermCaching, true, 'longTermCaching is true');
+  	t.true(Object.keys(defaultOptions).indexOf('longTermCaching') > -1, 'longTermCaching key exists in defaultOptions');
+});
+
+// longTermCaching option can be turned on using --long-term-caching argument
+test('react-server-cli:parseCliArgs::longTermCaching option can be turned on using --long-term-caching argument', async t => {
+	const args = [
+		...defaultArgs,
+  		'compile',
+  		'--long-term-caching'
+  	];
+  	const parsedArgs = await parseCliArgs(args);
+  	t.is(typeof parsedArgs.longTermCaching, 'boolean', 'longTermCaching is true');
+  	t.is(parsedArgs.longTermCaching, true, 'longTermCaching is true');
+  	t.true(Object.keys(defaultOptions).indexOf('longTermCaching') > -1, 'longTermCaching key exists in defaultOptions');
+});
+
+
+
+


### PR DESCRIPTION
See: https://github.com/redfin/react-server/issues/569

Most checks in the codebase, check for httpsOptions and not the https flag. This PR ensures httpsOptions is always defined and set from parseCli.

- I also added a babel plugin called `add-module-exports` to make things easier when importing default exports.
- I added a package called ava for tests (following the generator package lead).
- I moved the pem package from the start command over to parseCli, so we can get a standard httpsOptions object (or boolean) in cli.start.
- Removed the camelize function from parseCli, as the yargs package already does that for us.
- Wrote 24 unit tests. It's still not complete and will work on adding more tests around all cli flags.
- Linter passes.

