### PR TITLE
Support arrays of paths in routes files

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -278,7 +278,7 @@ module.exports = {
 		routesOutput.push(`
 		${routeName}: {`);
 		routesOutput.push(`
-			path: "${route.path}",`);
+			path: ${JSON.stringify(route.path)},`);
 		// if the route doesn't have a method, we'll assume it's "get". routr doesn't
 		// have a default (method is required), so we set it here.
 		routesOutput.push(`

--- a/packages/react-server-test-pages/pages/index.js
+++ b/packages/react-server-test-pages/pages/index.js
@@ -8,6 +8,12 @@ export default class IndexPage {
 			<ul>{_.map(entrypoints, (val, key) => <li>
 				<a href={val.entry}>{val.description||key}</a>
 			</li>)}</ul>
+			<h2>Homepage Aliases:</h2>
+			<p>This tests routes with arrays of paths</p>
+			<ul>
+				<li><a href="/foo">foo</a></li>
+				<li><a href="/bar">bar</a></li>
+			</ul>
 		</div>
 	}
 }

--- a/packages/react-server-test-pages/routes.js
+++ b/packages/react-server-test-pages/routes.js
@@ -9,7 +9,7 @@ module.exports = {
 	// this maps URLs to modules that export a Page class.
 	routes: _.assign({
 		Index: {
-			path: ["/"],
+			path: ["/", "/foo", "/bar"], // Test for array support.
 			page: "./pages/index",
 		},
 		DataDelay: {


### PR DESCRIPTION
Arrays were getting serialized as strings joined on comma in generated routes files.