### PR TITLE
Add getCustomScripts as a lifecycle method for pages

### DIFF
--- a/packages/react-server-test-pages/pages/scripts/getCustomScripts.js
+++ b/packages/react-server-test-pages/pages/scripts/getCustomScripts.js
@@ -1,0 +1,16 @@
+export default class CustomScriptPage {
+	getElements() {
+		return [
+			<div>I'm just some test stuff</div>,
+		];
+	}
+
+	getCustomScripts(next) {
+		var inlineScript = {
+			text: "console.log('This is a custom script');",
+			type: "text/javascript",
+			strict: false,
+		}
+		return [inlineScript].concat(next());
+	}
+}

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -311,6 +311,7 @@ function writeHeader(req, res, context, start, pageObject) {
 	// note: these responses can currently come back out-of-order, as many are returning
 	// promises. scripts and stylesheets are guaranteed
 	return Q.all([
+		renderCustomScripts(pageObject, res),
 		renderDebugComments(pageObject, res),
 		renderTitle(pageObject, res),
 		// PLAT-602: inline scripts come before stylesheets because
@@ -1048,6 +1049,24 @@ function getNonInternalConfigs() {
 		}
 	});
 	return nonInternal;
+}
+
+function renderCustomScripts(pageObject, res) {
+
+	// Want to gather these into one list of scripts, because we care if
+	// there are any non-JS scripts in the whole bunch.
+	var scripts = pageObject.getCustomScripts();
+
+	var thereIsAtLeastOneNonJSScript = scripts.filter(
+		script => script.type && script.type !== "text/javascript"
+	).length;
+
+	if (!thereIsAtLeastOneNonJSScript) {
+		renderScriptsSync(scripts, res);
+	}
+
+	// resolve immediately.
+	return Q("");
 }
 
 module.exports._testFunctions = {

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -134,6 +134,7 @@ var PAGE_METHODS = {
 	getTitle           : [() => "", Q],
 	getScripts         : [() => [], standardizeScripts],
 	getSystemScripts   : [() => [], standardizeScripts],
+	getCustomScripts   : [() => [], standardizeScripts],
 	getBodyStartContent: [() => [], Q],
 	getHeadStylesheets : [() => [], standardizeStyles],
 	getDebugComments   : [() => [], standardizeDebugComments],


### PR DESCRIPTION
Note: this is actually all @sbr1601's work, he just gave me the diff to make a separate PR from his other one.

We wanted to be able to add a custom script to our `<head/>` in order to preload some images on certain browsers (*cough* Safari *cough*). This has been tested with a test page - which is not part of this PR, b/c that was originally built in `react-server-test-pages`, but I'm wondering if that should go into `react-server-integration-tests` instead? For that matter, what's the difference between those two folders' intentions? (If it doesn't matter, I'll just push the test page I have right now into this PR.)