### PR TITLE
Fix import inconsistencies in page-writing guide

### DIFF
--- a/docs/guides/writing-pages.md
+++ b/docs/guides/writing-pages.md
@@ -61,10 +61,10 @@ A `react-server` page that serves a full webpage.
 
 ```js
 import HttpStatus from 'http-status-codes';
-import MobileEnabled from ('./middleware/MobileEnabled');
-const ExampleComponent = require("./components/example-component");
-const ExampleStore = require("./stores/example-store");
-const exampleAction = require("./actions/example-action");
+import MobileEnabled from './middleware/MobileEnabled';
+import ExampleComponent from './components/example-component';
+import ExampleStore from './stores/example-store';
+import exampleAction from './actions/example-action';
 
 class ExamplePage {
 	// See [writing middleware](/docs/writing-middleware) for how to write middleware
@@ -122,9 +122,9 @@ class ExamplePage {
 
 ```js
 // returns a promise for example data
-const getExampleData = require("./helpers/get-example-data");
+import getExampleData from './helpers/get-example-data';
 
-module.exports = class ExampleJsonPage {
+export default class ExampleJsonPage {
 
 	// see the example in [writing middleware](/docs/writing-middleware)
 	static middleware() { return [JsonEndpoint] }
@@ -147,8 +147,8 @@ For instance, to make a page into a fragment by setting the `isFragment` config
 value
 
 ```js
-const exampleComponent = require("./components/example-component");
-const exampleStore = require("./stores/example-store");
+import exampleComponent from './components/example-component';
+import exampleStore from './stores/example-store';
 
 export default class ExampleFragmentPage {
 	setConfigValues() { return { isFragment: true }; }
@@ -172,7 +172,7 @@ export default class ExampleFragmentPage {
 	}
 }
 
-module.exports = ExamplePage;
+export default ExamplePage;
 ```
 
 


### PR DESCRIPTION
Came across this when I was reading through the docs for React Server and integrating it into my project. Copied over the component just to get a sense of it in my text editor and the linter immediately caught `import x from ('y');`. Guessing this was just leftovers from converting things to import syntax, or at least that's what's happened to me before :) For the sake of consistency I changed the rest of the exports to be in line, not sure if that's not preferred for some reason I can't think of. Absolutely love the lib, phenomenal work everyone! 👍 