### PR TITLE
Fix react-server-cli AVA test issues

### DIFF
--- a/packages/react-server-cli/test/commands.js
+++ b/packages/react-server-cli/test/commands.js
@@ -67,8 +67,14 @@ fs.readdirSync(fixturesPath).forEach(testName => {
 			}, frequency);
 		});
 
-		if (stdoutIncludes) t.true(stdout.includes(stdoutIncludes), 'stdout includes expected output');
-		if (stderrIncludes) t.true(stderr.includes(stderrIncludes), 'stderr includes expected output');
+		t.true(
+			stderrIncludes ? stderr.includes(stderrIncludes) : stderr === '',
+			'stderr does not include expected output.  Instead, it says: ' + stderr
+		);
+		t.true(
+			stdoutIncludes ? stdout.includes(stdoutIncludes) : stdout === '',
+			'stdout does not include expected output.  Instead, it says: ' + stdout
+		);
 
 		server.kill();
 

--- a/packages/react-server-cli/test/fixtures/commands/start-basic/options.json
+++ b/packages/react-server-cli/test/fixtures/commands/start-basic/options.json
@@ -1,4 +1,4 @@
 {
-	"args": ["start"],
+	"args": ["start", "--port", "8780", "--js-port", "8781"],
 	"stdoutIncludes": "Started HTML server over HTTP on"
 }

--- a/packages/react-server-cli/test/fixtures/commands/start-missing-routes/options.json
+++ b/packages/react-server-cli/test/fixtures/commands/start-missing-routes/options.json
@@ -1,4 +1,4 @@
 {
-	"args": ["start"],
+	"args": ["start", "--port", "8782", "--js-port", "8783"],
 	"stderrIncludes": "Failed to load routes file at"
 }

--- a/packages/react-server-cli/test/fixtures/commands/start-reactserverrc/options.json
+++ b/packages/react-server-cli/test/fixtures/commands/start-reactserverrc/options.json
@@ -1,4 +1,4 @@
 {
-	"args": ["start"],
+	"args": ["start", "--port", "8784", "--js-port", "8785"],
 	"stdoutIncludes": "Started HTML server over HTTP on"
 }

--- a/packages/react-server-cli/test/fixtures/commands/start-routes-with-error/options.json
+++ b/packages/react-server-cli/test/fixtures/commands/start-routes-with-error/options.json
@@ -1,4 +1,4 @@
 {
-	"args": ["start", "--routes-file", "routes.js"],
+	"args": ["start", "--routes-file", "routes.js", "--port", "8786", "--js-port", "8787"],
 	"stderrIncludes": "ReferenceError: undeclaredVariable is not defined"
 }


### PR DESCRIPTION
Addresses issues discussed [here](https://react-server.slack.com/archives/discussion/p1485902484000972) and, possibly, reasons why #871 is failing build.

* Uses custom ports for the CLI tests
* Tests additional edge case for stdout/stderr in case there are other errors in stderr that need to be displayed.