### PR TITLE
Add cli option  for webpack-config

### DIFF
--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -140,7 +140,7 @@ export default (webpackConfig) => {
 }
 ```
 
-In the `.reactserverrc` file add an option for `webpackConfig` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed. On the command use the option `--webpack-config`
+In the `.reactserverrc` file add an option for `webpackConfig` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed. On the command line use the option `--webpack-config`
 
 ### Use Custom Express Middleware
 Currently the default Express Middlewares used are compression, body-parser, cookie-parser. If you need to setup custom express middleware you can do it with a setup function.

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -140,7 +140,7 @@ export default (webpackConfig) => {
 }
 ```
 
-In the `.reactserverrc` file add an option for `webpack-config` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed.
+In the `.reactserverrc` file add an option for `webpackConfig` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed. On the command use the option `--webpack-config`
 
 ### Use Custom Express Middleware
 Currently the default Express Middlewares used are compression, body-parser, cookie-parser. If you need to setup custom express middleware you can do it with a setup function.

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -140,7 +140,7 @@ export default (webpackConfig) => {
 }
 ```
 
-In the `.reactserverrc` file add an option for `webpackConfig` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed. On the command line use the option `--webpack-config`
+In the `.reactserverrc` file add an option for `webpackConfig` that points to that function file and when React Server is setting up Webpack it will call your function with the result of the built in Webpack options, allowing you to make any modifications needed. This may also be specified on the command line with the `--webpack-config=<FILE>` option.
 
 ### Use Custom Express Middleware
 Currently the default Express Middlewares used are compression, body-parser, cookie-parser. If you need to setup custom express middleware you can do it with a setup function.

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -283,6 +283,11 @@ Path to the custom middleware function file. If it is not defined the default se
 
 Defaults to **undefined**.
 
+#### --webpack-config
+Path to your webpack options callback function file.
+
+Defaults to **undefined**.
+
 #### --long-term-caching
 Adds hashes to all JavaScript and CSS file names output by the build, allowing
 for the static files to be served with far-future expires headers. This option

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -23,6 +23,7 @@ import callerDependency from "./callerDependency"
 export default (opts = {}) => {
 	const {
 		routes,
+		webpackConfig,
 		workingDir = "./__clientTemp",
 		routesDir = ".",
 		outputDir = workingDir + "/build",
@@ -39,8 +40,8 @@ export default (opts = {}) => {
 	}
 
 	var webpackConfigFunc = (data) => { return data }
-	if (opts['webpack-config']) {
-		const webpackDirAbsolute = path.resolve(process.cwd(), opts['webpack-config']);
+	if (webpackConfig) {
+		const webpackDirAbsolute = path.resolve(process.cwd(), webpackConfig);
 		const userWebpackConfigFunc = require(webpackDirAbsolute)
 		webpackConfigFunc = userWebpackConfigFunc.default
 	}

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -71,6 +71,11 @@ export default (args = process.argv) => {
 			default: undefined,
 			type: "string",
 		})
+		.option("webpack-config", {
+			describe: "Path to Webpack options callback function.",
+			default: undefined,
+			type: "string",
+		})
 		.option("long-term-caching", {
 			describe: "Use long-term cache headers for the static JS & CSS files. Default is true in production mode, false otherwise.",
 			default: undefined,

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -72,7 +72,7 @@ export default (args = process.argv) => {
 			type: "string",
 		})
 		.option("webpack-config", {
-			describe: "Path to Webpack options callback function.",
+			describe: "Path to Webpack options callback function file.",
 			default: undefined,
 			type: "string",
 		})


### PR DESCRIPTION
Currently do not have a command line option to pass a path to our webpack-config. This creates that option.
