### PR TITLE
Adding large data request site to provide additional testing for 866

### DIFF
--- a/packages/react-server-test-pages/entrypoints.js
+++ b/packages/react-server-test-pages/entrypoints.js
@@ -57,6 +57,10 @@ module.exports = {
 		entry: "/bottleneck/dataRequests",
 		description: "Test if number of data requests on a page is a bottleneck",
 	},
+	BottleneckLargeDataRequests: {
+		entry: "/bottleneck/largeDataRequests",
+		description: "Test if large data requests on a page is a bottleneck",
+	},
 	BottleneckMiddleware: {
 		entry: "/bottleneck/middleware",
 		description: "Test if amount of middleware on a page is a bottleneck",

--- a/packages/react-server-test-pages/pages/bottleneck/largeDataRequests.js
+++ b/packages/react-server-test-pages/pages/bottleneck/largeDataRequests.js
@@ -1,0 +1,36 @@
+import {ReactServerAgent, RootContainer, RootElement} from "react-server";
+import "./colors/red.scss";
+import "./colors/green.scss";
+
+const elements = [];
+/**
+* This page is a smoke test to determine whether or not large data requests in
+* a page are a performance bottleneck for react-server. It performs a hundred large data
+* requests before returning a simple message. Metrics are created in the browser's console
+* related to performance metrics (see react-server.core.ClientController).
+*/
+export default class LargeDataRequestsPage {
+
+	handleRoute() {
+		//Reset elements, then perform one hundred large, local data requests before returning
+		elements.length = 0;
+		for (var i = 1; i <= 100; i++) {
+			let current = i;
+			let promise = ReactServerAgent.get('/data/delay')
+				.query({ big: 10000 })
+				.then(response => response.body);
+			elements.push(<RootElement when={promise}><div>10K Data request number {current} complete.</div></RootElement>);
+		}
+		return { code: 200 };
+	}
+
+	getElements() {
+		return [
+			<div className="red-thing">Data requests starting...</div>,
+			<RootContainer>
+				{elements}
+			</RootContainer>,
+			<div className="green-thing">Content should be above me.</div>,
+		];
+	}
+}


### PR DESCRIPTION
When originally writing the react-server test sites, I did not account for the possibility that larger data requests, as opposed to the quantity of data requests, may be a bottleneck or performance regression. This change adds an additional test site that makes 100 larger data requests locally. 

In local testing, the page load times for this page were 6084ms, 5318ms, 5902ms, 5339ms, and 5416ms, for an average load time of 5612ms, in case this information is relevant after #866 .