### PR TITLE
Update or add .reactserverrc files

### DIFF
--- a/packages/react-server-examples/bike-share/.reactserverrc
+++ b/packages/react-server-examples/bike-share/.reactserverrc
@@ -1,0 +1,3 @@
+{
+  "routesFile": "./routes.js"
+}

--- a/packages/react-server-examples/hello-world/.reactserverrc
+++ b/packages/react-server-examples/hello-world/.reactserverrc
@@ -1,0 +1,3 @@
+{
+  "routesFile": "./routes.js"
+}

--- a/packages/react-server-examples/redux-basic/.reactserverrc
+++ b/packages/react-server-examples/redux-basic/.reactserverrc
@@ -1,5 +1,5 @@
 {
-  "routes": "./routes.js",
+  "routesFile": "./routes.js",
   "host": "localhost",
   "port": 3000,
   "js-port": 3001,

--- a/packages/react-server-test-pages/.reactserverrc
+++ b/packages/react-server-test-pages/.reactserverrc
@@ -1,0 +1,3 @@
+{
+  "routesFile": "./routes.js"
+}

--- a/packages/react-server-website/.reactserverrc
+++ b/packages/react-server-website/.reactserverrc
@@ -1,5 +1,5 @@
 {
-  "routes": "./routes.js",
+  "routesFile": "./routes.js",
   "host": "localhost",
   "port": 3010,
   "jsPort": 3011,


### PR DESCRIPTION
Forgot to add a `.reactserverrc` files in some packages and some `.reactserverrc` files were outdated when we switched from using the key `routes` to `routesFile`.