### PR TITLE
Another flash of unstyled content

### DIFF
--- a/packages/react-server/core/util/ClientCssHelper.js
+++ b/packages/react-server/core/util/ClientCssHelper.js
@@ -98,8 +98,8 @@ module.exports = {
 function normalizeLocalUrl(url) {
 	const urlBase = location.host + (location.port ? ':' + location.port : '');
 
-	// Step 1: make the url protocol less first.  This helps recognizing http://0.0.0.0:3001/common.css and //0.0.0.0:3001/common.css
-	// as the same file
+	// Step 1: make the url protocol less first.  This helps recognizing http://0.0.0.0:3001/common.css
+	// and //0.0.0.0:3001/common.css as the same file.
 	// Step 2: The browser will give us a full URL even if we only put a
 	// path in on the server.  So, if we're comparing against just
 	// a path here we need to strip the base off to avoid a flash
@@ -109,8 +109,6 @@ function normalizeLocalUrl(url) {
 			.replace(/^http[s]?:/, '')
 			.replace(new RegExp("^\/\/" + urlBase), '');
 	}
-
-	console.log('after modification: ', url);
 
 	return url;
 }

--- a/packages/react-server/core/util/ClientCssHelper.js
+++ b/packages/react-server/core/util/ClientCssHelper.js
@@ -96,15 +96,21 @@ module.exports = {
 }
 
 function normalizeLocalUrl(url) {
-	const urlBase = location.protocol + "//" + location.host;
+	const urlBase = location.host + (location.port ? ':' + location.port : '');
 
-	// The browser will give us a full URL even if we only put a
+	// Step 1: make the url protocol less first.  This helps recognizing http://0.0.0.0:3001/common.css and //0.0.0.0:3001/common.css
+	// as the same file
+	// Step 2: The browser will give us a full URL even if we only put a
 	// path in on the server.  So, if we're comparing against just
 	// a path here we need to strip the base off to avoid a flash
 	// of unstyled content.
-	if (url && url.indexOf(urlBase) === 0) {
-		url = url.substr(urlBase.length);
+	if (typeof url === 'string') {
+		url = url
+			.replace(/^http[s]?:/, '')
+			.replace(new RegExp("^\/\/" + urlBase), '');
 	}
+
+	console.log('after modification: ', url);
 
 	return url;
 }

--- a/packages/react-server/core/util/ClientCssHelper.js
+++ b/packages/react-server/core/util/ClientCssHelper.js
@@ -96,8 +96,6 @@ module.exports = {
 }
 
 function normalizeLocalUrl(url) {
-	const urlBase = location.host + (location.port ? ':' + location.port : '');
-
 	// Step 1: make the url protocol less first.  This helps recognizing http://0.0.0.0:3001/common.css
 	// and //0.0.0.0:3001/common.css as the same file.
 	// Step 2: The browser will give us a full URL even if we only put a
@@ -107,7 +105,7 @@ function normalizeLocalUrl(url) {
 	if (typeof url === 'string') {
 		url = url
 			.replace(/^http[s]?:/, '')
-			.replace(new RegExp("^\/\/" + urlBase), '');
+			.replace(new RegExp("^\/\/" + location.host), '');
 	}
 
 	return url;


### PR DESCRIPTION
This fix builds on the work in #501 and handles the case where the below URLs are seen as different, thereby creating a flash of unstyled content:

```
http://0.0.0.0:3001/common.css
//0.0.0.0:3001/common.css
```