### PR TITLE
Allow group selection in `logging.addRewriter`

### DIFF
--- a/packages/react-server/core/logging/server.js
+++ b/packages/react-server/core/logging/server.js
@@ -123,8 +123,10 @@ function addTransport(group, transport) {
 	});
 }
 
-function addRewriter(rewriter) {
-	common.forEachLogger(logger => logger.rewriters.push(rewriter));
+function addRewriter(group, rewriter) {
+	common.forEachLogger((logger, loggerGroup) => {
+		if (loggerGroup === group) logger.rewriters.push(rewriter);
+	});
 }
 
 function setTimestamp(bool) {


### PR DESCRIPTION
This makes it possible to add a rewriter only for the main logger, for example.

This also makes the interface consistent with `addTransport` and `setLevel`.

This is a breaking change.