### PR TITLE
Remove asini run prepublish since it doesn't run in topo order

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -4,8 +4,7 @@
 - `npm config get registry`
     - Make sure it's `https://registry.npmjs.org/`
 - `npm run clean`
-- optionally: `npm run nuke && npm run bootstrap`
-- `asini run prepublish`
+- `npm run nuke && npm run bootstrap`
 - `npm test`
 - `export GITHUB_AUTH="..."`
 - `npm run changelog >> CHANGELOG.md`


### PR DESCRIPTION
Error:

```
» asini run prepublish                                                                                                                       1 ↵

> react-server-core-middleware@0.4.10 prepublish /Users/dwade/foss/react-server/packages/react-server-core-middleware
> npm run build


> react-server-core-middleware@0.4.10 build /Users/dwade/foss/react-server/packages/react-server-core-middleware
> babel src -d lib


NpmUtilities.execInDir        ("run prepublish", [], "./packages/react-server-core-middleware")

> react-server-core-middleware@0.4.10 prepublish /Users/dwade/foss/react-server/packages/react-server-core-middleware
> npm run build


> react-server-core-middleware@0.4.10 build /Users/dwade/foss/react-server/packages/react-server-core-middleware
> babel src -d lib


NpmUtilities.runScriptInDir   ("prepublish", [], "./packages/react-server-core-middleware")

> react-server-core-middleware@0.4.10 prepublish /Users/dwade/foss/react-server/packages/react-server-core-middleware
> npm run build


> react-server-core-middleware@0.4.10 build /Users/dwade/foss/react-server/packages/react-server-core-middleware
> babel src -d lib


Errored while running npm script 'prepublish' in 'react-server-core-middleware'
Error: Command failed: npm run prepublish
Error: Cannot find module 'babel-plugin-react-server' (While processing preset: "/Users/dwade/foss/react-server/packages/babel-preset-react-server/index.js")
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/dwade/foss/react-server/packages/babel-preset-react-server/index.js:3:5)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/dwade/n/bin/node" "/Users/dwade/n/bin/npm" "run" "build"
npm ERR! node v6.9.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! react-server-core-middleware@0.4.10 build: `babel src -d lib`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-core-middleware@0.4.10 build script 'babel src -d lib'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-server-core-middleware package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     babel src -d lib
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-server-core-middleware
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-server-core-middleware
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dwade/foss/react-server/packages/react-server-core-middleware/npm-debug.log

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/dwade/n/bin/node" "/Users/dwade/n/bin/npm" "run" "prepublish"
npm ERR! node v6.9.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! react-server-core-middleware@0.4.10 prepublish: `npm run build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-core-middleware@0.4.10 prepublish script 'npm run build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-server-core-middleware package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-server-core-middleware
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-server-core-middleware
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dwade/foss/react-server/packages/react-server-core-middleware/npm-debug.log

    at ChildProcess.exithandler (child_process.js:206:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
Errored while running RunCommand.execute
Error: Command failed: npm run prepublish
Error: Cannot find module 'babel-plugin-react-server' (While processing preset: "/Users/dwade/foss/react-server/packages/babel-preset-react-server/index.js")
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/dwade/foss/react-server/packages/babel-preset-react-server/index.js:3:5)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/dwade/n/bin/node" "/Users/dwade/n/bin/npm" "run" "build"
npm ERR! node v6.9.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! react-server-core-middleware@0.4.10 build: `babel src -d lib`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-core-middleware@0.4.10 build script 'babel src -d lib'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-server-core-middleware package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     babel src -d lib
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-server-core-middleware
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-server-core-middleware
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dwade/foss/react-server/packages/react-server-core-middleware/npm-debug.log

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/dwade/n/bin/node" "/Users/dwade/n/bin/npm" "run" "prepublish"
npm ERR! node v6.9.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! react-server-core-middleware@0.4.10 prepublish: `npm run build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-core-middleware@0.4.10 prepublish script 'npm run build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-server-core-middleware package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-server-core-middleware
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-server-core-middleware
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dwade/foss/react-server/packages/react-server-core-middleware/npm-debug.log

    at ChildProcess.exithandler (child_process.js:206:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
Waiting for 3 child processes to exit. CTRL-C to exit immediately.
```

Info:

```
» asini --version
1.3.0
» node -v
v6.9.4
» npm -v
3.10.10
```

Repro:

```
» n 6
» npm i -g asini
» asini nuke
» asini clean
» asini bootstrap
» asini run bootstrap
```