### PR TITLE
Fix bug with displayAboveTheFold logging

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -82,12 +82,12 @@ class ClientController extends EventEmitter {
 		this._failDfd = Q.defer();
 
 		// Log this after loglevel is set.
-		logTimingData('wakeFromStart', window._reactServerTimingStart);
+		logTimingData('wakeFromStart', window.__reactServerTimingStart);
 
 		performanceMark('wake');
 
 		// this is a proxy for when above the fold content gets painted (displayed) on the browser
-		logTimingData('displayAboveTheFold.fromStart', window._reactServerTimingStart, window.__displayAboveTheFold);
+		logTimingData('displayAboveTheFold.fromStart', window.__reactServerTimingStart, window.__displayAboveTheFold);
 	}
 
 	terminate() {


### PR DESCRIPTION
displayAboveTheFold metric is used to track when the browser displays all the contents above `TheFold`. We were using the wrong start time while logging this stat.