### PR TITLE
Allows separating public host name from server IP address binding

### DIFF
--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -23,7 +23,7 @@ export default function start(options){
 
 	const {
 		port,
-		host,
+		bindIp,
 		jsPort,
 		hot,
 		jsUrl,
@@ -47,14 +47,14 @@ export default function start(options){
 
 		logger.notice("Starting servers...")
 
-		const jsServer = startJsServer(compiler, jsPort, host, longTermCaching, httpsOptions);
-		const htmlServerPromise = serverRoutes.then(serverRoutesFile => startHtmlServer(serverRoutesFile, port, host, httpsOptions, customMiddlewarePath));
+		const jsServer = startJsServer(compiler, jsPort, bindIp, longTermCaching, httpsOptions);
+		const htmlServerPromise = serverRoutes.then(serverRoutesFile => startHtmlServer(serverRoutesFile, port, bindIp, httpsOptions, customMiddlewarePath));
 
 		return {
 			stop: () => Promise.all([jsServer.stop(), htmlServerPromise.then(server => server.stop())]),
 			started: Promise.all([jsServer.started, htmlServerPromise.then(server => server.started)])
 				.catch(e => {logger.error(e); throw e})
-				.then(() => logger.notice(`Ready for requests on host ${host}:${port}.`)),
+				.then(() => logger.notice(`Ready for requests on ${bindIp}:${port}.`)),
 		};
 	}
 
@@ -65,7 +65,7 @@ export default function start(options){
 // given the server routes file and a port, start a react-server HTML server at
 // http://host:port/. returns an object with two properties, started and stop;
 // see the default function doc for explanation.
-const startHtmlServer = (serverRoutes, port, host, httpsOptions, customMiddlewarePath) => {
+const startHtmlServer = (serverRoutes, port, bindIp, httpsOptions, customMiddlewarePath) => {
 	const server = express();
 	const httpServer = httpsOptions ? https.createServer(httpsOptions, server) : http.createServer(server);
 	let middlewareSetup = (server, rsMiddleware) => {
@@ -104,12 +104,12 @@ const startHtmlServer = (serverRoutes, port, host, httpsOptions, customMiddlewar
 				console.error(e);
 				reject(e);
 			});
-			httpServer.listen(port, host, (e) => {
+			httpServer.listen(port, bindIp, (e) => {
 				if (e) {
 					reject(e);
 					return;
 				}
-				logger.info(`Started HTML server over ${httpsOptions ? "HTTPS" : "HTTP"} on host ${host}:${port}`);
+				logger.info(`Started HTML server over ${httpsOptions ? "HTTPS" : "HTTP"} on ${bindIp}:${port}`);
 				resolve();
 			});
 		}),
@@ -120,7 +120,7 @@ const startHtmlServer = (serverRoutes, port, host, httpsOptions, customMiddlewar
 // files and start up a web server at http://host:port/ that serves the
 // static compiled JavaScript. returns an object with two properties, started and stop;
 // see the default function doc for explanation.
-const startStaticJsServer = (compiler, port, host, longTermCaching, httpsOptions) => {
+const startStaticJsServer = (compiler, port, bindIp, longTermCaching, httpsOptions) => {
 	const server = express();
 	const httpServer = httpsOptions ? https.createServer(httpsOptions, server) : http.createServer(server);
 	return {
@@ -145,13 +145,13 @@ const startStaticJsServer = (compiler, port, host, longTermCaching, httpsOptions
 					console.error(e);
 					reject(e)
 				});
-				httpServer.listen(port, host, (e) => {
+				httpServer.listen(port, bindIp, (e) => {
 					if (e) {
 						reject(e);
 						return;
 					}
 
-					logger.info(`Started static JavaScript server over ${httpsOptions ? "HTTPS" : "HTTP"} on host ${host}:${port}`);
+					logger.info(`Started static JavaScript server over ${httpsOptions ? "HTTPS" : "HTTP"} on ${bindIp}:${port}`);
 					resolve();
 				});
 			});
@@ -163,7 +163,7 @@ const startStaticJsServer = (compiler, port, host, longTermCaching, httpsOptions
 // for hot reloading at http://localhost:port/. note that the webpack compiler
 // must have been configured correctly for hot reloading. returns an object with
 // two properties, started and stop; see the default function doc for explanation.
-const startHotLoadJsServer = (compiler, port, host, longTermCaching, httpsOptions) => {
+const startHotLoadJsServer = (compiler, port, bindIp, longTermCaching, httpsOptions) => {
 	logger.info("Starting hot reload JavaScript server...");
 	const compiledPromise = new Promise((resolve) => compiler.plugin("done", () => resolve()));
 	const jsServer = new WebpackDevServer(compiler, {
@@ -176,7 +176,7 @@ const startHotLoadJsServer = (compiler, port, host, longTermCaching, httpsOption
 		ca: httpsOptions ? httpsOptions.ca : undefined,
 	});
 	const serverStartedPromise = new Promise((resolve, reject) => {
-		jsServer.listen(port, host, (e) => {
+		jsServer.listen(port, bindIp, (e) => {
 			if (e) {
 				reject(e);
 				return;
@@ -187,7 +187,7 @@ const startHotLoadJsServer = (compiler, port, host, longTermCaching, httpsOption
 	return {
 		stop: serverToStopPromise(jsServer),
 		started: Promise.all([compiledPromise, serverStartedPromise])
-			.then(() => logger.info(`Started hot reload JavaScript server over ${httpsOptions ? "HTTPS" : "HTTP"} on host ${host}:${port}`)),
+			.then(() => logger.info(`Started hot reload JavaScript server over ${httpsOptions ? "HTTPS" : "HTTP"} on ${bindIp}:${port}`)),
 	};
 };
 

--- a/packages/react-server-cli/src/defaultOptions.js
+++ b/packages/react-server-cli/src/defaultOptions.js
@@ -15,6 +15,7 @@ export default {
 	host: "localhost",
 	port:3000,
 	jsPort: 3001,
+	bindIp: "0.0.0.0",
 	hot: true,
 	minify: false,
 	compileOnly: false,

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -22,6 +22,10 @@ export default (args = process.argv) => {
 			describe: "Port to start listening for react-server's JavaScript. Default is 3001.",
 			type: "number",
 		})
+		.option("bind-ip", {
+			describe: "IP address to bind to. Default: 0.0.0.0 (any)",
+			type: "string",
+		})
 		.option("https", {
 			describe: "If true, the server will start up using https with a self-signed certificate. Note that browsers do not trust self-signed certificates by default, so you will have to click through some warning screens. This is a quick and dirty way to test HTTPS, but it has some limitations and should never be used in production. Requires OpenSSL to be installed. Default is false.",
 			default: undefined,

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -15,7 +15,7 @@ export default (args = process.argv) => {
 			type: "number",
 		})
 		.option("host", {
-			describe: "Hostname to start listening for react-server",
+			describe: "The public host name combined with js-port used to construct URLs for static content. Ignored when js-url is set.",
 			type: "string",
 		})
 		.option("js-port", {


### PR DESCRIPTION
I was playing around w/ `react-server` in cloud9's IDE (https://c9.io/) and ran into an issue where passing --`host` into the server listen (the default behavior of `react-server-cli`) did the wrong thing. I _think_ the issue is due to cloud9's environment being containers running on a VM, where multiple public hostnames share the same public IP address, and the port that is presented to the container is not the actual physical port on the machine.

This PR separates the hostname given for loading resources like JS/CSS from the IP address that the server binds to, defaulting to binding to any IP address.

This fixes the issue for me (after I hand-modify the RequestToPort middleware so that it doesn't assume port 3000 :grin:) However, container networking isn't necessarily my forte, so if there are other/better ideas on how to fix the issue, I would love to hear them.