### PR TITLE
Let webpack see CSS from dependencies

### DIFF
--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -181,7 +181,6 @@ function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, l
 				{
 					test: /\.css$/,
 					loader: extractTextLoader,
-					exclude: /node_modules/,
 				},
 				{
 					test: /\.(eot|woff|woff2|ttf|ttc|png|svg|jpg|jpeg|gif|cgm|tiff|webp|bmp|ico)$/i,


### PR DESCRIPTION
If a dep has CSS, makes sense to bundle it.

Fixes #878.