### PR TITLE
Add a package with JSON response middleware

### DIFF
--- a/packages/react-server-middleware-json-response/.babelrc
+++ b/packages/react-server-middleware-json-response/.babelrc
@@ -1,0 +1,4 @@
+{
+	"presets": ["react-server"],
+	"plugins": ["add-module-exports"]
+}

--- a/packages/react-server-middleware-json-response/README.md
+++ b/packages/react-server-middleware-json-response/README.md
@@ -1,0 +1,17 @@
+# JSON Response middleware for React Server
+
+Use this middleware to return a JSON-serialized object from a React Server page.
+
+```javascript
+import JsonResponseMiddleware from "react-server-middleware-json-response"
+
+export default class DataEndpoint {
+    static middleware() {
+        return [JsonResponseMiddleware];
+    }
+
+    getResponseData() {
+        return { result: "OK!" };
+    }
+}
+```

--- a/packages/react-server-middleware-json-response/index.src.js
+++ b/packages/react-server-middleware-json-response/index.src.js
@@ -1,0 +1,14 @@
+export default class JsonResponseMiddleware {
+
+	setConfigValues() {
+		return { isRawResponse: true };
+	}
+
+	getContentType(next) {
+		return next() || 'application/json';
+	}
+
+	getResponseData(next) {
+		return next().then(data => JSON.stringify(data));
+	}
+}

--- a/packages/react-server-middleware-json-response/package.json
+++ b/packages/react-server-middleware-json-response/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "react-server-middleware-json-response",
+  "version": "0.4.10",
+  "description": "JSON response middleware for React Server",
+  "main": "index.js",
+  "scripts": {
+    "prepublish": "npm run build",
+    "build": "babel index.src.js --out-file index.js",
+    "clean": "rm index.js",
+    "test": "eslint src"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/redfin/react-server.git"
+  },
+  "keywords": [
+    "react",
+    "server",
+    "json",
+    "middleware"
+  ],
+  "author": "Bo Borgerson",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/redfin/react-server/issues"
+  },
+  "homepage": "https://github.com/redfin/react-server#readme",
+  "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-react-server": "^0.4.10",
+    "eslint": "^3.8.1",
+    "eslint-plugin-react": "^6.4.1",
+    "babel-eslint": "^7.0.0"
+  }
+}

--- a/packages/react-server-test-pages/package.json
+++ b/packages/react-server-test-pages/package.json
@@ -21,6 +21,7 @@
     "react-server": "^0.4.11",
     "react-server-cli": "^0.4.10",
     "react-server-data-bundle-cache": "^0.4.10",
+    "react-server-middleware-json-response": "^0.4.10",
     "eslint-plugin-react": "^6.4.1"
   },
   "devDependencies": {

--- a/packages/react-server-test-pages/pages/data/delay.js
+++ b/packages/react-server-test-pages/pages/data/delay.js
@@ -1,18 +1,18 @@
 import Q from "q";
 import _ from "lodash";
+import JsonResponseMiddleware from "react-server-middleware-json-response"
 
 const BIG = n => _.range(+n).reduce((m, v) => (m['element_'+v] = v, m), {})
 
 export default class DelayDataPage {
-	setConfigValues() {
-		return { isRawResponse: true };
+
+	static middleware() {
+		return [JsonResponseMiddleware];
 	}
-	getContentType() {
-		return 'application/json';
-	}
+
 	getResponseData() {
 		const { ms, val, big } = this.getRequest().getQuery();
 		return Q.delay(ms||0)
-			.then(() => val||JSON.stringify(big?BIG(big):{'ok':true}));
+			.then(() => val?JSON.parse(val):(big?BIG(big):{'ok':true}));
 	}
 }


### PR DESCRIPTION
This just handles some of the boilerplate involved with setting up a JSON
endpoint in React Server.

Example (from the README):

```javascript
import JsonResponseMiddleware from "react-server-middleware-json-response"

export default class DataEndpoint {
    static middleware() {
        return [JsonResponseMiddleware];
    }

    getResponseData() {
        return { result: "OK!" };
    }
}
```