### PR TITLE
Updating generator-react-server to use ^v0.6.0

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,6 +1,8 @@
 ### Deployment Checklist
 
 - `git checkout master && git pull upstream master`
+- verify `packages/generator-react-server/generators/app/templates/package.json` has the
+  correct versions of react-server packages
 - `npm config get registry`
     - Make sure it's `https://registry.npmjs.org/`
 - `npm run clean`

--- a/packages/generator-react-server/generators/app/templates/package.json
+++ b/packages/generator-react-server/generators/app/templates/package.json
@@ -10,12 +10,12 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "babel-preset-react-server": "^0.4.10",
+    "babel-preset-react-server": "^0.6.0",
     "babel-runtime": "^6.6.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-server": "^0.5.1",
-    "react-server-cli": "^0.5.1",
+    "react-server": "^0.6.0",
+    "react-server-cli": "^0.6.0",
     "superagent": "1.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
`generator-react-server` got missed when 0.6.0 was released, resulting in confusing issues for folks trying to use features that are new in 0.6.0.