### PR TITLE
Address routr api changes & Handle POST

### DIFF
--- a/docs/page-api.md
+++ b/docs/page-api.md
@@ -10,7 +10,7 @@ A binding of URL paths to a Page class that can render the results for those URL
 
 * The HTTP method(s) that are acceptable.
 
-* Default: “get”
+* Default: [“get”, "head"]
 
 `page: Page`
 * The page to render

--- a/docs/page-api.md
+++ b/docs/page-api.md
@@ -6,11 +6,13 @@ A binding of URL paths to a Page class that can render the results for those URL
 * A string or regex that will be tested against the path of the URL to
   determine if this route applies.
 
-`method, optional: String | [String]`
+`method, optional: undefined | String | [String]`
 
-* The HTTP method(s) that are acceptable.
+* The HTTP method(s) that are acceptable.  Use an array of strings to specify multiple methods.  Do not
+  set this value to `null` or `[]`.  To match all HTTP methods, either leave out the parameter altogether or explicitly
+  set the value to `undefined`.
 
-* Default: [“get”, "head"]
+* Default: undefined
 
 `page: Page`
 * The page to render

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -291,14 +291,17 @@ module.exports = {
 	for (let routeName of Object.keys(routes.routes)) {
 		let route = routes.routes[routeName];
 
+		// if the route doesn't have a method, we'll assume it's "get". routr doesn't
+		// have a default (method is required), so we set it here.
+		if (!route.method) {
+			route.method = "get";
+		}
+
 		routesOutput.push(`
 		${routeName}: {`);
 		routesOutput.push(`
-			path: ${JSON.stringify(route.path)},`);
-		// if the route doesn't have a method, we'll assume it's "get". routr doesn't
-		// have a default (method is required), so we set it here.
-		routesOutput.push(`
-			method: "${route.method || "get"}",`);
+			path: ${JSON.stringify(route.path)},
+			method: ${JSON.stringify(route.method)},`);
 
 		let formats = normalizeRoutesPage(route.page);
 		routesOutput.push(`

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -295,9 +295,9 @@ module.exports = {
 		// routr passes through and matches any method
 		// https://github.com/yahoo/routr/blob/v2.1.0/lib/router.js#L49-L57
 		let method = route.method;
-		if ((Array.isArray(route.method) && route.method.length === 0) ||
-			(typeof route.method === 'string' && route.method !== "")) {
-			// If it's an empty array or empty string, specifically set it to 'undefined'
+
+		// Safely check for an empty object, array, or string and specifically set it to 'undefined'
+		if (method === undefined || method === null || method === {} || method.length === 0) {
 			method = undefined; // 'undefined' is the value that routr needs to accept any method
 		}
 

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -294,7 +294,7 @@ module.exports = {
 		// if the route doesn't have a method, we'll assume it's "get". routr doesn't
 		// have a default (method is required), so we set it here.
 		if (!route.method) {
-			route.method = "get";
+			route.method = ["get", "head"];
 		}
 
 		routesOutput.push(`

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -291,17 +291,20 @@ module.exports = {
 	for (let routeName of Object.keys(routes.routes)) {
 		let route = routes.routes[routeName];
 
-		// if the route doesn't have a method, we'll assume it's ["get", "head"]. routr doesn't
-		// have a default (method is required), so we set it here.
-		if (!route.method) {
-			route.method = ["get", "head"];
+		// On the line below specifying 'method', if the route doesn't have a method, we'll assume it's [] so that
+		// routr passes through and matches any method
+		// https://github.com/yahoo/routr/blob/v2.1.0/lib/router.js#L49-L57
+		let method = route.method;
+		if ((Array.isArray(route.method) && route.method.length === 0) ||
+			(typeof route.method === 'string' && route.method !== "")) {
+			// If it's an empty array or empty string, specifically set it to 'undefined'
+			method = undefined; // 'undefined' is the value that routr needs to accept any method
 		}
 
 		routesOutput.push(`
-		${routeName}: {`);
-		routesOutput.push(`
+		${routeName}: {
 			path: ${JSON.stringify(route.path)},
-			method: ${JSON.stringify(route.method)},`);
+			method: ${JSON.stringify(method)},`);
 
 		let formats = normalizeRoutesPage(route.page);
 		routesOutput.push(`

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -291,7 +291,7 @@ module.exports = {
 	for (let routeName of Object.keys(routes.routes)) {
 		let route = routes.routes[routeName];
 
-		// if the route doesn't have a method, we'll assume it's "get". routr doesn't
+		// if the route doesn't have a method, we'll assume it's ["get", "head"]. routr doesn't
 		// have a default (method is required), so we set it here.
 		if (!route.method) {
 			route.method = ["get", "head"];

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -291,7 +291,7 @@ module.exports = {
 	for (let routeName of Object.keys(routes.routes)) {
 		let route = routes.routes[routeName];
 
-		// On the line below specifying 'method', if the route doesn't have a method, we'll assume it's [] so that
+		// On the line below specifying 'method', if the route doesn't have a method, we'll set it to `undefined` so that
 		// routr passes through and matches any method
 		// https://github.com/yahoo/routr/blob/v2.1.0/lib/router.js#L49-L57
 		let method = route.method;

--- a/packages/react-server/core/__tests__/context/navigator/DumbPage.js
+++ b/packages/react-server/core/__tests__/context/navigator/DumbPage.js
@@ -1,0 +1,6 @@
+export default class DumbPage {
+	getElements() {
+		const routeName = this.getRequest().getRouteName();
+		return <div id="routeName">{routeName}</div>;
+	}
+}

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorRoutes.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorRoutes.js
@@ -10,19 +10,39 @@ const pageWrapper = {
 };
 
 const Routes = {
-	"BasicPage": {
-		"path": ["/basicPage"],
+	"GetPage": {
+		"path": ["/getPage"],
 		"page": pageWrapper,
+		"method": "get",
 	},
-	"BasicPageCaps": {
-		"path": ["/basicPageCaps"],
+	"HeadPage": {
+		"path": ["/headPage"],
 		"page": pageWrapper,
-		"method": "GET", // this should be all caps because the req.getMethod() will return 'get'.
+		"method": "head",
 	},
 	"PostPage": {
 		"path": ["/postPage"],
 		"page": pageWrapper,
 		"method": "post",
+	},
+	"PatchPage": {
+		"path": ["/patchPage"],
+		"page": pageWrapper,
+		"method": "patch",
+	},
+	"PutPage": {
+		"path": ["/putPage"],
+		"page": pageWrapper,
+		"method": "put",
+	},
+	"GetPageCaps": {
+		"path": ["/getPageCaps"],
+		"page": pageWrapper,
+		"method": "GET", // this should be all caps because the req.getMethod() will return 'get'.
+	},
+	"GetAndHeadPage": {
+		"path": ["/getAndHeadPage"],
+		"page": pageWrapper,
 	},
 	"GetAndPostPage": {
 		"path": ["/getAndPostPage"],

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorRoutes.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorRoutes.js
@@ -40,15 +40,27 @@ const Routes = {
 		"page": pageWrapper,
 		"method": "GET", // this should be all caps because the req.getMethod() will return 'get'.
 	},
-	"GetAndHeadPage": {
-		"path": ["/getAndHeadPage"],
-		"page": pageWrapper,
-	},
 	"GetAndPostPage": {
 		"path": ["/getAndPostPage"],
 		"page": pageWrapper,
 		"method": ["get", "post"],
 	},
+	"AllMethodsPage": {
+		"path": ["/allMethodsPage"],
+		"page": pageWrapper,
+		"method": undefined,
+	},
+	"NullMethodsPage": {
+		"path": ["/nullMethodsPage"],
+		"page": pageWrapper,
+		"method": null,
+	},
+	"EmptyArrayMethodsPage": {
+		"path": ["/emptyArrayMethodsPage"],
+		"page": pageWrapper,
+		"method": [],
+	},
+
 };
 
 export default Routes;

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorRoutes.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorRoutes.js
@@ -1,0 +1,34 @@
+import DumbPage from "./DumbPage";
+
+// This wrapper is taken from the compileClient function that writes the routes_(client|server).js file
+const pageWrapper = {
+	default: () => {
+		return {
+			done: (cb) => { cb(DumbPage); },
+		};
+	},
+};
+
+const Routes = {
+	"BasicPage": {
+		"path": ["/basicPage"],
+		"page": pageWrapper,
+	},
+	"BasicPageCaps": {
+		"path": ["/basicPageCaps"],
+		"page": pageWrapper,
+		"method": "GET", // this should be all caps because the req.getMethod() will return 'get'.
+	},
+	"PostPage": {
+		"path": ["/postPage"],
+		"page": pageWrapper,
+		"method": "post",
+	},
+	"GetAndPostPage": {
+		"path": ["/getAndPostPage"],
+		"page": pageWrapper,
+		"method": ["get", "post"],
+	},
+};
+
+export default Routes;

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -28,42 +28,6 @@ describe("Navigator", () => {
 		requestContext = null;
 	});
 
-	it("routes to a page using an unspecified method get", (done) => {
-		const req = {
-			method: "get",
-			protocol: "http",
-			secure: false,
-			hostname: "localhost",
-			url: "/getAndHeadPage",
-		};
-		const expressRequest = new ExpressServerRequest(req);
-
-		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'GetAndHeadPage');
-			done();
-		});
-
-		requestContext.navigate(expressRequest, History.events.PAGELOAD);
-	});
-
-	it("routes to a page using an unspecified method HEAD", (done) => {
-		const req = {
-			method: "head",
-			protocol: "http",
-			secure: false,
-			hostname: "localhost",
-			url: "/getAndHeadPage",
-		};
-		const expressRequest = new ExpressServerRequest(req);
-
-		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'GetAndHeadPage');
-			done();
-		});
-
-		requestContext.navigate(expressRequest, History.events.PAGELOAD);
-	});
-
 	it("routes to a page using a method GET (caps)", (done) => {
 		const req = {
 			method: "get",
@@ -74,10 +38,12 @@ describe("Navigator", () => {
 		};
 		const expressRequest = new ExpressServerRequest(req);
 
-		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'GetPageCaps');
+		const navigatedToPage = () => {
+			expect(expressRequest.getRouteName()).toBe('GetPageCaps');
 			done();
-		});
+		};
+		requestContext.navigator.on('navigateDone', navigatedToPage);
+		requestContext.navigator.on('page', navigatedToPage);
 
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
@@ -92,10 +58,12 @@ describe("Navigator", () => {
 		};
 		const expressRequest = new ExpressServerRequest(req);
 
-		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'GetAndPostPage');
+		const navigatedToPage = () => {
+			expect(expressRequest.getRouteName()).toBe('GetAndPostPage');
 			done();
-		});
+		};
+		requestContext.navigator.on('navigateDone', navigatedToPage);
+		requestContext.navigator.on('page', navigatedToPage);
 
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
@@ -110,10 +78,12 @@ describe("Navigator", () => {
 		};
 		const expressRequest = new ExpressServerRequest(req);
 
-		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'GetAndPostPage');
+		const navigatedToPage = () => {
+			expect(expressRequest.getRouteName()).toBe('GetAndPostPage');
 			done();
-		});
+		};
+		requestContext.navigator.on('navigateDone', navigatedToPage);
+		requestContext.navigator.on('page', navigatedToPage);
 
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
@@ -138,10 +108,9 @@ describe("Navigator", () => {
 			};
 			const expressRequest = new ExpressServerRequest(req);
 
-			let navigatedToPage;
 			if (testingMethod === otherMethod) {
 				it(`does route to a page expecting ${otherMethod} using a method ${testingMethod}`, (done) => {
-					navigatedToPage = (err) => {
+					const navigatedToPage = (err) => {
 						const httpStatus = err.status || 200;
 						expect(httpStatus).toBe(200, `A route with method ${testingMethod} was not found when one should have been found.`);
 						done();
@@ -150,9 +119,73 @@ describe("Navigator", () => {
 					requestContext.navigator.on('page', navigatedToPage);
 					requestContext.navigate(expressRequest, History.events.PAGELOAD);
 				});
+
+				it("routes to a page that accepts all methods", (done) => {
+					const allMethodReq = {
+						method: otherMethod,
+						protocol: "http",
+						secure: false,
+						hostname: "localhost",
+						url: "/allMethodsPage",
+					};
+					const allMethodExpressRequest = new ExpressServerRequest(allMethodReq);
+
+					const navigatedToPage = (err) => {
+						const httpStatus = err.status || 200;
+						expect(httpStatus).toBe(200, `A route with method ${testingMethod} was not found for the AllMethodsPage.`);
+						expect(allMethodExpressRequest.getRouteName()).toBe('AllMethodsPage');
+						done();
+					};
+					requestContext.navigator.on('navigateDone', navigatedToPage);
+					requestContext.navigator.on('page', navigatedToPage);
+
+					requestContext.navigate(allMethodExpressRequest, History.events.PAGELOAD);
+				});
+
+				it("doesn't route to a page because the methods were set improperly with a 'null'", (done) => {
+					const noMethodReq = {
+						method: otherMethod,
+						protocol: "http",
+						secure: false,
+						hostname: "localhost",
+						url: "/nullMethodsPage",
+					};
+					const noMethodExpressRequest = new ExpressServerRequest(noMethodReq);
+
+					const navigatedToPage = (err) => {
+						const httpStatus = err.status || 200;
+						expect(httpStatus).toBe(404, `A route with method ${testingMethod} was found for the NullMethodsPage.`);
+						done();
+					};
+					requestContext.navigator.on('navigateDone', navigatedToPage);
+					requestContext.navigator.on('page', navigatedToPage);
+
+					requestContext.navigate(noMethodExpressRequest, History.events.PAGELOAD);
+				});
+
+				it("doesn't route to a page because the methods were set improperly with a '[]'", (done) => {
+					const noMethodReq = {
+						method: otherMethod,
+						protocol: "http",
+						secure: false,
+						hostname: "localhost",
+						url: "/emptyArrayMethodsPage",
+					};
+					const noMethodExpressRequest = new ExpressServerRequest(noMethodReq);
+
+					const navigatedToPage = (err) => {
+						const httpStatus = err.status || 200;
+						expect(httpStatus).toBe(404, `A route with method ${testingMethod} was found for the EmptyArrayMethodsPage.`);
+						done();
+					};
+					requestContext.navigator.on('navigateDone', navigatedToPage);
+					requestContext.navigator.on('page', navigatedToPage);
+
+					requestContext.navigate(noMethodExpressRequest, History.events.PAGELOAD);
+				});
 			} else {
 				it(`doesn't route to a page expecting ${otherMethod} using a method ${testingMethod}`, (done) => {
-					navigatedToPage = (err) => {
+					const navigatedToPage = (err) => {
 						const httpStatus = err.status || 200;
 						expect(httpStatus).toBe(404, `A route with method ${testingMethod} was found when one should not have been found.`);
 						done();

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -136,4 +136,25 @@ describe("Navigator", () => {
 
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
+
+
+	it("doesn't route to a page expecting POST using a method GET", (done) => {
+		const req = {
+			method: "get",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/postPage",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+
+		const navigatedToPage = (err) => {
+			const httpStatus = err.status || 200;
+			expect(httpStatus).toBe(404, "A route was found when one should not have been found.");
+			done();
+		};
+		requestContext.navigator.on('page', navigatedToPage);
+		requestContext.navigator.on('navigateDone', navigatedToPage);
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
 });

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -62,7 +62,6 @@ describe("Navigator", () => {
 			url: "/postPage",
 		};
 		const expressRequest = new ExpressServerRequest(req);
-		console.log('method: ', expressRequest.getMethod());
 
 		requestContext.navigator.on('page', () => {
 			expect(expressRequest.getRouteName() === 'PostPage');
@@ -82,7 +81,6 @@ describe("Navigator", () => {
 			url: "/getAndPostPage",
 		};
 		const expressRequest = new ExpressServerRequest(req);
-		console.log('method: ', expressRequest.getMethod());
 
 		requestContext.navigator.on('page', () => {
 			expect(expressRequest.getRouteName() === 'GetAndPostPage');
@@ -101,7 +99,6 @@ describe("Navigator", () => {
 			url: "/getAndPostPage",
 		};
 		const expressRequest = new ExpressServerRequest(req);
-		console.log('method: ', expressRequest.getMethod());
 
 		requestContext.navigator.on('page', () => {
 			expect(expressRequest.getRouteName() === 'GetAndPostPage');

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -1,0 +1,113 @@
+import RequestContext from "../../../context/RequestContext";
+import History from "../../../components/History";
+import ExpressServerRequest from "../../../ExpressServerRequest";
+import NavigatorRoutes from "./NavigatorRoutes";
+
+describe("Navigator", () => {
+	let requestContext;
+	const options = {
+		routes: NavigatorRoutes,
+	};
+
+	beforeEach(() => {
+		requestContext = new RequestContext(options);
+	});
+	afterEach(() => {
+		requestContext = null;
+	});
+
+	it("routes to a basic page using an unspecified method get", (done) => {
+		const req = {
+			method: "get",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/basicPage",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+
+		requestContext.navigator.on('page', () => {
+			expect(expressRequest.getRouteName() === 'BasicPage');
+			done();
+		});
+
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
+
+
+	it("routes to a page using a method GET (caps)", (done) => {
+		const req = {
+			method: "get",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/basicPageCaps",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+
+		requestContext.navigator.on('page', () => {
+			expect(expressRequest.getRouteName() === 'BasicPageCaps');
+			done();
+		});
+
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
+
+	it("routes to a page using a method POST", (done) => {
+		const req = {
+			method: "post",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/postPage",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+		console.log('method: ', expressRequest.getMethod());
+
+		requestContext.navigator.on('page', () => {
+			expect(expressRequest.getRouteName() === 'PostPage');
+			done();
+		});
+
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
+
+
+	it("routes to a page that can handle GET and POST using a method GET", (done) => {
+		const req = {
+			method: "get",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/getAndPostPage",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+		console.log('method: ', expressRequest.getMethod());
+
+		requestContext.navigator.on('page', () => {
+			expect(expressRequest.getRouteName() === 'GetAndPostPage');
+			done();
+		});
+
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
+
+	it("routes to a page that can handle GET and POST using a method POST", (done) => {
+		const req = {
+			method: "post",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/getAndPostPage",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+		console.log('method: ', expressRequest.getMethod());
+
+		requestContext.navigator.on('page', () => {
+			expect(expressRequest.getRouteName() === 'GetAndPostPage');
+			done();
+		});
+
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
+});

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -28,36 +28,36 @@ describe("Navigator", () => {
 		requestContext = null;
 	});
 
-	it("routes to a basic page using an unspecified method get", (done) => {
+	it("routes to a page using an unspecified method get", (done) => {
 		const req = {
 			method: "get",
 			protocol: "http",
 			secure: false,
 			hostname: "localhost",
-			url: "/basicPage",
+			url: "/getAndHeadPage",
 		};
 		const expressRequest = new ExpressServerRequest(req);
 
 		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'BasicPage');
+			expect(expressRequest.getRouteName() === 'GetAndHeadPage');
 			done();
 		});
 
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
 
-	it("routes to a basic page using an unspecified method HEAD", (done) => {
+	it("routes to a page using an unspecified method HEAD", (done) => {
 		const req = {
 			method: "head",
 			protocol: "http",
 			secure: false,
 			hostname: "localhost",
-			url: "/basicPage",
+			url: "/getAndHeadPage",
 		};
 		const expressRequest = new ExpressServerRequest(req);
 
 		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'BasicPage');
+			expect(expressRequest.getRouteName() === 'GetAndHeadPage');
 			done();
 		});
 
@@ -70,36 +70,17 @@ describe("Navigator", () => {
 			protocol: "http",
 			secure: false,
 			hostname: "localhost",
-			url: "/basicPageCaps",
+			url: "/getPageCaps",
 		};
 		const expressRequest = new ExpressServerRequest(req);
 
 		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'BasicPageCaps');
+			expect(expressRequest.getRouteName() === 'GetPageCaps');
 			done();
 		});
 
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
-
-	it("routes to a page using a method POST", (done) => {
-		const req = {
-			method: "post",
-			protocol: "http",
-			secure: false,
-			hostname: "localhost",
-			url: "/postPage",
-		};
-		const expressRequest = new ExpressServerRequest(req);
-
-		requestContext.navigator.on('page', () => {
-			expect(expressRequest.getRouteName() === 'PostPage');
-			done();
-		});
-
-		requestContext.navigate(expressRequest, History.events.PAGELOAD);
-	});
-
 
 	it("routes to a page that can handle GET and POST using a method GET", (done) => {
 		const req = {
@@ -138,23 +119,51 @@ describe("Navigator", () => {
 	});
 
 
-	it("doesn't route to a page expecting POST using a method GET", (done) => {
-		const req = {
-			method: "get",
-			protocol: "http",
-			secure: false,
-			hostname: "localhost",
-			url: "/postPage",
-		};
-		const expressRequest = new ExpressServerRequest(req);
+	const methods = [
+		'get',
+		'head',
+		'put',
+		'patch',
+		'post',
+	];
 
-		const navigatedToPage = (err) => {
-			const httpStatus = err.status || 200;
-			expect(httpStatus).toBe(404, "A route was found when one should not have been found.");
-			done();
-		};
-		requestContext.navigator.on('page', navigatedToPage);
-		requestContext.navigator.on('navigateDone', navigatedToPage);
-		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	methods.forEach((testingMethod) => {
+		methods.forEach((otherMethod) => {
+			const req = {
+				method: otherMethod,
+				protocol: "http",
+				secure: false,
+				hostname: "localhost",
+				url: `/${testingMethod}Page`,
+			};
+			const expressRequest = new ExpressServerRequest(req);
+
+			let navigatedToPage;
+			if (testingMethod === otherMethod) {
+				it(`does route to a page expecting ${otherMethod} using a method ${testingMethod}`, (done) => {
+					navigatedToPage = (err) => {
+						const httpStatus = err.status || 200;
+						expect(httpStatus).toBe(200, `A route with method ${testingMethod} was not found when one should have been found.`);
+						done();
+					};
+					requestContext.navigator.on('navigateDone', navigatedToPage);
+					requestContext.navigator.on('page', navigatedToPage);
+					requestContext.navigate(expressRequest, History.events.PAGELOAD);
+				});
+			} else {
+				it(`doesn't route to a page expecting ${otherMethod} using a method ${testingMethod}`, (done) => {
+					navigatedToPage = (err) => {
+						const httpStatus = err.status || 200;
+						expect(httpStatus).toBe(404, `A route with method ${testingMethod} was found when one should not have been found.`);
+						done();
+					};
+					requestContext.navigator.on('navigateDone', navigatedToPage);
+					requestContext.navigator.on('page', navigatedToPage);
+					requestContext.navigate(expressRequest, History.events.PAGELOAD);
+				});
+			}
+		});
+
 	});
+
 });

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -22,7 +22,6 @@ describe("Navigator", () => {
 	};
 
 	beforeEach(() => {
-		//requestContext = new RequestContext(options);
 		requestContext = new RequestContextStub(options);
 	});
 	afterEach(() => {

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -1,7 +1,19 @@
-import RequestContext from "../../../context/RequestContext";
+import Navigator from "../../../context/Navigator";
 import History from "../../../components/History";
 import ExpressServerRequest from "../../../ExpressServerRequest";
 import NavigatorRoutes from "./NavigatorRoutes";
+
+class RequestContextStub {
+	constructor(options) {
+		this.navigator = new Navigator(this, options);
+	}
+	navigate (request, type) {
+		this.navigator.navigate(request, type);
+	}
+	framebackControllerWillHandle() { return false; }
+	getMobileDetect() { return null; }
+}
+
 
 describe("Navigator", () => {
 	let requestContext;
@@ -10,7 +22,8 @@ describe("Navigator", () => {
 	};
 
 	beforeEach(() => {
-		requestContext = new RequestContext(options);
+		//requestContext = new RequestContext(options);
+		requestContext = new RequestContextStub(options);
 	});
 	afterEach(() => {
 		requestContext = null;
@@ -34,6 +47,23 @@ describe("Navigator", () => {
 		requestContext.navigate(expressRequest, History.events.PAGELOAD);
 	});
 
+	it("routes to a basic page using an unspecified method HEAD", (done) => {
+		const req = {
+			method: "head",
+			protocol: "http",
+			secure: false,
+			hostname: "localhost",
+			url: "/basicPage",
+		};
+		const expressRequest = new ExpressServerRequest(req);
+
+		requestContext.navigator.on('page', () => {
+			expect(expressRequest.getRouteName() === 'BasicPage');
+			done();
+		});
+
+		requestContext.navigate(expressRequest, History.events.PAGELOAD);
+	});
 
 	it("routes to a page using a method GET (caps)", (done) => {
 		const req = {

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -53,7 +53,6 @@ class Navigator extends EventEmitter {
 		var route = this.router.getRoute(request.getUrl(), { method: request.getMethod() });
 
 		if (route) {
-			console.log(`Mapped ${request.getUrl()} to route ${route.name} when method = ${JSON.stringify(request.getMethod())}`);
 			logger.debug(`Mapped ${request.getUrl()} to route ${route.name}`);
 		} else if (!request._frameback) {
 			this.emit('navigateDone', { status: 404, message: "No Route!" }, null, request.getUrl(), type);

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -50,7 +50,7 @@ class Navigator extends EventEmitter {
 
 		this._haveInitialized = true;
 
-		var route = this.router.getRoute(request.getUrl(), {method: request.method});
+		var route = this.router.getRoute(request.getUrl(), {method: request.getMethod()});
 
 		if (route) {
 			logger.debug(`Mapped ${request.getUrl()} to route ${route.name}`);

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -50,7 +50,7 @@ class Navigator extends EventEmitter {
 
 		this._haveInitialized = true;
 
-		var route = this.router.getRoute(request.getUrl(), {navigate: {path:request.getUrl(), type:type}});
+		var route = this.router.getRoute(request.getUrl(), {method: request.method});
 
 		if (route) {
 			logger.debug(`Mapped ${request.getUrl()} to route ${route.name}`);

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -50,9 +50,10 @@ class Navigator extends EventEmitter {
 
 		this._haveInitialized = true;
 
-		var route = this.router.getRoute(request.getUrl(), {method: request.getMethod()});
+		var route = this.router.getRoute(request.getUrl(), { method: request.getMethod() });
 
 		if (route) {
+			console.log(`Mapped ${request.getUrl()} to route ${route.name} when method = ${JSON.stringify(request.getMethod())}`);
 			logger.debug(`Mapped ${request.getUrl()} to route ${route.name}`);
 		} else if (!request._frameback) {
 			this.emit('navigateDone', { status: 404, message: "No Route!" }, null, request.getUrl(), type);


### PR DESCRIPTION
This PR makes the following changes:

- Handle the new Routr API according to their changelog (remove the `navigate` object and only pass the `method` option).
- Supports (and properly encodes) handling multiple HTTP methods other than just 'GET' (such as `method: ['get', 'post']`).  This is a breaking change because now the recommended solution in #312 of setting `method: "get"` for POST requests will no longer work.
- Changes the default method type from `method: "get"` to `method: ["get", "head"]` for feature parity between GET and HEAD requests.  Prior to this change, a HEAD request for a page that returns HTTP code 200 normally would return a 404 error.
- Adds unit tests.