### PR TITLE
Fix ReactServerAgent CORS preflight

### DIFF
--- a/packages/react-server/core/ReactServerAgent.js
+++ b/packages/react-server/core/ReactServerAgent.js
@@ -20,7 +20,7 @@ var API = {
 
 	head (url, data) {
 		var req = new Request('HEAD', url, API.cache());
-		if (data) req.send(data);
+		if (data) req.query(data);
 		return req;
 	},
 

--- a/packages/react-server/core/ReactServerAgent/Request.js
+++ b/packages/react-server/core/ReactServerAgent/Request.js
@@ -15,7 +15,10 @@ function Request(method, urlPath, cache) {
 	this._cache = cache;
 
 	this._queryParams = [];
-	this._postParams = {};
+	// _postParams should initially be null instead of {} because we want to allow people to send POST requests with
+	// empty data sets (if they need to).  This way, we can differentiate between a default of null, an empty data set,
+	// and a populated data set.
+	this._postParams = null;
 	this._headers = {};
 	this._timeout = null;
 	this._type = "json"; // superagent's default, only for POST/PUT/PATCH methods
@@ -71,9 +74,14 @@ Request.prototype.query = function (queryParams) {
 
 Request.prototype.send = function (postParams) {
 	if (typeof postParams === 'undefined') {
-		return merge({}, this._postParams);
+		return merge({}, this._postParams || {});
 	}
-	merge(this._postParams, postParams);
+	if (postParams !== null) {
+		if (this._postParams === null) {
+			this._postParams = {};
+		}
+		merge(this._postParams, postParams);
+	}
 	return this;
 }
 
@@ -228,8 +236,10 @@ function buildSuperagentRequest() {
 		}
 	}
 
+	// query parameters exist if there are more than one set
+	// post parameters exist if the value is not null
 	const hasQueryParams = (this._queryParams.length > 0),
-		hasPostParams = (Object.keys(this._postParams).length > 0);
+		hasPostParams = (this._postParams !== null);
 
 	if (hasPostParams) {
 		// superagent has some weird, implicit file upload support

--- a/packages/react-server/core/ReactServerAgent/Request.js
+++ b/packages/react-server/core/ReactServerAgent/Request.js
@@ -18,7 +18,7 @@ function Request(method, urlPath, cache) {
 	this._postParams = {};
 	this._headers = {};
 	this._timeout = null;
-	this._type = "json"; // superagent's default
+	this._type = "json"; // superagent's default, only for POST/PUT/PATCH methods
 
 	// public field
 	this.aborted = undefined; //default to undefined
@@ -206,34 +206,48 @@ function buildSuperagentRequest() {
 		req.agent(this._agent);
 	}
 
-	// superagent has some weird, implicit file upload support
-	// that only works if you don't set `type`.
-	if (this._type && this._type !== 'form-data') {
-		req.type(this._type);
-	}
-
 	req.set(this._headers);
-	this._queryParams.forEach(params => req.query(params));
 
-	var postParams = this._postParams;
+	switch (this._method) {
+		case 'GET':
+		case 'HEAD':
+			this._queryParams.forEach(params => req.query(params));
+			break;
 
-	// convert params to FormData if the request type is form-data
-	if (this._type === "form-data") {
-		if (!SERVER_SIDE) {
-			var formData = new FormData();
-			if (postParams) {
-				var paramKeys = Object.keys(postParams);
-				paramKeys.forEach(key => {
-					formData.append(key, postParams[key]);
-				});
+		case 'POST':
+		case 'PATCH':
+		case 'PUT':
+			// superagent has some weird, implicit file upload support
+			// that only works if you don't set `type`.
+			if (this._type && this._type !== 'form-data') {
+				req.type(this._type);
 			}
-			postParams = formData;
-		} else {
-			throw new Error(`ReactServerAgent.type("form-data") not allowed server-side`);
-		}
-	}
 
-	req.send(postParams);
+
+			var postParams = this._postParams;
+
+			// convert params to FormData if the request type is form-data
+			if (this._type === "form-data") {
+				if (!SERVER_SIDE) {
+					var formData = new FormData();
+					if (postParams) {
+						var paramKeys = Object.keys(postParams);
+						paramKeys.forEach(key => {
+							formData.append(key, postParams[key]);
+						});
+					}
+					postParams = formData;
+				} else {
+					throw new Error(`ReactServerAgent.type("form-data") not allowed server-side`);
+				}
+			}
+
+			if (postParams) {
+				req.send(postParams);
+			}
+
+			break;
+	}
 
 	if (this._timeout) {
 		req.timeout(this._timeout);

--- a/packages/react-server/core/ReactServerAgent/Request.js
+++ b/packages/react-server/core/ReactServerAgent/Request.js
@@ -228,7 +228,7 @@ function buildSuperagentRequest() {
 		}
 	}
 
-	let hasQueryParams = (this._queryParams.length > 0),
+	const hasQueryParams = (this._queryParams.length > 0),
 		hasPostParams = (Object.keys(this._postParams).length > 0);
 
 	if (hasPostParams) {

--- a/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
+++ b/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
@@ -170,7 +170,8 @@ describe("ReactServerAgent", () => {
 	describe("general POST requests", () => {
 
 		it("defaults to application/json", withRlsContext( (done) => {
-			ReactServerAgent.post("/describe")
+			// This needs to pass some data or else the POST request won't have a content type set at all.
+			ReactServerAgent.post("/describe", {blankData: true})
 				.then( res => {
 					// lowercase
 					expect(res.body.req.headers['content-type']).toBe("application/json");
@@ -180,7 +181,8 @@ describe("ReactServerAgent", () => {
 		}));
 
 		it("can be set to form-encoded", withRlsContext( (done) => {
-			ReactServerAgent.post("/describe")
+			// This needs to pass some data or else the POST request won't have a content type set at all.
+			ReactServerAgent.post("/describe", {blankData: true})
 				.type("form")
 				.then(res => {
 					// lowercase

--- a/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
+++ b/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
@@ -169,7 +169,18 @@ describe("ReactServerAgent", () => {
 
 	describe("general POST requests", () => {
 
-		it("defaults to application/json", withRlsContext( (done) => {
+		it("have no content-type set when there is no data passed", withRlsContext( (done) => {
+			// This needs to pass some data or else the POST request won't have a content type set at all.
+			ReactServerAgent.post("/describe")
+				.then( res => {
+					// lowercase
+					expect(res.body.req.headers['content-type']).toBe(undefined);
+					done();
+				})
+				.done();
+		}));
+
+		it("defaults to application/json when data is passed", withRlsContext( (done) => {
 			// This needs to pass some data or else the POST request won't have a content type set at all.
 			ReactServerAgent.post("/describe", {blankData: true})
 				.then( res => {
@@ -180,7 +191,20 @@ describe("ReactServerAgent", () => {
 				.done();
 		}));
 
-		it("can be set to form-encoded", withRlsContext( (done) => {
+		it("type is not set to form-encoded when there is no data passed", withRlsContext( (done) => {
+			// This needs to pass some data or else the POST request won't have a content type set at all.
+			ReactServerAgent.post("/describe")
+				.type("form")
+				.then(res => {
+					// lowercase
+					expect(res.body.req.headers['content-type']).toBe(undefined);
+					// TODO: check data somehow?
+					done();
+				})
+				.done();
+		}));
+
+		it("can be set to form-encoded when data is passed", withRlsContext( (done) => {
 			// This needs to pass some data or else the POST request won't have a content type set at all.
 			ReactServerAgent.post("/describe", {blankData: true})
 				.type("form")

--- a/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
+++ b/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
@@ -180,6 +180,17 @@ describe("ReactServerAgent", () => {
 				.done();
 		}));
 
+		it("defaults to application/json when an empty object is passed", withRlsContext( (done) => {
+			// This needs to pass some data or else the POST request won't have a content type set at all.
+			ReactServerAgent.post("/describe", {})
+				.then( res => {
+					// lowercase
+					expect(res.body.req.headers['content-type']).toBe("application/json");
+					done();
+				})
+				.done();
+		}));
+
 		it("defaults to application/json when data is passed", withRlsContext( (done) => {
 			// This needs to pass some data or else the POST request won't have a content type set at all.
 			ReactServerAgent.post("/describe", {blankData: true})


### PR DESCRIPTION
Fixes #619.  ReactServerAgent shouldn't create a CORS preflight request when executing simple GET queries of an external API.  This patch fixes that problem as well as an unidentified problem where a HEAD request generate a CORS preflight request as well, because it was attempting to pass data to the request using SuperAgent's `.send()` method instead of `.query()`.