### PR TITLE
Add CLI argument for configuration path

### DIFF
--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -295,6 +295,11 @@ Path to your webpack options callback function file.
 
 Defaults to **undefined**.
 
+#### --config-path
+Path to configuration files such as .reactserverrc, .eslintrc and .babelrc.
+
+Defaults to **undefined**.
+
 #### --long-term-caching
 Adds hashes to all JavaScript and CSS file names output by the build, allowing
 for the static files to be served with far-future expires headers. This option

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -296,7 +296,7 @@ Path to your webpack options callback function file.
 Defaults to **undefined**.
 
 #### --config-path
-Path to configuration files such as .reactserverrc, .eslintrc and .babelrc.
+Path to configuration files such as .reactserverrc, .eslintrc and .babelrc. This option may be useful in the case that your configuration files are not in the root of the project.
 
 Defaults to **undefined**.
 

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -3,7 +3,10 @@ const path = require("path");
 const cli = require(".");
 
 cli.parseCliArgs().then(args => {
-	const config = args.configPath ? JSON.parse(fs.readFileSync(path.join(args.configPath, ".babelrc"))) : {};
+	const babelrcPath = path.join(args.configPath, ".babelrc");
+	const config = args.configPath && fs.existsSync(babelrcPath) ?
+		JSON.parse(fs.readFileSync(babelrcPath)) :
+		{};
 	require("babel-core/register")(config);
 	cli.run(args);
 }).catch(console.error);

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -3,7 +3,7 @@ const path = require("path");
 const cli = require(".");
 
 cli.parseCliArgs().then(args => {
-  const config = args.configPath ? JSON.parse(fs.readFileSync(path.join(args.configPath, ".babelrc"))) : {};
-  require("babel-core/register")(config);
-  cli.run(args);
+	const config = args.configPath ? JSON.parse(fs.readFileSync(path.join(args.configPath, ".babelrc"))) : {};
+	require("babel-core/register")(config);
+	cli.run(args);
 }).catch(console.error);

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -3,8 +3,9 @@ const path = require("path");
 const cli = require(".");
 
 cli.parseCliArgs().then(args => {
-	const babelrcPath = path.join(args.configPath, ".babelrc");
-	const config = args.configPath && fs.existsSync(babelrcPath) ?
+	const {configPath = ''} = args;
+	const babelrcPath = path.join(configPath, ".babelrc");
+	const config = configPath && fs.existsSync(babelrcPath) ?
 		JSON.parse(fs.readFileSync(babelrcPath)) :
 		{};
 	require("babel-core/register")(config);

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -1,4 +1,9 @@
-require("babel-core/register");
-
+const fs = require("fs");
+const path = require("path");
 const cli = require(".");
-cli.parseCliArgs().then(cli.run).catch(console.error);
+
+cli.parseCliArgs().then(args => {
+  const config = args.configPath ? JSON.parse(fs.readFileSync(path.join(args.configPath, ".babelrc"))) : {};
+  require("babel-core/register")(config);
+  cli.run(args);
+}).catch(console.error);

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -163,7 +163,7 @@ function statsToManifest(stats) {
 function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, longTermCaching, stats, configPath) {
 	const NonCachingExtractTextLoader = path.join(__dirname, "./NonCachingExtractTextLoader");
 	const extractTextLoader = require.resolve(NonCachingExtractTextLoader) + "?{remove:true}!css-loader";
-	const babelrcPath = path.join(configPath, ".babelrc");
+	const babelrcPath = path.join(configPath || '', ".babelrc");
 	const babelConfig = configPath && fs.existsSync(babelrcPath) ?
 		JSON.parse(fs.readFileSync(babelrcPath)) :
 		{};

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -24,6 +24,7 @@ export default (opts = {}) => {
 	const {
 		routes,
 		webpackConfig,
+		configPath,
 		workingDir = "./__clientTemp",
 		routesDir = ".",
 		outputDir = workingDir + "/build",
@@ -93,7 +94,7 @@ export default (opts = {}) => {
 	writeWebpackCompatibleRoutesFile(routes, routesDir, workingDirAbsolute, null, true);
 
 	// finally, let's pack this up with webpack.
-	const compiler = webpack(webpackConfigFunc(packageCodeForBrowser(entrypoints, outputDirAbsolute, outputUrl, hot, minify, longTermCaching, stats)));
+	const compiler = webpack(webpackConfigFunc(packageCodeForBrowser(entrypoints, outputDirAbsolute, outputUrl, hot, minify, longTermCaching, stats, configPath)));
 
 	const serverRoutes = new Promise((resolve) => {
 		compiler.plugin("done", (stats) => {
@@ -159,9 +160,10 @@ function statsToManifest(stats) {
 	};
 }
 
-function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, longTermCaching, stats) {
+function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, longTermCaching, stats, configPath) {
 	const NonCachingExtractTextLoader = path.join(__dirname, "./NonCachingExtractTextLoader");
 	const extractTextLoader = require.resolve(NonCachingExtractTextLoader) + "?{remove:true}!css-loader";
+	const babelConfig = configPath ? JSON.parse(fs.readFileSync(path.join(configPath, ".babelrc"))) : {};
 	let webpackConfig = {
 		entry: entrypoints,
 		output: {
@@ -177,6 +179,7 @@ function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, l
 					test: /\.jsx?$/,
 					loader: "babel",
 					exclude: /node_modules/,
+					query: babelConfig,
 				},
 				{
 					test: /\.css$/,

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -163,7 +163,10 @@ function statsToManifest(stats) {
 function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, longTermCaching, stats, configPath) {
 	const NonCachingExtractTextLoader = path.join(__dirname, "./NonCachingExtractTextLoader");
 	const extractTextLoader = require.resolve(NonCachingExtractTextLoader) + "?{remove:true}!css-loader";
-	const babelConfig = configPath ? JSON.parse(fs.readFileSync(path.join(configPath, ".babelrc"))) : {};
+	const babelrcPath = path.join(configPath, ".babelrc");
+	const babelConfig = configPath && fs.existsSync(babelrcPath) ?
+		JSON.parse(fs.readFileSync(babelrcPath)) :
+		{};
 	let webpackConfig = {
 		entry: entrypoints,
 		output: {

--- a/packages/react-server-cli/src/findOptionsInFiles.js
+++ b/packages/react-server-cli/src/findOptionsInFiles.js
@@ -18,7 +18,7 @@ export default (args = process.argv) => {
 
 	do {
 		let reactServerRc = null;
-		let configPath = args.configPath || '';
+		const {configPath = ''} = args;
 		try {
 			// readFileSync throws if the file doesn't exist.
 			reactServerRc = fs.readFileSync(path.join(dir, configPath, REACT_SERVER_RC));

--- a/packages/react-server-cli/src/findOptionsInFiles.js
+++ b/packages/react-server-cli/src/findOptionsInFiles.js
@@ -18,7 +18,7 @@ export default (args = process.argv) => {
 
 	do {
 		let reactServerRc = null;
-		let configPath = args.configPath;
+		let configPath = args.configPath || '';
 		try {
 			// readFileSync throws if the file doesn't exist.
 			reactServerRc = fs.readFileSync(path.join(dir, configPath, REACT_SERVER_RC));

--- a/packages/react-server-cli/src/findOptionsInFiles.js
+++ b/packages/react-server-cli/src/findOptionsInFiles.js
@@ -13,12 +13,15 @@ const PACKAGE_JSON = "package.json";
 // the package.json. if it finds neither, it goes up a directory and looks again.
 // it returns the contents of the first config file found; it never merges multiple
 // configurations.
-export default (dir = process.cwd()) => {
+export default (args = process.argv) => {
+	let dir = process.cwd();
+
 	do {
 		let reactServerRc = null;
+		let configPath = args.configPath;
 		try {
 			// readFileSync throws if the file doesn't exist.
-			reactServerRc = fs.readFileSync(path.join(dir, REACT_SERVER_RC));
+			reactServerRc = fs.readFileSync(path.join(dir, configPath, REACT_SERVER_RC));
 		} catch (e) {} //eslint-disable-line no-empty
 		if (reactServerRc) {
 			return JSON.parse(reactServerRc);

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -107,6 +107,11 @@ export default (args = process.argv) => {
 			default: false,
 			type: "boolean",
 		})
+		.option("config-path", {
+			describe: "Path to configuration files such as .reactserverrc, .eslintrc and .babelrc.",
+			default: undefined,
+			type: "string",
+		})
 		.version(function() {
 			return require('../package').version;
 		})

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -11,7 +11,7 @@ export default function run(options = {}) {
 	// for the option properties that weren't sent in, look for a config file
 	// (either .reactserverrc or a reactServer section in a package.json). for
 	// options neither passed in nor in a config file, use the defaults.
-	options = mergeOptions(defaultOptions, findOptionsInFiles() || {}, options);
+	options = mergeOptions(defaultOptions, findOptionsInFiles(options) || {}, options);
 
 	const {
 		routesFile,

--- a/packages/react-server-cli/test/fixtures/commands/start-reactserverrc-configPath/in-files/config/.reactserverrc
+++ b/packages/react-server-cli/test/fixtures/commands/start-reactserverrc-configPath/in-files/config/.reactserverrc
@@ -1,0 +1,5 @@
+{
+	"routesFile": "customRoutes.js",
+	"port": 5000,
+	"jsPort": 5001
+}

--- a/packages/react-server-cli/test/fixtures/commands/start-reactserverrc-configPath/in-files/customRoutes.js
+++ b/packages/react-server-cli/test/fixtures/commands/start-reactserverrc-configPath/in-files/customRoutes.js
@@ -1,0 +1,3 @@
+module.exports = {
+	routes: {}
+};

--- a/packages/react-server-cli/test/fixtures/commands/start-reactserverrc-configPath/options.json
+++ b/packages/react-server-cli/test/fixtures/commands/start-reactserverrc-configPath/options.json
@@ -1,0 +1,4 @@
+{
+	"args": ["start", "--config-path", "config"],
+	"stdoutIncludes": "Started HTML server over HTTP on"
+}


### PR DESCRIPTION
**Disclaimer** This pull request was closed because of:
- [alternative ways to include configuration files](https://github.com/redfin/react-server/pull/804#discussion_r98417797)
- there was no concrete need for this at the time of writing
- less configuration is better

Hi, firstly I would like to thank the contributors for all their hard work on this important project! It pushes the state of the art for universal rendering to new limits and introduces ideas such as streaming that hopefully make their way back into React itself at some point.

During integration of `react-server` in a project, we ran into an issue with the configuration files. Certain projects such as those set up with `create-react-app` (and ours) decide to keep their configuration files such as `.babelrc` and `.eslintrc` in a non-project-root location. We came up with the idea of configuring the path to these files via a command line argument, which is what resulted in this proof of concept pull request.

Since then our requirements have changed and we will keep the files in the root after all. Because of this and because I wasn't sure what response this was going to get, I didn't take this further than a first proof of concept. Feel free to reject this, since the best use case that I can present is that it improves configurability for projects structured this way.

However, if this configuration option is of interest to you, I will add the following to this pull request:

- [x] Documentation
- [x] Tests
- [x] #828 merged

Thanks!