### PR TITLE
ignore react-server-middleware-json-response's index.js

### DIFF
--- a/packages/react-server-middleware-json-response/.gitignore
+++ b/packages/react-server-middleware-json-response/.gitignore
@@ -1,0 +1,1 @@
+index.js


### PR DESCRIPTION
I've had an untracked `packages/react-server-middleware-json-response/index.js` floating around for a bit.