### PR TITLE
Fix react-server-examples linting

### DIFF
--- a/packages/react-server-examples/gulpfile.babel.js
+++ b/packages/react-server-examples/gulpfile.babel.js
@@ -2,16 +2,19 @@ import eslint from "gulp-eslint";
 import gulp from "gulp";
 
 gulp.task("eslint", [], () => {
-	return gulp.src(["./**/*.js", '!node_modules/**'])
-        // eslint() attaches the lint output to the eslint property
-        // of the file object so it can be used by other modules.
-        .pipe(eslint())
-        // eslint.format() outputs the lint results to the console.
-        // Alternatively use eslint.formatEach() (see Docs).
-        .pipe(eslint.format())
-        // To have the process exit with an error code (1) on
-        // lint error, return the stream and pipe to failOnError last.
-        .pipe(eslint.failAfterError());
+	return gulp.src(["./**/*.js", '!./**/node_modules/**', '!./**/__clientTemp/**'])
+		// eslint() attaches the lint output to the eslint property
+		// of the file object so it can be used by other modules.
+		.pipe(eslint({
+			configFile: "../../.eslintrc",
+			useEslintrc: false,
+		}))
+		// eslint.format() outputs the lint results to the console.
+		// Alternatively use eslint.formatEach() (see Docs).
+		.pipe(eslint.format())
+		// To have the process exit with an error code (1) on
+		// lint error, return the stream and pipe to failOnError last.
+		.pipe(eslint.failAfterError());
 });
 
 // there are no tests for this project :(


### PR DESCRIPTION
Running `npm test` at the root fails with

```
» npm test
> @ test /Users/dwade/foss/react-server
> asini run test
> react-server-examples@ test /Users/dwade/foss/react-server/packages/react-server-examples
> gulp test
[17:50:50] Requiring external module babel-register
[17:50:51] Using gulpfile ~/foss/react-server/packages/react-server-examples/gulpfile.babel.js
[17:50:51] Starting 'eslint'...
NpmUtilities.execInDir        ("run test", [], "./packages/react-server-examples")
> react-server-examples@ test /Users/dwade/foss/react-server/packages/react-server-examples
> gulp test
[17:50:50] Requiring external module babel-register
[17:50:51] Using gulpfile ~/foss/react-server/packages/react-server-examples/gulpfile.babel.js
[17:50:51] Starting 'eslint'...
NpmUtilities.runScriptInDir   ("test", [], "./packages/react-server-examples")
> react-server-examples@ test /Users/dwade/foss/react-server/packages/react-server-examples
> gulp test
[17:50:50] Requiring external module babel-register
[17:50:51] Using gulpfile ~/foss/react-server/packages/react-server-examples/gulpfile.babel.js
[17:50:51] Starting 'eslint'...
Errored while running npm script 'test' in 'react-server-examples'
Error: Command failed: npm run test
/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:401
            throw e;
            ^
Error: Cannot find module '@satazor/eslint-config/addons/node'
Referenced from: /Users/dwade/foss/react-server/packages/react-server-examples/bike-share/node_modules/cross-spawn/.eslintrc
    at ModuleResolver.resolve (/Users/dwade/foss/react-server/node_modules/eslint/lib/util/module-resolver.js:74:19)
    at resolve (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:478:33)
    at load (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:495:26)
    at configExtends.reduceRight.e (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:391:36)
    at Array.reduceRight (native)
    at applyExtends (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:362:28)
    at Object.load (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:529:22)
    at loadConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:259:26)
npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/dwade/n/bin/node" "/Users/dwade/foss/react-server/node_modules/.bin/npm" "run" "test"
npm ERR! node v6.9.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! react-server-examples@ test: `gulp test`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-examples@ test script 'gulp test'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-server-examples package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp test
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-server-examples
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-server-examples
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dwade/foss/react-server/packages/react-server-examples/npm-debug.log
    at ChildProcess.exithandler (child_process.js:206:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
Errored while running RunCommand.execute
Error: Command failed: npm run test
/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:401
            throw e;
            ^
Error: Cannot find module '@satazor/eslint-config/addons/node'
Referenced from: /Users/dwade/foss/react-server/packages/react-server-examples/bike-share/node_modules/cross-spawn/.eslintrc
    at ModuleResolver.resolve (/Users/dwade/foss/react-server/node_modules/eslint/lib/util/module-resolver.js:74:19)
    at resolve (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:478:33)
    at load (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:495:26)
    at configExtends.reduceRight.e (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:391:36)
    at Array.reduceRight (native)
    at applyExtends (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:362:28)
    at Object.load (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:529:22)
    at loadConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:259:26)
npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/dwade/n/bin/node" "/Users/dwade/foss/react-server/node_modules/.bin/npm" "run" "test"
npm ERR! node v6.9.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! react-server-examples@ test: `gulp test`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-server-examples@ test script 'gulp test'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-server-examples package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp test
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-server-examples
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-server-examples
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dwade/foss/react-server/packages/react-server-examples/npm-debug.log
    at ChildProcess.exithandler (child_process.js:206:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
Waiting for 3 child processes to exit. CTRL-C to exit immediately.
```

When you run test in react-server-examples, the example is more explicit

```
» npm test
> react-server-examples@ test /Users/dwade/foss/react-server/packages/react-server-examples
> gulp test
[17:45:44] Requiring external module babel-register
[17:45:44] Using gulpfile ~/foss/react-server/packages/react-server-examples/gulpfile.babel.js
[17:45:44] Starting 'eslint'...
/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:401
            throw e;
            ^
Error: Cannot find module '@satazor/eslint-config/addons/node'
Referenced from: /Users/dwade/foss/react-server/packages/react-server-examples/bike-share/node_modules/cross-spawn/.eslintrc
    at ModuleResolver.resolve (/Users/dwade/foss/react-server/node_modules/eslint/lib/util/module-resolver.js:74:19)
    at resolve (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:478:33)
    at load (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:495:26)
    at configExtends.reduceRight.e (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:391:36)
    at Array.reduceRight (native)
    at applyExtends (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:362:28)
    at Object.load (/Users/dwade/foss/react-server/node_modules/eslint/lib/config/config-file.js:529:22)
    at loadConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig (/Users/dwade/foss/react-server/node_modules/eslint/lib/config.js:259:26)
npm ERR! Test failed.  See above for more details.
```

Repro:

```
» npm run clean && npm run nuke && npm run bootstrap
» npm test
```