### PR TITLE
Upgrade to lerna@2.0.0-beta.28

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.26",
+  "lerna": "2.0.0-beta.28",
   "version": "0.4.7",
   "changelog": {
     "repo": "redfin/react-server",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jasmine": "2.5.1",
     "jsdom": "9.4.5",
     "jsx-loader": "0.12.2",
-    "lerna": "2.0.0-beta.26",
+    "lerna": "2.0.0-beta.28",
     "lerna-changelog": "^0.2.0",
     "minimist": "1.1.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This picks up:

- [Enhanced bootstrap](https://github.com/lerna/lerna/pull/237)
- [Private module support](https://github.com/lerna/lerna/pull/321)

You'll neeed to `npm update` after this lands (and `npm i -g
lerna@2.0.0-beta.28` if you're using a global Lerna).

You'll also want to re-bootstrap to get your repo up-to-date.