### PR TITLE
Only add the errorInterceptor to the main logger

### DIFF
--- a/packages/react-server/core/logging/server.js
+++ b/packages/react-server/core/logging/server.js
@@ -35,7 +35,10 @@ var makeLogger = function(group, opts){
 
 	logger.setLevels(config.levels);
 
-	logger.rewriters.push(errorInterceptor);
+	// Only need to look for errors in the main logger's meta.
+	if (group === "main") {
+		logger.rewriters.push(errorInterceptor);
+	}
 
 	logger.stack = common.stack;
 


### PR DESCRIPTION
There are no error objects in stat logger meta that need rewriting.