### PR TITLE
fix react-server.io CLI webpackConfig override splice example

### DIFF
--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -132,10 +132,10 @@ React Server will take care of the default Webpack options but if you need to se
 ```javascript
 export default (webpackConfig) => {
 	// Insert a new sass and css loader before the default.
-	webpackConfig.module.loaders.splice(0, {
+	webpackConfig.module.loaders.unshift({
 		test: /\.s(a|c)ss$/,
 		loaders: ["style", "css", "sass", "customloader"],
-	})
+	});
 	return webpackConfig
 }
 ```


### PR DESCRIPTION
I think [splicing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) syntax is: `array.splice(start, deleteCount, item1, item2, ...)`

If deleteCount is not a number, it just disregards it. So this example as is will do nothing. What we're actually trying to do is an [unshift](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift) (as @gigabo noted below in comments).