### PR TITLE
Improve Redux-Basic example

### DIFF
--- a/packages/react-server-examples/redux-basic/components/Counter.js
+++ b/packages/react-server-examples/redux-basic/components/Counter.js
@@ -1,11 +1,20 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
+import { ReactServerAgent } from 'react-server'
 
 class Counter extends Component {
   constructor(props) {
     super(props)
     this.incrementAsync = this.incrementAsync.bind(this)
     this.incrementIfOdd = this.incrementIfOdd.bind(this)
+  }
+
+  static init() {
+    return ReactServerAgent.get('http://localhost:3000/count').then( (res) => {
+      return JSON.parse(res.text).payload;
+    }).catch( (error) => {
+      console.log(error);
+    });
   }
 
   incrementIfOdd() {

--- a/packages/react-server-examples/redux-basic/middleware/json_endpoint.js
+++ b/packages/react-server-examples/redux-basic/middleware/json_endpoint.js
@@ -1,0 +1,20 @@
+export default class JsonEndpoint {
+  setConfigValues() {
+    return { isRawResponse: true };
+  }
+
+  handleRoute(next) {
+    return next();
+  }
+
+  getContentType() {
+    return 'application/json';
+  }
+
+  getResponseData(next) {
+    return next().then(object => JSON.stringify({
+      payload: object
+    }));
+  }
+}
+

--- a/packages/react-server-examples/redux-basic/pages/counter-app/api.js
+++ b/packages/react-server-examples/redux-basic/pages/counter-app/api.js
@@ -1,0 +1,16 @@
+import JsonEndpoint from '../../middleware/json_endpoint';
+
+export default class CounterAPI {
+  static middleware() {
+    return [JsonEndpoint];
+  }
+
+  handleRoute() {
+    return {code: 200};
+  }
+
+  getResponseData() {
+    return Promise.resolve(123);
+  }
+
+}

--- a/packages/react-server-examples/redux-basic/pages/counter-app/index.js
+++ b/packages/react-server-examples/redux-basic/pages/counter-app/index.js
@@ -8,8 +8,15 @@ import store from '../store'
 
 export default class CounterPage {
   getElements() {
+
+    const counterPromise = Counter.init();
+
+    counterPromise.then( (count) => {
+      store.dispatch({type: 'INIT', val: count})
+    });
+
     return [
-      <RootElement key={0}>
+      <RootElement key={0} when={counterPromise}>
         <Provider store={store}>
           <Counter
             value={store.getState()}

--- a/packages/react-server-examples/redux-basic/pages/counter-app/index.js
+++ b/packages/react-server-examples/redux-basic/pages/counter-app/index.js
@@ -11,12 +11,13 @@ export default class CounterPage {
 
     const counterPromise = Counter.init();
 
-    counterPromise.then( (count) => {
+    const storeUpdatedPromise = counterPromise.then( (count) => {
       store.dispatch({type: 'INIT', val: count})
+      return count;
     });
 
     return [
-      <RootElement key={0} when={counterPromise}>
+      <RootElement key={0} when={storeUpdatedPromise}>
         <Provider store={store}>
           <Counter
             value={store.getState()}
@@ -24,7 +25,7 @@ export default class CounterPage {
             onDecrement={() => store.dispatch({ type: 'DECREMENT' })}
           />
         </Provider>
-      </RootElement>,
+      </RootElement>
     ]
   }
 

--- a/packages/react-server-examples/redux-basic/pages/counter-app/index.js
+++ b/packages/react-server-examples/redux-basic/pages/counter-app/index.js
@@ -8,7 +8,6 @@ import store from '../store'
 
 export default class CounterPage {
   getElements() {
-
     const counterPromise = Counter.init();
 
     const storeUpdatedPromise = counterPromise.then( (count) => {

--- a/packages/react-server-examples/redux-basic/pages/counter-app/reducer.js
+++ b/packages/react-server-examples/redux-basic/pages/counter-app/reducer.js
@@ -4,6 +4,8 @@ export default function counter(state = 0, action) {
       return state + 1
     case 'DECREMENT':
       return state - 1
+    case 'INIT':
+      return action.val
     default:
       return state
   }

--- a/packages/react-server-examples/redux-basic/routes.js
+++ b/packages/react-server-examples/redux-basic/routes.js
@@ -5,5 +5,11 @@ module.exports = {
 			method: 'get',
 			page: './pages/counter-app/index',
 		},
+		CounterAPI: {
+			path: ['/count'],
+			method: 'get',
+			page: './pages/counter-app/api',
+		},
+
 	},
 }


### PR DESCRIPTION
Related to #600 , Original Redux-Basic example doesn't have state initialization.

This change demonstrates ways to initialize Redux state with promises.

1) `CounterAPI` responds with initial count value;
2) In `CounterPage`, `CounterAPI` response is dispatched to Redux store and triggers `Counter` rendering through `when`.
