### PR TITLE
fix contributing link on react-server.io (text change)

### DIFF
--- a/docs/intro/why-react-server.md
+++ b/docs/intro/why-react-server.md
@@ -290,7 +290,7 @@ to parse and execute JavaScript.
 
 To combat this, over the past decade some in the web developer community have
 embraced the [single-page
-application](http://en.wikipedia.org/wiki/Single-page_application), or SPA.
+application](https://en.wikipedia.org/wiki/Single-page_application), or SPA.
 The idea behind an SPA is that the browser downloads all the code for an
 application on first page load. The upside to this is that when a user clicks
 on an internal link that would normally download a new HTML page and force a

--- a/packages/react-server-website/components/content/HomeContributingSection.md
+++ b/packages/react-server-website/components/content/HomeContributingSection.md
@@ -1,3 +1,3 @@
 ## Want to Help?
 
-Great, there’s a lot to do! See [the contributing guide](https://github.com/redfin/react-server/blob/hackathon-website/CONTRIBUTING.md) to get started.
+Great, there’s a lot to do! See [the contributing guide](https://github.com/redfin/react-server/blob/master/CONTRIBUTING.md) to get started.

--- a/packages/react-server-website/components/content/HomeWhySection.md
+++ b/packages/react-server-website/components/content/HomeWhySection.md
@@ -12,4 +12,4 @@ One of the great things about React is its support for server-side rendering, wh
 
 React-server is a framework designed to make universal (née isomorphic) React easier to write, providing standard answers for these questions and more. When you write your app for react-server, you concentrate on your React components, and react-server takes care of everything else that's needed to run and deploy real React server-rendered apps. Under the hood, react-server is doing a bunch of clever optimizations, many borrowed from the ideas behind [Facebook's Big Pipe](https://www.facebook.com/notes/facebook-engineering/bigpipe-pipelining-web-pages-for-high-performance/389414033919/), to make sure that your site shows up as quickly as humanly possible for your users.
 
-Once you're hungry for more, dig into [the docs](/docs) and [`react-server`](https://github.com/redfin/react-server/blob/hackathon-website/packages/react-server) itself.
+Once you're hungry for more, dig into [the docs](/docs) and [`react-server`](https://github.com/redfin/react-server/) itself.


### PR DESCRIPTION
The contributing link on https://react-server.io/ homepage is pointing to the wrong URL. This is a text change to fix it.