### PR TITLE
Add compileOnStartup Option

### DIFF
--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -27,6 +27,7 @@ It helps to setup your project with per-environment settings that are appropriat
        "jsUrl": "/assets/"
     },
     "production": {
+       "compileOnStartup": false,
        "jsUrl": "/assets/",
        "logLevel": "error",
        "minify": true
@@ -185,6 +186,16 @@ and 3001.  This is probably not what you want in production.
 
 A referenced asset would be something that your application links to, but `react-server` doesn't know about.  This might
 be a logo image that you link to with an `<img>` tag.
+
+## Compiling Static Assets
+See the [`react-server-cli`](https://react-server.io/docs/guides/react-server-cli) documentation to understand how to
+compile static assets.  After you have compiled the assets, you can decrease the startup time on a server by setting the
+`compileOnStartup` option to `false`.  This tells `react-server` that you previously compiled the assets and it doesn't
+need to compile anything at run time.  Integrating this into your deployment pipeline can greatly improve server startup
+time, especially with immutable infrastructure.  As a simple example of this pipeline, you can compile the assets when
+building a server image then, when starting many servers using the same image, each server has the already-compiled version
+of the software and can reliably startup.  If you use this option without previously compiling your application, `react-server`
+will fail to start.
 
 ## Served through a Fronting Server
 The example fronting server configurations show how to configure a fronting HTTP/HTTPS server to serve the static assets

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -383,7 +383,6 @@ run({
     jsPort          : 3001,
     hot             : true,
     minify          : false,
-    compileOnly     : false,
     jsUrl           : null,
     longTermCaching : true,
 });

--- a/docs/guides/react-server-cli.md
+++ b/docs/guides/react-server-cli.md
@@ -157,7 +157,8 @@ export default (server, reactServerMiddleware) => {
 	server.use(compression());
 	server.use(bodyParser.urlencoded({ extended: false }));
 	server.use(bodyParser.json());
-	server.use(session(options));
+	server.use(helmet());
+	server.use(session(options));  // Custom express middleware being added
 	reactServerMiddleware(); // Must be called once or server will not start
 }
 ```
@@ -301,6 +302,14 @@ for the static files to be served with far-future expires headers. This option
 is incompatible with --hot.
 
 Defaults to **false** in development mode and **true** in production.
+
+#### --compile-on-startup
+Tells `react-server` to compile the client code during the startup procedure.
+In many cases, such as in production, the code has already been compiled and
+the server shouldn't take the time to compile it again.
+This option is incompatible with --hot and will be ignored if hot is `true`.
+
+Defaults to **true**.
 
 #### --js-url
 A URL base for the pre-compiled client JavaScript; usually this is a base URL

--- a/packages/generator-react-server/generators/app/templates/_reactserverrc
+++ b/packages/generator-react-server/generators/app/templates/_reactserverrc
@@ -6,7 +6,6 @@
   "hot": false,
   "minify": false,
   "longTermCaching": false,
-  "compileOnly": false,
   "https": false,
   "logLevel": "debug",
   "env": {

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -1,4 +1,7 @@
 require("babel-core/register");
 
 const cli = require(".");
-cli.parseCliArgs().then(cli.run).catch(console.error);
+cli.parseCliArgs().then((options) => {
+	const commandResult = cli.run(options);
+	return (options.command === "start") ? commandResult.started : commandResult;
+}).catch(console.error);

--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -274,6 +274,9 @@ export default function start(options){
 				cb(null, null);
 			};
 		} else {
+			// ES6 destructuring without a preceding `let` or `const` results in a syntax error.  Therefore, the below
+			// statement must be wrapped in parentheses to work properly.
+			// http://exploringjs.com/es6/ch_destructuring.html#sec_leading-curly-brace-destructuring
 			({serverRoutes, compiler} = compileClient(options));
 		}
 

--- a/packages/react-server-cli/src/defaultOptions.js
+++ b/packages/react-server-cli/src/defaultOptions.js
@@ -4,7 +4,8 @@
 // jsPort: the port number for JavaScript and CSS on the server.
 // hot: enable hot reloading. do not use in production.
 // minify: minify the client-side JavaScript.
-// compileOnly: just compile the client-side JavaScript; don't start up a server.
+// compileOnStartup: start up a server without compiling the client-side JavaScript; this expects that you have already
+//   run the compile command prior to starting (i.e. in a production environment where build and run times are separated).
 // jsUrl: serve up the HTML, but don't serve up the JavaScript and CSS; instead point the
 //   JS & CSS URLs at this URL.
 // logLevel: the level of logging to use.
@@ -18,7 +19,6 @@ export default {
 	bindIp: "0.0.0.0",
 	hot: true,
 	minify: false,
-	compileOnly: false,
 	compileOnStartup: true,
 	logLevel: "debug",
 	timingLogLevel: "fast",

--- a/packages/react-server-cli/src/defaultOptions.js
+++ b/packages/react-server-cli/src/defaultOptions.js
@@ -19,6 +19,7 @@ export default {
 	hot: true,
 	minify: false,
 	compileOnly: false,
+	compileOnStartup: true,
 	logLevel: "debug",
 	timingLogLevel: "fast",
 	gaugeLogLevel: "ok",

--- a/packages/react-server-cli/src/handleCompilationErrors.js
+++ b/packages/react-server-cli/src/handleCompilationErrors.js
@@ -10,13 +10,13 @@ export default function handleCompilationErrors (err, stats){
 		logger.error(err);
 		return new Error(err);
 		// TODO: inspect stats to see if there are errors -sra.
-	} else if (stats.hasErrors()) {
+	} else if (stats && stats.hasErrors()) {
 		console.error("There were errors in the JavaScript compilation.");
 		stats.toJson().errors.forEach((error) => {
 			console.error(error);
 		});
 		return new Error("There were errors in the JavaScript compilation.");
-	} else if (stats.hasWarnings()) {
+	} else if (stats && stats.hasWarnings()) {
 		logger.warning("There were warnings in the JavaScript compilation. Note that this is normal if you are minifying your code.");
 		// for now, don't enumerate warnings; they are absolutely useless in minification mode.
 		// TODO: handle this more intelligently, perhaps with a --reportwarnings flag or with different

--- a/packages/react-server-cli/src/mergeOptions.js
+++ b/packages/react-server-cli/src/mergeOptions.js
@@ -1,4 +1,4 @@
-// takes in an arrray of options objects for `startServer.js`, and returns a merged
+// takes in an array of options objects for `startServer.js`, and returns a merged
 // version of them. it essentially acts like Object.assign(), so options objects
 // later in the argument list override the properties of ones earlier in the list.
 // like Object.assign, the merging is done on a property-by-property basis;

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -93,11 +93,6 @@ export default (args = process.argv) => {
 			describe: "Set the severity level for the gauge logs. Values are, in ascending order of severity: 'no', 'hi', 'lo', 'ok'. Default is 'no' in production mode, 'ok' otherwise.",
 			type: "string",
 		})
-		.option("compile-only", {
-			describe: "Compile the client JavaScript only, and don't start any servers. This is what you want to do if you are building the client JavaScript to be hosted on a CDN. Unless you have a very specific reason, it's almost alway a good idea to only do this in production mode. Defaults to false.",
-			default: undefined,
-			type: "boolean",
-		})
 		.option("js-url", {
 			describe: "A URL base for the pre-compiled client JavaScript. Setting a value for jsurl means that react-server-cli will not compile the client JavaScript at all, and it will not serve up any JavaScript. Obviously, this means that --jsurl overrides all of the options related to JavaScript compilation: --hot, --minify, and --bundleperroute.",
 			type: "string",

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -107,6 +107,11 @@ export default (args = process.argv) => {
 			default: false,
 			type: "boolean",
 		})
+		.option("compile-on-startup", {
+			describe: "Enable/disable compiling on startup.  Recommended for use in production when files have been pre-compiled.",
+			default: true,
+			type: "boolean",
+		})
 		.version(function() {
 			return require('../package').version;
 		})

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -104,6 +104,7 @@ export default (args = process.argv) => {
 		})
 		.option("compile-on-startup", {
 			describe: "Enable/disable compiling on startup.  Recommended for use in production when files have been pre-compiled.",
+			default: undefined,
 			type: "boolean",
 		})
 		.version(function() {

--- a/packages/react-server-cli/src/parseCliArgs.js
+++ b/packages/react-server-cli/src/parseCliArgs.js
@@ -109,7 +109,6 @@ export default (args = process.argv) => {
 		})
 		.option("compile-on-startup", {
 			describe: "Enable/disable compiling on startup.  Recommended for use in production when files have been pre-compiled.",
-			default: true,
 			type: "boolean",
 		})
 		.version(function() {

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -43,7 +43,8 @@ export default function run(options = {}) {
 	options.outputUrl = jsUrl || `//${host}:${jsPort}/`;
 
 	try {
-		return require("./" + path.join("commands", options.command))(options);
+		const commandResult = require("./" + path.join("commands", options.command))(options);
+		return (options.command === "start") ? commandResult.started : commandResult;
 	} catch (e) {
 		if (e instanceof ConfigurationError) {
 			console.error(chalk.red(e.message));

--- a/packages/react-server-cli/src/run.js
+++ b/packages/react-server-cli/src/run.js
@@ -43,8 +43,7 @@ export default function run(options = {}) {
 	options.outputUrl = jsUrl || `//${host}:${jsPort}/`;
 
 	try {
-		const commandResult = require("./" + path.join("commands", options.command))(options);
-		return (options.command === "start") ? commandResult.started : commandResult;
+		return require("./" + path.join("commands", options.command))(options);
 	} catch (e) {
 		if (e instanceof ConfigurationError) {
 			console.error(chalk.red(e.message));

--- a/packages/react-server-cli/test/parseCliArgs.js
+++ b/packages/react-server-cli/test/parseCliArgs.js
@@ -308,3 +308,40 @@ test('react-server-cli:parseCliArgs::longTermCaching option can be turned on usi
   	t.is(parsedArgs.longTermCaching, true, 'longTermCaching is true');
   	t.true(Object.keys(defaultOptions).indexOf('longTermCaching') > -1, 'longTermCaching key exists in defaultOptions');
 });
+
+// **** compileOnStartup ****
+// compileOnStartup will be undefined if no argument is provided
+test('react-server-cli:parseCliArgs::compileOnStartup will be undefined if no argument is provided', async t => {
+	const args = [
+		...defaultArgs,
+		'compile'
+	];
+	const parsedArgs = await parseCliArgs(args);
+	t.is(parsedArgs.compileOnStartup, undefined, 'compileOnStartup is undefined if no argument is provided');
+});
+
+// compileOnStartup option can be turned on using --compileOnStartup argument
+test('react-server-cli:parseCliArgs::compileOnStartup option can be turned on using --compileOnStartup argument', async t => {
+	const args = [
+		...defaultArgs,
+		'compile',
+		'--compileOnStartup'
+	];
+	const parsedArgs = await parseCliArgs(args);
+	t.is(typeof parsedArgs.compileOnStartup, 'boolean', 'compileOnStartup is true');
+	t.is(parsedArgs.compileOnStartup, true, 'compileOnStartup is true');
+	t.true(Object.keys(defaultOptions).indexOf('compileOnStartup') > -1, 'compileOnStartup key exists in defaultOptions');
+});
+
+// compileOnStartup option can be turned on using --compile-on-startup argument
+test('react-server-cli:parseCliArgs::compileOnStartup option can be turned on using --compile-on-startup argument', async t => {
+	const args = [
+		...defaultArgs,
+		'compile',
+		'--compile-on-startup'
+	];
+	const parsedArgs = await parseCliArgs(args);
+	t.is(typeof parsedArgs.compileOnStartup, 'boolean', 'compileOnStartup is true');
+	t.is(parsedArgs.compileOnStartup, true, 'compileOnStartup is true');
+	t.true(Object.keys(defaultOptions).indexOf('compileOnStartup') > -1, 'compileOnStartup key exists in defaultOptions');
+});

--- a/packages/react-server-examples/redux-basic/.reactserverrc
+++ b/packages/react-server-examples/redux-basic/.reactserverrc
@@ -6,7 +6,6 @@
   "hot": true,
   "minify": false,
   "long-term-caching": false,
-  "compile-only": false,
   "https": false,
   "log-level": "debug",
   "env": {

--- a/packages/react-server-examples/styled-components/.reactserverrc
+++ b/packages/react-server-examples/styled-components/.reactserverrc
@@ -6,7 +6,6 @@
   "hot": false,
   "minify": false,
   "longTermCaching": false,
-  "compileOnly": false,
   "https": false,
   "logLevel": "debug",
   "env": {


### PR DESCRIPTION
Addresses #868.  Tests and documentation have been updated as well.  Also, fixes #801 by removing references to the old `compileOnly` option from source code and documentation.  Lastly, fixes a minor issue with the Promise chain within the cli script.