### PR TITLE
Protect multiple RSA requesters from each other

### DIFF
--- a/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
+++ b/packages/react-server/core/ReactServerAgent/__tests__/ReactServerAgentSpec.js
@@ -537,7 +537,10 @@ describe("ReactServerAgent", () => {
 			]).then(results => {
 				var [res1, res2] = results;
 
-				expect(res1).toBe(res2);
+				expect(res1).toEqual(res2);
+
+				// Must be a deep copy, not a reference.
+				expect(res1).not.toBe(res2);
 
 				var cache = ReactServerAgent.cache();
 				var dehydrated = cache.dehydrate();
@@ -566,7 +569,10 @@ describe("ReactServerAgent", () => {
 			]).then(results => {
 				var [res1, res2] = results;
 
-				expect(res1).toBe(res2);
+				expect(res1).toEqual(res2);
+
+				// Must be a deep copy, not a reference.
+				expect(res1).not.toBe(res2);
 
 				var cache = ReactServerAgent.cache();
 				var dehydrated = cache.dehydrate();


### PR DESCRIPTION
If two ReactServerAgent requests are made to a given endpoint only one upstream http request is actually issued, and the result is provided to both requesters.  Previously this result was passed by reference, so mutations by one requester interfered with the data for others.

This patch provides a fresh deep copy to each requester.

This has the unfortunate side effect of introducing a deep copy in the browser where we previously thought we could get away without one.  It's a minor perf hit, but it's important for data integrity.