### PR TITLE
Moved call to set the page on the response logger from

### DIFF
--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -5,7 +5,8 @@ var EventEmitter = require('events').EventEmitter,
 	Q = require('q'),
 	History = require("../components/History"),
 	ReactServerAgent = require("../ReactServerAgent"),
-	PageUtil = require("../util/PageUtil");
+	PageUtil = require("../util/PageUtil"),
+	{setResponseLoggerPage} = SERVER_SIDE ? require('../logging/response') : { setResponseLoggerPage: () => {} };
 
 var _ = {
 	isFunction: require('lodash/isFunction'),
@@ -183,6 +184,10 @@ class Navigator extends EventEmitter {
 			isFragment    : false,
 			isRawResponse : false,
 		});
+
+		// Set the page context on the response logger so it can figure
+		// out whether to flush logs to the response document
+		setResponseLoggerPage(page);
 
 		// call page.handleRoute(), and use the resulting code to decide how to
 		// respond.

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -17,7 +17,7 @@ var logger = require('./logging').getLogger(__LOGGER__),
 	StringEscapeUtil = require('./util/StringEscapeUtil'),
 	{getRootElementAttributes} = require('./components/RootElement'),
 	{PAGE_CSS_NODE_ID, PAGE_LINK_NODE_ID, PAGE_CONTENT_NODE_ID, PAGE_CONTAINER_NODE_ID} = require('./constants'),
-	{setResponseLoggerPage, flushLogsToResponse} = require('./logging/response');
+	{flushLogsToResponse} = require('./logging/response');
 
 var _ = {
 	map: require('lodash/map'),
@@ -132,9 +132,6 @@ module.exports = function(server, routes) {
 					return;
 				}
 			}
-			// Set the page context on the response logger so it can figure
-			// out whether to flush logs to the response document
-			setResponseLoggerPage(page);
 			renderPage(req, res, context, start, page);
 
 		});


### PR DESCRIPTION
renderMiddleware(onNavigate) to Navigator.handlePage. This will include
all logs leading up to and during the execution the handleRoute method.