### PR TITLE
Fix deprecation warning for lodash/isarray function calls; replaced with Array.isArray

### DIFF
--- a/packages/react-server/core/ReactServerAgent/Cache.js
+++ b/packages/react-server/core/ReactServerAgent/Cache.js
@@ -3,7 +3,6 @@ var logger = require('../logging').getLogger(__LOGGER__)
 ,	Q = require('q')
 ,	merge = require("lodash/merge")
 ,	isEqual = require("lodash/isEqual")
-,	isArray = require("lodash/isArray")
 ;
 
 // TODO: we should figure out a way to consolidate this with SuperAgentExtender
@@ -366,7 +365,7 @@ class RequestDataCache {
 			var entries = state.dataCache[url];
 			// convert entries to an array, if it was serialized as
 			// a single entry
-			entries = isArray(entries) ? entries : [entries];
+			entries = Array.isArray(entries) ? entries : [entries];
 			dataCache[url] = entries.map(entryData => {
 				var newEntry = new CacheEntry(this);
 				newEntry.rehydrate(entryData);

--- a/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
+++ b/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
@@ -1,8 +1,6 @@
 var ReactServerAgent = require("../../ReactServerAgent");
 var superagent = require("superagent");
 var Q = require("q");
-var isArray = require("lodash/isArray");
-
 
 var {
 	makeServer,
@@ -508,7 +506,7 @@ describe("ReactServerAgent", () => {
 				var dehydrated = cache.dehydrate();
 
 				// single entry; not an array
-				expect(isArray(dehydrated.dataCache[URL])).toBeFalsy();
+				expect(Array.isArray(dehydrated.dataCache[URL])).toBeFalsy();
 				expect(getSingleDehydratedCacheEntry(dehydrated, URL).requesters).toBe(2);
 
 			})
@@ -536,7 +534,7 @@ describe("ReactServerAgent", () => {
 				var cache = ReactServerAgent.cache();
 				var dehydrated = cache.dehydrate();
 
-				expect(isArray(dehydrated.dataCache[URL])).toBeFalsy();
+				expect(Array.isArray(dehydrated.dataCache[URL])).toBeFalsy();
 				expect(getSingleDehydratedCacheEntry(dehydrated, URL).requesters).toBe(2);
 
 			})
@@ -676,7 +674,7 @@ describe("ReactServerAgent", () => {
 	function getSingleDehydratedCacheEntry(dehydratedCache, url) {
 		var entryOrArray = dehydratedCache.dataCache[url];
 		// we expect a _single_ entry, i.e. not an array
-		expect(isArray(entryOrArray)).toBeFalsy();
+		expect(Array.isArray(entryOrArray)).toBeFalsy();
 		return entryOrArray;
 	}
 

--- a/packages/react-server/core/components/__tests__/FragmentDataCacheSpec.js
+++ b/packages/react-server/core/components/__tests__/FragmentDataCacheSpec.js
@@ -4,7 +4,6 @@ var ReactServerAgent = require("../../ReactServerAgent")
 ,   React = require("react")
 ,   ReactDOMServer = require("react-dom/server")
 ,   FragmentDataCache = require("../FragmentDataCache")
-,   isArray = require("lodash/isArray")
 ;
 
 var {
@@ -326,7 +325,7 @@ describe("FragmentDataCache", () => {
 	function getSingleEntry(parsedData, url) {
 		var entryOrArray = parsedData.dataCache[url];
 		// we expect a _single_ entry
-		expect(isArray(entryOrArray)).toBeFalsy();
+		expect(Array.isArray(entryOrArray)).toBeFalsy();
 		return entryOrArray;
 	}
 


### PR DESCRIPTION
Fixes issue #822 