### PR TITLE
Get test cases synchronously for gulp-module-tagger

### DIFF
--- a/packages/react-server-gulp-module-tagger/test/test.js
+++ b/packages/react-server-gulp-module-tagger/test/test.js
@@ -4,14 +4,12 @@ import cp from 'child_process';
 import path from 'path';
 import del from 'del';
 
-getTestCases().then((testCases) => {
-  testCases.forEach((dir) => {
-    test(`testing fixture in ${dir}`, async t => {
-      await runGulp(dir);
-      const expected = await readFile(path.join('fixtures', dir, 'expected.js'));
-      const actual = await readFile(path.join('fixtures', dir, 'build', 'actual.js'));
-      t.is(actual.toString(), expected.toString());
-    });
+getTestCases().forEach((dir) => {
+  test(`testing fixture in ${dir}`, async t => {
+    await runGulp(dir);
+    const expected = await readFile(path.join('fixtures', dir, 'expected.js'));
+    const actual = await readFile(path.join('fixtures', dir, 'build', 'actual.js'));
+    t.is(actual.toString(), expected.toString());
   });
 });
 
@@ -26,7 +24,7 @@ test('module can be required', t => {
 
 test.after.always('cleanup', async t => {
   const promises = [];
-  const fixtures = await getTestCases();
+  const fixtures = getTestCases();
   fixtures.forEach(fixture => {
     promises.push(del(path.join('fixtures', fixture, 'build')));
   })
@@ -34,15 +32,7 @@ test.after.always('cleanup', async t => {
 });
 
 function getTestCases() {
-  return new Promise((resolve, reject) => {
-    fs.readdir('fixtures', (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data);
-      }
-    })
-  })
+  return fs.readdirSync('fixtures');
 }
 
 function readFile(filename) {


### PR DESCRIPTION
Travis is failing on master with:

```
Errored while running npm script 'test' in 'react-server-gulp-module-tagger'
Error: Command failed: npm run test
  ✔ module can be required (147ms)
  Unhandled Rejection: test/test.js
    Error: All tests and hooks must be declared synchronously in your test
	file, and cannot be nested within other tests or hooks.
```

This is an attempt to avoid that by synchronously declaring tests.

Not able to repro locally.