### PR TITLE
Add support for a `?_debug_lab=1` parameter

### DIFF
--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -485,7 +485,8 @@ function renderScriptsAsync(scripts, res) {
 	if (!RLS().didLoadLAB){
 
 		// This is the full implementation of LABjs.
-		res.write(flab.min);
+		// Pass `?_debug_lab=1` for unminified source with debugging output.
+		res.write(DebugUtil.getLab() ? flab.src : flab.min);
 
 		// We always want scripts to be executed in order.
 		res.write("$LAB.setGlobalDefaults({AlwaysPreserveOrder:true});");

--- a/packages/react-server/core/util/DebugUtil.js
+++ b/packages/react-server/core/util/DebugUtil.js
@@ -17,6 +17,7 @@ const RLS = RequestLocalStorage.getNamespace();
 const DEBUG_PARAMS = {
 	getRenderTimeout : "_debug_render_timeout",
 	getOutputLogs    : "_debug_output_logs",
+	getLab           : "_debug_lab",
 	getLogLevel      : "_react_server_log_level",
 	getLogLevelMain  : "_react_server_log_level_main",
 	getLogLevelTime  : "_react_server_log_level_time",


### PR DESCRIPTION
Triggers un-minified LABjs source with debug output to the console.