### PR TITLE
Export 'watch' as an npm script to speed dev on react-server-cli

### DIFF
--- a/packages/react-server-cli/gulpfile.babel.js
+++ b/packages/react-server-cli/gulpfile.babel.js
@@ -1,27 +1,30 @@
 import eslint from "gulp-eslint";
 import gulp from "gulp";
 import babel from "gulp-babel";
+import changed from "gulp-changed";
 import jasmine from "gulp-jasmine";
 import logging from "react-server-gulp-module-tagger";
 
 gulp.task("default", () => {
+	var dest = "target";
 	return gulp.src("src/**/*.js")
+		.pipe(changed(dest))
 		.pipe(logging())
 		.pipe(babel())
-		.pipe(gulp.dest("target"));
+		.pipe(gulp.dest(dest));
 });
 
 gulp.task("eslint", [], () => {
 	return gulp.src("src/**/*.js")
-        // eslint() attaches the lint output to the eslint property
-        // of the file object so it can be used by other modules.
-        .pipe(eslint())
-        // eslint.format() outputs the lint results to the console.
-        // Alternatively use eslint.formatEach() (see Docs).
-        .pipe(eslint.format())
-        // To have the process exit with an error code (1) on
-        // lint error, return the stream and pipe to failOnError last.
-        .pipe(eslint.failAfterError());
+	// eslint() attaches the lint output to the eslint property
+	// of the file object so it can be used by other modules.
+	.pipe(eslint())
+	// eslint.format() outputs the lint results to the console.
+	// Alternatively use eslint.formatEach() (see Docs).
+	.pipe(eslint.format())
+	// To have the process exit with an error code (1) on
+	// lint error, return the stream and pipe to failOnError last.
+	.pipe(eslint.failAfterError());
 });
 
 gulp.task("test", ["default", "eslint"], () => {
@@ -30,5 +33,5 @@ gulp.task("test", ["default", "eslint"], () => {
 });
 
 gulp.task("watch", () => {
-	gulp.watch("src/*.js", ['default']);
+	gulp.watch("src/**/*.js", ['default']);
 });

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prepublish": "gulp",
     "lint": "gulp eslint",
+    "watch": "gulp && gulp watch",
     "test": "npm run ava && gulp test && nsp check",
     "ava": "ava",
     "ava-watch": "ava --watch",
@@ -60,6 +61,7 @@
     "fs-readdir-recursive": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
+    "gulp-changed": "^1.3.2",
     "gulp-eslint": "^3.0.1",
     "gulp-jasmine": "^2.4.2",
     "memory-stream": "0.0.3",


### PR DESCRIPTION
* Adds gulp-changed to avoid unnecessary rebuilds
* Fixes mixed spaces/tabs in gulpfile (converts to tabs)

View gulpfile changes with `?w=1`: https://github.com/redfin/react-server/pull/922/files?w=1