### PR TITLE
Fixes issue where client-side 404s were getting swallowed

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -419,6 +419,8 @@ class ClientController extends EventEmitter {
 	}
 
 	_handleDebugParams(page) {
+		if (!page) return;
+
 		const params = page.getRequest().getQuery();
 
 		// Allow adjustment of log levels.


### PR DESCRIPTION
If route can't be found, no `page` class is set, and we were
throwing an error about `page` being undefined instead of logging
the 404.

I toyed with just moving the `_handleDebugParams` call after the `if (err)` on line ~347, but it seems like we could theoretically be getting page-specified errors here, in which case it seems like we would want to check the debug params (maybe?)