### PR TITLE
Get dynamic config from process.env.REACT_SERVER_CONFIGS

### DIFF
--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -87,6 +87,15 @@ into your application.  One example of the file `_configs/production/config.json
 }
 ```
 
+If dynamic config is preferred, just replace `config.json` with file `config.js`. One example of `config.js` might look like this:
+
+```js
+module.exports = {
+  APP_ENV: process.env.NODE_ENV === "production" ? "prod" : "dev",
+  MY_GLOBAL_VARIABLE: process.env.NODE_ENV === "production" ? "foo" : "bar"
+}
+```
+
 To use these config variables inside your application, just use the `config()` function inside `react-server` and
 you're all set!  This works reliably on both server and client sides of the application--fully isomorphic! 
 Here's an example:

--- a/packages/react-server/core/config.js
+++ b/packages/react-server/core/config.js
@@ -19,7 +19,7 @@ if (SERVER_SIDE) {
 				// Node.js tries to load `config.js` file first. If `config.js` doesn't exist, Node.js
 				// then try to load `config.json`.
 				configFilePath = path.join(process.cwd(), configFilePath + "/config");
-				config = Object.freeze(configFilePath);
+				config = Object.freeze(require(configFilePath));
 			} else {
 				config = Object.freeze({});
 			}

--- a/packages/react-server/core/config.js
+++ b/packages/react-server/core/config.js
@@ -1,4 +1,3 @@
-
 /**
  * Thin wrapper around the environment-specific configuration file
  */
@@ -10,13 +9,17 @@ if (SERVER_SIDE) {
 	module.exports = function () {
 		// only read out the config once, and then cache it. -sra.
 		if (null === config) {
-			/*eslint-disable no-process-env */
+
+			//eslint-disable-next-line no-process-env
 			if (process.env.REACT_SERVER_CONFIGS) {
-				var fs = require("fs");
-				/*eslint-disable no-process-env */
-				var configFile = fs.readFileSync(process.env.REACT_SERVER_CONFIGS + "/config.json");
-				/*eslint-disable no-process-env */
-				config = Object.freeze(JSON.parse(configFile));
+				var path = require('path');
+				//eslint-disable-next-line no-process-env
+				var configFilePath = process.env.REACT_SERVER_CONFIGS;
+
+				// Node.js tries to load `config.js` file first. If `config.js` doesn't exist, Node.js
+				// then try to load `config.json`.
+				var configFilePath = path.join(process.cwd(), configFilePath + "/config");
+				config = require(configFilePath);
 			} else {
 				config = Object.freeze({});
 			}

--- a/packages/react-server/core/config.js
+++ b/packages/react-server/core/config.js
@@ -18,8 +18,8 @@ if (SERVER_SIDE) {
 
 				// Node.js tries to load `config.js` file first. If `config.js` doesn't exist, Node.js
 				// then try to load `config.json`.
-				var configFilePath = path.join(process.cwd(), configFilePath + "/config");
-				config = require(configFilePath);
+				configFilePath = path.join(process.cwd(), configFilePath + "/config");
+				config = Object.freeze(configFilePath);
 			} else {
 				config = Object.freeze({});
 			}


### PR DESCRIPTION
There is a hidden feature in [`packages/react-server/core/config.js`](https://github.com/redfin/react-server/blob/master/packages/react-server/core/config.js), it read `config.json` file from folder specified by `process.env.REACT_SERVER_CONFIGS` and client side gets same config by rehydration. However, since it is json file, there is no way to config dynamically. For example, different API endpoint for dev env and production env.

This PR make `react-server` try to load `config.js` file in `process.env.REACT_SERVER_CONFIGS` folder first. If `config.js` doesn't exist, then `config.json` file is used.

An exmaple of  `.config.js` file might be like below.
```
if (process.env.NODE_ENV==='production') {
  module.exports = {
     api: 'http://some-domain/'
  };
} else {
  module.exports = {
     api: 'http://dev.some-domain/'
  };
]
```
This might be helpful for a lot of application.
