### PR TITLE
Manage debug parameters with a `DebugUtil` helper

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -5,6 +5,7 @@ var React = require('react'),
 	logging = require('./logging'),
 	RequestContext = require('./context/RequestContext'),
 	RequestLocalStorage = require('./util/RequestLocalStorage'),
+	DebugUtil = require('./util/DebugUtil'),
 	Q = require('q'),
 	cssHelper = require('./util/ClientCssHelper'),
 	EventEmitter = require("events").EventEmitter,
@@ -421,7 +422,9 @@ class ClientController extends EventEmitter {
 	_handleDebugParams(page) {
 		if (!page) return;
 
-		const params = page.getRequest().getQuery();
+		DebugUtil.setRequest(page.getRequest());
+
+		const params = DebugUtil.getAllDebugValues();
 
 		// Allow adjustment of log levels.
 		_.forEach({

--- a/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
+++ b/packages/react-server/core/__tests__/context/navigator/NavigatorSpec.js
@@ -2,13 +2,16 @@ import Navigator from "../../../context/Navigator";
 import History from "../../../components/History";
 import ExpressServerRequest from "../../../ExpressServerRequest";
 import NavigatorRoutes from "./NavigatorRoutes";
+import RequestLocalStorage from "../../../util/RequestLocalStorage";
 
 class RequestContextStub {
 	constructor(options) {
 		this.navigator = new Navigator(this, options);
 	}
 	navigate (request, type) {
-		this.navigator.navigate(request, type);
+		RequestLocalStorage.startRequest(() => {
+			this.navigator.navigate(request, type);
+		});
 	}
 	framebackControllerWillHandle() { return false; }
 	getMobileDetect() { return null; }

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -6,6 +6,7 @@ var EventEmitter = require('events').EventEmitter,
 	History = require("../components/History"),
 	ReactServerAgent = require("../ReactServerAgent"),
 	PageUtil = require("../util/PageUtil"),
+	DebugUtil = require("../util/DebugUtil"),
 	{setResponseLoggerPage} = SERVER_SIDE ? require('../logging/response') : { setResponseLoggerPage: () => {} };
 
 var _ = {
@@ -49,6 +50,10 @@ class Navigator extends EventEmitter {
 		type = type || History.events.PAGELOAD;
 
 		this._haveInitialized = true;
+
+		// Pull debug parameters out of the query string and expose via a well
+		// defined interface.
+		DebugUtil.setRequest(request);
 
 		var route = this.router.getRoute(request.getUrl(), { method: request.getMethod() });
 

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -5,6 +5,7 @@ var logger = require('./logging').getLogger(__LOGGER__),
 	MobileDetect = require('mobile-detect'),
 	RequestContext = require('./context/RequestContext'),
 	RequestLocalStorage = require('./util/RequestLocalStorage'),
+	DebugUtil = require('./util/DebugUtil'),
 	RLS = RequestLocalStorage.getNamespace(),
 	LABString = require('./util/LABString'),
 	Q = require('q'),
@@ -715,7 +716,7 @@ function writeBody(req, res, context, start, page) {
 	// Some time has already elapsed since the request started.
 	// Note that you can override `FAILSAFE_RENDER_TIMEOUT` with a
 	// `?_debug_render_timeout={ms}` query string parameter.
-	var totalWait     = req.query._debug_render_timeout || FAILSAFE_RENDER_TIMEOUT
+	var totalWait     = DebugUtil.getRenderTimeout() || FAILSAFE_RENDER_TIMEOUT
 	,   timeRemaining = totalWait - (new Date - start)
 
 	var retval = Q.defer();
@@ -988,7 +989,7 @@ function wrapUpLateArrivals(){
 
 function closeBody(req, res) {
 	// Flush timing/log data to the response document
-	if (req.query._debug_output_logs) {
+	if (DebugUtil.getOutputLogs()) {
 		flushLogsToResponse(res);
 	}
 	res.write("</div></body></html>");

--- a/packages/react-server/core/util/DebugUtil.js
+++ b/packages/react-server/core/util/DebugUtil.js
@@ -1,0 +1,38 @@
+import RequestLocalStorage from "./RequestLocalStorage";
+import forEach from "lodash/forEach";
+import map from "lodash/map";
+import assign from "lodash/assign";
+import pick from "lodash/pick";
+
+const RLS = RequestLocalStorage.getNamespace();
+
+// This module provides methods that expose values from the query string.
+//
+// So, for example, if you pass `?_debug_render_timeout=1000` then you can
+// call `DebugUtil.getRenderTimeout()` and receive `1000`.
+//
+// Additionally you may call `DebugUtil.getAllDebugValues()` to obtain an
+// object with all debug parameters extracted from the query string.
+//
+const DEBUG_PARAMS = {
+	getRenderTimeout : "_debug_render_timeout",
+	getOutputLogs    : "_debug_output_logs",
+	getLogLevel      : "_react_server_log_level",
+	getLogLevelMain  : "_react_server_log_level_main",
+	getLogLevelTime  : "_react_server_log_level_time",
+	getLogLevelGauge : "_react_server_log_level_gauge",
+};
+
+const DebugUtil = {
+	setRequest(req) {
+		assign(RLS(), pick(req.getQuery(), map(DEBUG_PARAMS, v => v)));
+	},
+	getAllDebugValues() {
+		return assign({}, RLS());
+	},
+};
+
+// Make the methods.
+forEach(DEBUG_PARAMS, (param, method) => DebugUtil[method] = () => RLS()[param]);
+
+export default DebugUtil;


### PR DESCRIPTION
This is mainly to collect all of the supported debug parameters into one place.

Tired of having to hunt for them.