### PR TITLE
Fix timeout error handling

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -529,6 +529,15 @@ class ClientController extends EventEmitter {
 		// These resolve with React elements when their data
 		// dependencies are fulfilled.
 		var elementPromises = PageUtil.standardizeElements(page.getElements());
+		var timeoutDfd = [];
+		var elementPromisesOr = elementPromises.map((promise, index) => {
+			var orPromise = Q.defer();
+			timeoutDfd[index] = Q.defer();
+			promise.then(orPromise.resolve)
+			timeoutDfd[index].promise.catch(orPromise.reject);
+
+			return orPromise.promise;
+		});
 
 		// These resolve with DOM mount points for the elements.
 		//
@@ -672,7 +681,7 @@ class ClientController extends EventEmitter {
 		// Always render in order to proritize content higher in the
 		// page.
 		//
-		elementPromises.reduce((chain, promise, index) => chain
+		elementPromisesOr.reduce((chain, promise, index) => chain
 			.then(() => promise
 				.then(element => rootNodePromises[index]
 					.then(root => renderElement(element, root, index))
@@ -691,7 +700,14 @@ class ClientController extends EventEmitter {
 		// Look out for a failsafe timeout from the server on our
 		// first render.
 		if (!this._previouslyRendered){
-			this._failDfd.promise.then(retval.resolve);
+			this._failDfd.promise.then(() => {
+				elementPromises.forEach((promise, index) => {
+					//Reject any elements that have failed to render
+					if (promise.isPending()) {
+						timeoutDfd[index].reject(`Error with element ${index}, it failed to render within timeout time`);
+					}
+				});
+			});
 		}
 
 		return retval.promise.then(() => {

--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -533,7 +533,9 @@ class ClientController extends EventEmitter {
 		var elementPromisesOr = elementPromises.map((promise, index) => {
 			var orPromise = Q.defer();
 			timeoutDfd[index] = Q.defer();
-			promise.then(orPromise.resolve)
+
+			promise.then(orPromise.resolve);
+			promise.catch(orPromise.reject);
 			timeoutDfd[index].promise.catch(orPromise.reject);
 
 			return orPromise.promise;

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -736,6 +736,8 @@ function writeBody(req, res, context, start, page) {
 
 		// Let the client know it's not getting any more data.
 		renderScriptsAsync([{ text: `__reactServerClientController.failArrival()` }], res)
+		// Close off the body since the page life cycle will not complete
+		res.write("</div></body></html>");
 	});
 
 	Q.all(dfds.map(dfd => dfd.promise)).then(retval.resolve);

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -740,7 +740,7 @@ function writeBody(req, res, context, start, page) {
 
 		//Log timeout error but still resolve so we continue in the lifecycle process
 		logger.error("Error in writeBody", err);
-		retval.promise.resolve();
+		retval.resolve();
 	});
 
 	Q.all(dfds.map(dfd => dfd.promise)).then(writeBodyDfd.resolve);
@@ -767,7 +767,7 @@ function writeBody(req, res, context, start, page) {
 	writeBodyDfd.promise.then(() => {
 		clearTimeout(timeout);
 		//writeBody ran successfully, sweet
-		retval.promise.resolve();
+		retval.resolve();
 	});
 
 	return retval.promise;


### PR DESCRIPTION
Relates to issue #711 

The main issues addressed here are:
1. When renderMiddleware timesout, it will send down what ever it has left but it fails to close out the body and html.
2. In ClientController there is a race condition between nodeArrival and failArrival. nodeArrival will receive a bunch of nodes since before failArrival is sent the nodes we have left are sent down. If failArrival runs an resolves `retVal` before the nodes can actually render the `_previouslyRender` flag will be set. Once that is set and the elements try to render, because `_previouslyRender` is set at the point `_cleanup` will be called which will wipe away everything on the page.
