### PR TITLE
Add an option to move all JS below the fold

### DIFF
--- a/packages/react-server-test-pages/pages/root/aboveTheFold.js
+++ b/packages/react-server-test-pages/pages/root/aboveTheFold.js
@@ -3,13 +3,15 @@ import {
 	RootContainer,
 	RootElement,
 	TheFold,
+	Link,
 } from "react-server";
 
 export default class RootWhenPage {
-	handleRoute(next) {
+	handleRoute() {
 		this.data = ReactServerAgent.get('/data/delay?ms=200&big=10000')
 			.then(res => res.body);
-		return next();
+		const {jsBelowTheFold} = this.getRequest().getQuery();
+		return {code: 200, jsBelowTheFold};
 	}
 	getElements() {
 		return [
@@ -23,6 +25,10 @@ export default class RootWhenPage {
 				<RootElement when={this.data}><div>Four</div></RootElement>
 			</RootContainer>,
 			<div>Five</div>,
+			<div>
+				<Link path={"/root/aboveTheFold"}>JS in HEAD</Link> |
+				<Link path={"/root/aboveThefold?jsBelowTheFold=1"}>JS below the fold</Link>
+			</div>,
 		]
 	}
 }

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -200,6 +200,8 @@ class Navigator extends EventEmitter {
 
 			page.setHasDocument(handleRouteResult.hasDocument);
 
+			page.setJsBelowTheFold(handleRouteResult.jsBelowTheFold);
+
 			// TODO: I think that 3xx/4xx/5xx shouldn't be considered "errors" in navigateDone, but that's
 			// how the code is structured right now, and I'm changing too many things at once at the moment. -sra.
 			if (handleRouteResult.code && ((handleRouteResult.code / 100)|0) !== 2) {

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -110,6 +110,8 @@ var PAGE_CHAIN_PROTOTYPE = {
 	setStatus          : makeSetter('status'),
 	getHasDocument     : makeGetter('hasDocument'),
 	setHasDocument     : makeSetter('hasDocument'),
+	getJsBelowTheFold  : makeGetter('jsBelowTheFold'),
+	setJsBelowTheFold  : makeSetter('jsBelowTheFold'),
 };
 
 // We log all method calls on the page chain for debugging purposes.


### PR DESCRIPTION
This can improve the performance of above the fold render by eliminating
resource competition due to network I/O and synchronous JS parse.

This is an opt-in feature triggered by a `jsBelowTheFold` key in the response
from `handleRoute`.

```javascript
handleRoute() {
  return {
    code           : 200,
    jsBelowTheFold : true,
}
```