### PR TITLE
Async flag to allow scripts to be rendered async or not

### DIFF
--- a/packages/react-server/core/__tests__/NormalValuesPage.js
+++ b/packages/react-server/core/__tests__/NormalValuesPage.js
@@ -14,4 +14,9 @@ export default class NormalValuesPage {
 			href: '//www.google.com',
 		};
 	}
+	getScripts() {
+		return [
+			{href: '//www.google.com/test.js', async: false}
+		];
+	}
 }

--- a/packages/react-server/core/__tests__/reactMiddlewareSpec.js
+++ b/packages/react-server/core/__tests__/reactMiddlewareSpec.js
@@ -123,5 +123,13 @@ describe("renderMiddleware", () => {
 				}, finishTest.fail)
 				.done(finishTest);
 		});
+
+		it("render a script tag", (finishTest) => {
+			_testFunctions.renderScripts(page, mockSocket)
+				.then(() => {
+					expect(mockSocket.toString()).toBe('<script src="//www.google.com/test.js" type="text/javascript"></script>');
+				}, finishTest.fail)
+				.done(finishTest);
+		});
 	});
 });

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -602,7 +602,11 @@ function renderScripts(pageObject, res) {
 		script => script.type && script.type !== "text/javascript"
 	).length;
 
-	if (thereIsAtLeastOneNonJSScript){
+	var hasSyncScript = scripts.some(function (script) {
+		return !script.async
+	});
+
+	if (thereIsAtLeastOneNonJSScript || hasSyncScript) {
 
 		// If there are non-JS scripts we can't use LAB for async
 		// loading.  We still want to preserve script execution order,
@@ -1074,4 +1078,5 @@ module.exports._testFunctions = {
 	renderMetaTags,
 	renderLinkTags,
 	renderBaseTag,
+	renderScripts,
 };

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -280,6 +280,8 @@ function standardizeScripts(scripts) {
 			script = { href:script }
 		}
 
+		if (script.async === undefined) script.async = true;
+
 		if (!script.type) script.type = "text/javascript";
 
 		// Default is strict mode unless otherwise specified.


### PR DESCRIPTION
Add an async flag to allow fine grained control over how scripts should be rendered. Helpful when you need to include some third party libraries.

