### PR TITLE
Override default Content-Type in JSON response middleware

### DIFF
--- a/packages/react-server-middleware-json-response/index.src.js
+++ b/packages/react-server-middleware-json-response/index.src.js
@@ -4,8 +4,8 @@ export default class JsonResponseMiddleware {
 		return { isRawResponse: true };
 	}
 
-	getContentType(next) {
-		return next() || 'application/json';
+	getContentType() {
+		return 'application/json';
 	}
 
 	getResponseData(next) {


### PR DESCRIPTION
The default Content-Type is non-empty.

We should probably default externally... :thinking: