### PR TITLE
Handle absolute paths in `REACT_SERVER_CONFIGS`

### DIFF
--- a/packages/react-server/core/config.js
+++ b/packages/react-server/core/config.js
@@ -18,7 +18,12 @@ if (SERVER_SIDE) {
 
 				// Node.js tries to load `config.js` file first. If `config.js` doesn't exist, Node.js
 				// then try to load `config.json`.
-				configFilePath = path.join(process.cwd(), configFilePath + "/config");
+				//
+				// If `configFilePath` is absolute `require.resolve` will
+				// reset to it, correctly overriding `process.cwd()`.  If it
+				// is relative, then it will be relative to `process.cwd()`.
+				//
+				configFilePath = path.resolve(process.cwd(), configFilePath, "config");
 				config = Object.freeze(require(configFilePath));
 			} else {
 				config = Object.freeze({});


### PR DESCRIPTION
Looks like #871 introduced a regression where absolute paths are no longer
supported in the `REACT_SERVER_CONFIGS` environment variable.

This can be addressed by using `path.resolve`:
```js
> path.resolve("/home/foo", "bar/baz", "config");
'/home/foo/bar/baz/config'
> path.resolve("/home/foo", "/bar/baz", "config");
'/bar/baz/config'
```

In place of `path.join`:
```js
> path.join("/home/foo", "bar/baz", "config");
'/home/foo/bar/baz/config'
> path.join("/home/foo", "/bar/baz", "config");
'/home/foo/bar/baz/config'
```

I also removed the path concatenation (`... + "/config"`).