### PR TITLE
Test page for page forwarding

### DIFF
--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -29,6 +29,10 @@ module.exports = {
 		entry: "/navigation/playground",
 		description: "Navigation playground",
 	},
+	Forwarding: {
+		entry: "/navigation/forward",
+		description: "Test how page forwarding works with passing data down",
+	},
 	StylePromises: {
 		entry: "/styles/promises",
 		description: "Stylesheets returned from promises",

--- a/packages/react-server-test-pages/pages/navigation/forward.js
+++ b/packages/react-server-test-pages/pages/navigation/forward.js
@@ -17,7 +17,7 @@ export default class ForwardPage {
 			//then depending on said data, forward to one of two pages, and pass along the data we pre-fetched
 			if (res.body % 2 === 0) {
 				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
-					require.ensure(["./forwardEven"], () => {
+					return require.ensure(["./forwardEven"], () => {
 						return {
 							page: require("./forwardEven").default,
 						};
@@ -29,7 +29,7 @@ export default class ForwardPage {
 				}
 			} else {
 				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
-					require.ensure(["./forwardOdd"], () => {
+					return require.ensure(["./forwardOdd"], () => {
 						return {
 							page: require("./forwardOdd").default,
 						};

--- a/packages/react-server-test-pages/pages/navigation/forward.js
+++ b/packages/react-server-test-pages/pages/navigation/forward.js
@@ -16,7 +16,8 @@ export default class ForwardPage {
 		return this.data.then((res) => {
 			//then depending on said data, forward to one of two pages, and pass along the data we pre-fetched
 			const pageName = (res.body % 2 === 0) ? "./forwardEven" : "./forwardOdd";
-            if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
+			// TODO: change this to use isBrowser when that check is available.
+            if (typeof window !== 'undefined') {
             	return require.ensure([pageName], () => {
 	            	return {
 	            		page: require(pageName).default,

--- a/packages/react-server-test-pages/pages/navigation/forward.js
+++ b/packages/react-server-test-pages/pages/navigation/forward.js
@@ -17,17 +17,17 @@ export default class ForwardPage {
 			//then depending on said data, forward to one of two pages, and pass along the data we pre-fetched
 			const pageName = (res.body % 2 === 0) ? "./forwardEven" : "./forwardOdd";
 			// TODO: change this to use isBrowser when that check is available.
-            if (typeof window !== 'undefined') {
-            	return require.ensure([pageName], () => {
-	            	return {
-	            		page: require(pageName).default,
-	            	};
-            	});
-            } else {
-            	return {
-	            	page: require(pageName).default,
-            	};
-            }
+			if (typeof window !== 'undefined') {
+				return require.ensure([pageName], () => {
+					return {
+						page: require(pageName).default,
+					};
+				});
+			} else {
+				return {
+					page: require(pageName).default,
+				};
+			}
 		});
 	}
 

--- a/packages/react-server-test-pages/pages/navigation/forward.js
+++ b/packages/react-server-test-pages/pages/navigation/forward.js
@@ -1,0 +1,50 @@
+import {ReactServerAgent} from "react-server";
+
+export default class ForwardPage {
+	handleRoute() {
+		const request = this.getRequest();
+		let params = request.getQuery();
+		if (params) {
+			params = params.value;
+		} else {
+			params = 0;
+		}
+
+		//fetch some data
+		this.data = ReactServerAgent.get('/data/delay?ms=1000&val='+params);
+
+		return this.data.then((res) => {
+			//then depending on said data, forward to one of two pages, and pass along the data we pre-fetched
+			if (res.body % 2 === 0) {
+				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
+					require.ensure(["./forwardEven"], () => {
+						return {
+							page: require("./forwardEven").default,
+						};
+					});
+				} else {
+					return {
+						page: require("./forwardEven").default,
+					};
+				}
+			} else {
+				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
+					require.ensure(["./forwardOdd"], () => {
+						return {
+							page: require("./forwardOdd").default,
+						};
+					});
+				} else {
+					return {
+						page: require("./forwardOdd").default,
+					};
+				}
+			}
+		});
+	}
+
+	getElements() {
+		return <div>boop</div>;
+	}
+}
+

--- a/packages/react-server-test-pages/pages/navigation/forward.js
+++ b/packages/react-server-test-pages/pages/navigation/forward.js
@@ -15,31 +15,18 @@ export default class ForwardPage {
 
 		return this.data.then((res) => {
 			//then depending on said data, forward to one of two pages, and pass along the data we pre-fetched
-			if (res.body % 2 === 0) {
-				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
-					return require.ensure(["./forwardEven"], () => {
-						return {
-							page: require("./forwardEven").default,
-						};
-					});
-				} else {
-					return {
-						page: require("./forwardEven").default,
-					};
-				}
-			} else {
-				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
-					return require.ensure(["./forwardOdd"], () => {
-						return {
-							page: require("./forwardOdd").default,
-						};
-					});
-				} else {
-					return {
-						page: require("./forwardOdd").default,
-					};
-				}
-			}
+			const pageName = (res.body % 2 === 0) ? "./forwardEven" : "./forwardOdd";
+            if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
+            	return require.ensure([pageName], () => {
+	            	return {
+	            		page: require(pageName).default,
+	            	};
+            	});
+            } else {
+            	return {
+	            	page: require(pageName).default,
+            	};
+            }
 		});
 	}
 

--- a/packages/react-server-test-pages/pages/navigation/forwardEven.js
+++ b/packages/react-server-test-pages/pages/navigation/forwardEven.js
@@ -1,0 +1,23 @@
+import {ReactServerAgent, RootElement} from "react-server";
+
+const Even = ({body}) => <div className="even">Hey look I'm even because I am {body}</div>;
+
+export default class ForwardEvenPage {
+	handleRoute() {
+		const request = this.getRequest();
+		let params = request.getQuery();
+		if (params) params = params.value;
+		else params = 0;
+
+		//fetch some data (should be from cache)
+		this.data = ReactServerAgent.get('/data/delay?ms=1000&val='+params);
+
+		return {code: 200};
+	}
+
+	getElements() {
+		return [
+			<RootElement when={this.data}><Even /></RootElement>,
+		];
+	}
+}

--- a/packages/react-server-test-pages/pages/navigation/forwardOdd.js
+++ b/packages/react-server-test-pages/pages/navigation/forwardOdd.js
@@ -1,0 +1,23 @@
+import {ReactServerAgent, RootElement} from "react-server";
+
+const Odd = ({body}) => <div className="odd">Hey look I'm odd because I am {body}</div>;
+
+export default class ForwardOddPage {
+	handleRoute() {
+		const request = this.getRequest();
+		let params = request.getQuery();
+		if (params) params = params.value;
+		else params = 0;
+
+		//fetch some data (should be from cache)
+		this.data = ReactServerAgent.get('/data/delay?ms=1000&val='+params);
+
+		return {code: 200};
+	}
+
+	getElements() {
+		return [
+			<RootElement when={this.data}><Odd /></RootElement>,
+		];
+	}
+}


### PR DESCRIPTION
Specifically, to make sure that data can be passed down from the forwarding page to the forwarded-to page via the data cache, and that we can do code splitting between the forwarded-to pages. (Requirements for a particular use case I'm anticipating.)