### PR TITLE
Re-add the `.default` to require of TheFold in common.js

### DIFF
--- a/packages/react-server/core/common.js
+++ b/packages/react-server/core/common.js
@@ -4,7 +4,7 @@ module.exports = {
 	RootContainer: require("./components/RootContainer"),
 	RootElement: require("./components/RootElement"),
 	Link: require('./components/Link'),
-	TheFold: require('./components/TheFold'),
+	TheFold: require('./components/TheFold').default,
 	History: require('./components/History'),
 	navigateTo: require('./util/navigateTo'),
 	ClientRequest: require('./ClientRequest'),


### PR DESCRIPTION
Turns out the add-module-exports babel plugin doesn't work when there are
multiple exports from a module (as there are for TheFold).  Makes sense.