### PR TITLE
Update react-server dependencies on examples to latest

### DIFF
--- a/packages/react-server-examples/bike-share/package.json
+++ b/packages/react-server-examples/bike-share/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "react": "^15.4.1",
     "react-dom": "15.4.1",
-    "react-server": "^0.5.1",
-    "react-server-cli": "^0.5.1",
+    "react-server": "^0.6.3",
+    "react-server-cli": "^0.6.3",
     "request-promise": "^4.1.1",
     "superagent": "1.8.4"
   },

--- a/packages/react-server-examples/hello-world/package.json
+++ b/packages/react-server-examples/hello-world/package.json
@@ -17,8 +17,8 @@
     "babel-runtime": "^6.18.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-server": "^0.5.1",
-    "react-server-cli": "^0.5.1",
+    "react-server": "^0.6.3",
+    "react-server-cli": "^0.6.3",
     "superagent": "1.8.4"
   }
 }

--- a/packages/react-server-examples/meteor-site/package.json
+++ b/packages/react-server-examples/meteor-site/package.json
@@ -18,14 +18,14 @@
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^4.4.6",
-    "react-server": "^0.6.1",
-    "react-server-redux": "^0.6.1",
+    "react-server": "^0.6.3",
+    "react-server-redux": "^0.6.3",
     "redux": "3.6.0",
     "redux-thunk": "2.1.0",
     "superagent": "1.8.4"
   },
   "devDependencies": {
     "babel-preset-react-server": "^0.4.10",
-    "react-server-cli": "^0.6.1"
+    "react-server-cli": "^0.6.3"
   }
 }

--- a/packages/react-server-examples/redux-basic/package.json
+++ b/packages/react-server-examples/redux-basic/package.json
@@ -15,9 +15,9 @@
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^4.4.5",
-    "react-server": "^0.5.1",
-    "react-server-redux": "^0.5.1",
-    "react-server-cli": "^0.5.1",
+    "react-server": "^0.6.3",
+    "react-server-redux": "^0.6.3",
+    "react-server-cli": "^0.6.3",
     "redux": "^3.5.2",
     "superagent": "1.8.4"
   },


### PR DESCRIPTION
redux-basic example needs compatible version of react-server to install correctly.
```
npm ERR! notarget No compatible version found: react-server-redux@^0.5.1  
npm ERR! notarget Valid install targets:   
npm ERR! notarget 0.6.3, 0.6.1, 0.6.0   
```
(other examples needed update also)