### PR TITLE
Add additional fields to the Request objects

### DIFF
--- a/packages/react-server/core/ClientRequest.js
+++ b/packages/react-server/core/ClientRequest.js
@@ -63,6 +63,28 @@ class ClientRequest {
 		return decode(this._url.substring(indexOfQuestion + 1));
 	}
 
+	getHostname() {
+		var hostname = null;
+		if (typeof window.location.hostname === "string") {
+			hostname = window.location.hostname;
+		}
+
+		return hostname;
+	}
+
+	getProtocol() {
+		var proto = null;
+		if (typeof window.location.protocol === "string") {
+			proto = window.location.protocol.replace(/:/g,'');
+		}
+
+		return proto;
+	}
+
+	getSecure() {
+		return ('https' === this.getProtocol());
+	}
+
 	getRouteParams() {
 		return this._route.params;
 	}

--- a/packages/react-server/core/ExpressServerRequest.js
+++ b/packages/react-server/core/ExpressServerRequest.js
@@ -20,6 +20,18 @@ class ExpressServerRequest {
 		return this._wrappedRequest.query;
 	}
 
+	getHostname() {
+		return this._wrappedRequest.hostname;
+	}
+
+	getProtocol() {
+		return this._wrappedRequest.protocol;
+	}
+
+	getSecure() {
+		return this._wrappedRequest.secure;
+	}
+
 	getRouteParams() {
 		return this._route.params;
 	}


### PR DESCRIPTION
Request objects available through `this.getRequest()` in middleware and elsewhere in the codebase provide access to the path and query portions of a URI (`scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]`).  This PR incorporates changes to the client and server side request wrappers to return scheme, host, and "secure" (matches the ExpressJS request object) values.  This does not address port, user, password, or fragment at this time.  The client implementation uses `window.location` if available and falls back to returning null.  The server implementation uses the ExpressJS request object.