### PR TITLE
Fix Forward Test Page

### DIFF
--- a/packages/react-server-test-pages/pages/navigation/forward.js
+++ b/packages/react-server-test-pages/pages/navigation/forward.js
@@ -15,18 +15,32 @@ export default class ForwardPage {
 
 		return this.data.then((res) => {
 			//then depending on said data, forward to one of two pages, and pass along the data we pre-fetched
-			const pageName = (res.body % 2 === 0) ? "./forwardEven" : "./forwardOdd";
-			// TODO: change this to use isBrowser when that check is available.
-			if (typeof window !== 'undefined') {
-				return require.ensure([pageName], () => {
+			if (res.body % 2 === 0) {
+				// TODO: change this to use isBrowser when that check is available.
+				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
+					return require.ensure(["./forwardEven"], () => {
+						return {
+							page: require("./forwardEven").default,
+						};
+					});
+				} else {
 					return {
-						page: require(pageName).default,
+						page: require("./forwardEven").default,
 					};
-				});
+				}
 			} else {
-				return {
-					page: require(pageName).default,
-				};
+				// TODO: change this to use isBrowser when that check is available.
+				if (typeof window !== 'undefined') { //would be nice if this is `process.env.isServer`
+					return require.ensure(["./forwardOdd"], () => {
+						return {
+							page: require("./forwardOdd").default,
+						};
+					});
+				} else {
+					return {
+						page: require("./forwardOdd").default,
+					};
+				}
 			}
 		});
 	}


### PR DESCRIPTION
Restore @lwang's original commit. I dorked this up in an attempt to optimize the code but didn't realize that Webpack can't statically analyze the require statements when they are in a variable.