### PR TITLE
Pretty print errors for the client in dev environments

### DIFF
--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -69,6 +69,7 @@ const startHtmlServer = (serverRoutes, port, bindIp, httpsOptions, customMiddlew
 		server.use(bodyParser.json());
 		server.use(helmet());
 		rsMiddleware();
+		server.use(reactServer.errorHandlingMiddleWare);
 	};
 
 	return {
@@ -88,10 +89,9 @@ const startHtmlServer = (serverRoutes, port, bindIp, httpsOptions, customMiddlew
 				// sets the namespace that data will be exposed into client-side
 				// TODO: express-state doesn't do much for us until we're using a templating library
 				server.set('state namespace', '__reactServerState');
+				server.set("reactServerRoutes", require(serverRoutes));
+				server.use(reactServer.renderMiddleware);
 
-				server.use((req, res, next) => {
-					reactServer.middleware(req, res, next, require(serverRoutes));
-				});
 			};
 
 			if (customMiddlewarePath) {

--- a/packages/react-server-cli/src/commands/start.js
+++ b/packages/react-server-cli/src/commands/start.js
@@ -69,7 +69,7 @@ const startHtmlServer = (serverRoutes, port, bindIp, httpsOptions, customMiddlew
 		server.use(bodyParser.json());
 		server.use(helmet());
 		rsMiddleware();
-		server.use(reactServer.errorHandlingMiddleWare);
+		server.use(reactServer.errorHandlingMiddleware);
 	};
 
 	return {

--- a/packages/react-server-integration-tests/src/__tests__/internalServerError/InternalServerErrorSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/internalServerError/InternalServerErrorSpec.js
@@ -1,22 +1,12 @@
 var helper = require("../../specRuntime/testHelper");
 var Browser = require("zombie");
 
-const INTERNAL_SERVER_ERROR_PAGE = `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Error</title>
-</head>
-<body>
-<pre>[object Object]</pre>
-</body>
-</html>\n`;
-
 describe("A 500 internal server error page", () => {
 
 	a500("has no body by default", '/internalServerErrorNoDocument', txt => {
 		// Yikes... not good default behavior.
-		expect(txt).toBe(INTERNAL_SERVER_ERROR_PAGE);
+		expect(txt).toContain("<b>Code:</b> 500");
+		expect(txt).toContain("Error: Page returned code 500");
 	});
 
 	a500("has a body with `hasDocument: true`", '/internalServerErrorWithDocument', txt => {
@@ -26,11 +16,13 @@ describe("A 500 internal server error page", () => {
 	});
 
 	a500("can result from an exception during `handleRoute()`", '/internalServerErrorException', txt => {
-		expect(txt).toBe(INTERNAL_SERVER_ERROR_PAGE)
+		expect(txt).toContain("<b>Code:</b> undefined");
+		expect(txt).toContain("Error: died");
 	});
 
 	a500("can result from a rejection from `handleRoute()`", '/internalServerErrorRejection', txt => {
-		expect(txt).toBe(INTERNAL_SERVER_ERROR_PAGE)
+		expect(txt).toContain("<b>Code:</b> undefined");
+		expect(txt).toContain("rejected");
 	});
 
 	// Pass `xit` for `the500` to mark a test as pending.

--- a/packages/react-server-integration-tests/src/__tests__/notFound/NotFoundSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/notFound/NotFoundSpec.js
@@ -1,33 +1,22 @@
 var helper = require("../../specRuntime/testHelper");
 var Browser = require("zombie");
 
-function getNotFoundPage(message) {
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Error</title>
-</head>
-<body>
-<pre>${message}</pre>
-</body>
-</html>\n`;
-}
-
 describe("A 404 not found page", () => {
 
 	a404("can result from no route", '/notFoundDoesNotExist', txt => {
-		expect(txt).toBe(getNotFoundPage('Cannot GET /notFoundDoesNotExist'))
+		expect(txt).toContain("<b>Code:</b> 404");
+		expect(txt).toContain("Error: Route not found /notFoundDoesNotExist");
 	});
 
 	a404("has no body by default", '/notFoundNoDocument', txt => {
-		expect(txt).toBe(getNotFoundPage('Cannot GET /notFoundNoDocument'))
+		expect(txt).toContain("<b>Code:</b> 404");
+		expect(txt).toContain("Error: Page returned code 404");
 	});
 
-	a404("has a body with `hasDocument: true`", '/notFoundWithDocument', txt => {
-		expect(txt).not.toMatch(getNotFoundPage('Cannot GET /notFoundNoDocument'))
-		expect(txt).toMatch('foo</title>')
-		expect(txt).toMatch('foo</div>')
+	a404("has a body with `hasDocument: true`", "/notFoundWithDocument", txt => {
+		expect(txt).not.toContain("Error: Route not found /notFoundNoDocument");
+		expect(txt).toMatch("foo</title>");
+		expect(txt).toMatch("foo</div>");
 	});
 
 	function a404(spec, url, callback) {

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -1,4 +1,3 @@
-
 var EventEmitter = require('events').EventEmitter,
 	logger = require('../logging').getLogger(__LOGGER__),
 	Router = require('routr'),
@@ -7,6 +6,7 @@ var EventEmitter = require('events').EventEmitter,
 	ReactServerAgent = require("../ReactServerAgent"),
 	PageUtil = require("../util/PageUtil"),
 	DebugUtil = require("../util/DebugUtil"),
+	HttpError = require('../errors/HttpError'),
 	{setResponseLoggerPage} = SERVER_SIDE ? require('../logging/response') : { setResponseLoggerPage: () => {} };
 
 var _ = {
@@ -52,7 +52,8 @@ class Navigator extends EventEmitter {
 		if (route) {
 			logger.debug(`Mapped ${request.getUrl()} to route ${route.name}`);
 		} else {
-			this.emit('navigateDone', { status: 404, message: "No Route!" }, null, request.getUrl(), type);
+			let url = request.getUrl();
+			this.emit('navigateDone', new HttpError("Route not found " + url, {code: 404, url: url}), null, request.getUrl(), type);
 			return;
 		}
 
@@ -203,7 +204,11 @@ class Navigator extends EventEmitter {
 			// TODO: I think that 3xx/4xx/5xx shouldn't be considered "errors" in navigateDone, but that's
 			// how the code is structured right now, and I'm changing too many things at once at the moment. -sra.
 			if (handleRouteResult.code && ((handleRouteResult.code / 100)|0) !== 2) {
-				this.emit("navigateDone", {status: handleRouteResult.code, redirectUrl: handleRouteResult.location}, page, request.getUrl(), type);
+				let redirectError = new HttpError("Redirect");
+				redirectError.code = handleRouteResult.code;
+				redirectError.redirectUrl = handleRouteResult.location;
+
+				this.emit("navigateDone", redirectError, page, request.getUrl(), type);
 				return;
 			}
 			if (handleRouteResult.page) {
@@ -216,9 +221,7 @@ class Navigator extends EventEmitter {
 
 			this.emit('navigateDone', null, page, request.getUrl(), type);
 		}).catch(err => {
-			logger.error("Error while handling route", err);
-
-			this.emit('navigateDone', {status: 500}, page, request.getUrl(), type);
+			this.emit('navigateDone', err, page, request.getUrl(), type);
 		});
 
 	}

--- a/packages/react-server/core/context/Navigator.js
+++ b/packages/react-server/core/context/Navigator.js
@@ -204,11 +204,11 @@ class Navigator extends EventEmitter {
 			// TODO: I think that 3xx/4xx/5xx shouldn't be considered "errors" in navigateDone, but that's
 			// how the code is structured right now, and I'm changing too many things at once at the moment. -sra.
 			if (handleRouteResult.code && ((handleRouteResult.code / 100)|0) !== 2) {
-				let redirectError = new HttpError("Redirect");
-				redirectError.code = handleRouteResult.code;
-				redirectError.redirectUrl = handleRouteResult.location;
 
-				this.emit("navigateDone", redirectError, page, request.getUrl(), type);
+				let error = new HttpError("Page returned code " + handleRouteResult.code, {code: handleRouteResult.code});
+				error.redirectUrl = handleRouteResult.location;
+				page.setRedirectUrl(handleRouteResult.location);
+				this.emit("navigateDone", error, page, request.getUrl(), type);
 				return;
 			}
 			if (handleRouteResult.page) {
@@ -220,9 +220,7 @@ class Navigator extends EventEmitter {
 			}
 
 			this.emit('navigateDone', null, page, request.getUrl(), type);
-		}).catch(err => {
-			this.emit('navigateDone', err, page, request.getUrl(), type);
-		});
+		}).catch(err => this.emit('navigateDone', err, page, request.getUrl(), type));
 
 	}
 

--- a/packages/react-server/core/context/RequestContext.js
+++ b/packages/react-server/core/context/RequestContext.js
@@ -56,11 +56,9 @@ class RequestContext {
 		let defer = Q.defer();
 		this.navigator.on('navigateDone', (err, page) => {
 			if (!err) {
-				logger.debug("no error")
 				return defer.resolve(page);
 			}
 			if (!page || !page.getHasDocument()) {
-				logger.debug("no page document")
 				return defer.reject(err);
 			}
 

--- a/packages/react-server/core/context/RequestContext.js
+++ b/packages/react-server/core/context/RequestContext.js
@@ -1,5 +1,6 @@
 
 var Navigator = require('./Navigator'),
+	Q = require("q"),
 	RequestLocals = require('../util/RequestLocalStorage').getNamespace();
 
 class RequestContext {
@@ -51,6 +52,12 @@ class RequestContext {
 		this.navigator.on('navigateDone', callback);
 	}
 
+	onNavigatePromise () {
+		let defer = Q.defer();
+		this.navigator.on('navigateDone', (err, page) => err ? defer.reject(err) : defer.resolve(page));
+		return defer.promise;
+	}
+
 	onNavigateStart (callback) {
 		this.navigator.on('navigateStart', callback);
 	}
@@ -88,4 +95,3 @@ class RequestContextBuilder {
 
 module.exports = RequestContext;
 module.exports.Builder = RequestContextBuilder;
-

--- a/packages/react-server/core/errorHandlingMiddleware.js
+++ b/packages/react-server/core/errorHandlingMiddleware.js
@@ -1,0 +1,41 @@
+
+import HttpError from './errors/HttpError';
+
+var logger = require('./logging').getLogger(__LOGGER__);
+
+module.exports = function(err, req, res, next) {
+
+	logger.error(err.message, err);
+
+	//Delegate to default express error handler if headers have been sent,
+	//or if we are dealing with a native error
+	if (res.headersSent || !(err instanceof HttpError)) {
+		next(err);
+		return;
+	}
+
+	let code = err.code || err.status;
+
+	if (code === 301 || code === 302 || code === 307) {
+		res.redirect(code, err.redirectUrl);
+		return;
+	}
+
+	//Some rough bounds checking here
+	if (typeof code !== "number" || code <= 0 || code >= 1000) {
+		code = 500;
+	}
+
+	res.status(code);
+
+	if (process.env.NODE_ENV === "production") { // eslint-disable-line no-process-env
+		res.send(err.message);
+		return;
+	}
+
+	res.json({
+		message: err.message,
+		code: code,
+		metaData: err.metaData,
+	});
+}

--- a/packages/react-server/core/errors/HttpError.js
+++ b/packages/react-server/core/errors/HttpError.js
@@ -1,0 +1,17 @@
+//Basic wrapper for errors that elicit a non-2xx HTTP response
+//Examples: 404, 400, 500
+export default class HttpError extends Error {
+	constructor(message, metaData) {
+		super(message);
+		this.name = this.constructor.name;
+		this.code = this.status = metaData && metaData.code ? metaData.code : 500;
+		this.metaData = metaData;
+
+		if (typeof Error.captureStackTrace === 'function') {
+			Error.captureStackTrace(this, this.constructor);
+		}
+		else {
+			this.stack = (new Error(message)).stack;
+		}
+	}
+}

--- a/packages/react-server/core/errors/HttpError.js
+++ b/packages/react-server/core/errors/HttpError.js
@@ -6,12 +6,6 @@ export default class HttpError extends Error {
 		this.name = this.constructor.name;
 		this.code = this.status = metaData && metaData.code ? metaData.code : 500;
 		this.metaData = metaData;
-
-		if (typeof Error.captureStackTrace === 'function') {
-			Error.captureStackTrace(this, this.constructor);
-		}
-		else {
-			this.stack = (new Error(message)).stack;
-		}
+		this.stack = (new Error(message)).stack;
 	}
 }

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -6,6 +6,7 @@ var logger = require('./logging').getLogger(__LOGGER__),
 	RequestContext = require('./context/RequestContext'),
 	RequestLocalStorage = require('./util/RequestLocalStorage'),
 	DebugUtil = require('./util/DebugUtil'),
+	HttpError = require('./errors/HttpError'),
 	RLS = RequestLocalStorage.getNamespace(),
 	flab = require('flab'),
 	Q = require('q'),
@@ -43,7 +44,8 @@ var ELEMENT_ALREADY_WRITTEN = -2;
 /**
  * renderMiddleware entrypoint. Called by express for every request.
  */
-module.exports = function(req, res, next, routes) {
+module.exports = function(req, res, next) {
+
 	RequestLocalStorage.startRequest(() => {
 		ACTIVE_REQUESTS++;
 
@@ -67,7 +69,7 @@ module.exports = function(req, res, next, routes) {
 
 		// TODO? pull this context building into its own middleware
 		var context = new RequestContext.Builder()
-				.setRoutes(routes)
+				.setRoutes(req.app.get("reactServerRoutes"))
 				.setDefaultXhrHeadersFromRequest(req)
 				.create({
 					// TODO: context opts?
@@ -75,77 +77,35 @@ module.exports = function(req, res, next, routes) {
 
 		// Need this stuff in for logging.
 		context.setServerStash({ req, res, start, startHR });
-
 		context.setMobileDetect(new MobileDetect(req.get('user-agent')));
 
-		var navigateDfd = Q.defer();
+		let timeoutDefer = Q.defer();
+
+		const timeout = setTimeout(() => {
+			let metaData = {
+				page: context.page,
+				path: req.path,
+			};
+			timeoutDefer.reject(new HttpError(`Navigation timed out after ${FAILSAFE_ROUTER_TIMEOUT}ms`, metaData));
+		}, FAILSAFE_ROUTER_TIMEOUT);
+
+		context.onNavigate((err, page) => logger.debug('on nav' , err, page))
 
 		// setup navigation handler (TODO: should we have a 'once' version?)
-		context.onNavigate( (err, page) => {
-
-			if (!navigateDfd.promise.isPending()) {
-				logger.error("Finished navigation after FAILSAFE_ROUTER_TIMEOUT", {
-					page: context.page,
-					path: req.path,
-				});
-				return;
-			}
-
-			// Success.
-			navigateDfd.resolve();
-
-
-			if (err) {
-				// The page can elect to proceed to render
-				// even with a non-2xx response.  If it
-				// _doesn't_ do so then we're done.
-				var done = !(page && page.getHasDocument());
-
-				if (err.status === 301 || err.status === 302 || err.status === 307) {
-					if (done){
-						// This adds a boilerplate body.
-						res.redirect(err.status, err.redirectUrl);
-					} else {
-						// This expects our page to
-						// render a body.  Hope they
-						// know what they're doing.
-						res.set('Location', err.redirectUrl);
-					}
-				} else if (done) {
-					if (err.status === 404) {
-						next();
-					} else {
-						next(err);
-					}
-				}
-				if (done) {
-					logger.log("onNavigate received a non-2xx HTTP code", err);
-					handleResponseComplete(req, res, context, start, page);
-					return;
-				}
-			}
-			renderPage(req, res, context, start, page);
-
-		});
-
-
-		const timeout = setTimeout(navigateDfd.reject, FAILSAFE_ROUTER_TIMEOUT);
-
-		// Don't leave dead timers hanging around.
-		navigateDfd.promise.then(() => clearTimeout(timeout));
-
-		// If we fail to navigate, we'll throw a 500 and move on.
-		navigateDfd.promise.catch(() => {
-			logger.error("Failed to navigate after FAILSAFE_ROUTER_TIMEOUT", {
-				page: context.navigator.getCurrentRoute().name,
-				path: req.path,
-			});
-			handleResponseComplete(req, res, context, start, context.page);
-			next({status: 500});
-		});
+		Q.race([
+			context.onNavigatePromise(),
+			timeoutDefer.promise,
+		])
+		.tap(() => clearTimeout(timeout)) //Clear timeout if promise succeeds - not strictly neccessary
+		.then((page) => renderPage(req, res, context, page))
+		.then(() => endResponse(req, res))
+		.catch(next)
+		.finally(() => {
+			clearTimeout(timeout);
+			handleResponseComplete(req, res, context);
+		}); //Clear timeout if promise fails
 
 		context.navigate(new ExpressServerRequest(req));
-
 	});
 };
 
@@ -160,7 +120,7 @@ function initResponseCompletePromise(res){
 	RLS().responseCompletePromise = dfd.promise;
 }
 
-function handleResponseComplete(req, res, context, start, page) {
+function handleResponseComplete(req, res, context) {
 
 	RLS().responseCompletePromise.then(RequestLocalStorage.bind(() => {
 
@@ -174,15 +134,16 @@ function handleResponseComplete(req, res, context, start, page) {
 		// a page, we won't be able to call middleware
 		// `handleComplete()` here.
 		//
+		let page = RLS().page;
 		if (page) {
-			logRequestStats(req, res, context, start, page);
+			logRequestStats(req, res, context, page);
 
 			page.handleComplete();
 		}
 	}));
 }
 
-function renderPage(req, res, context, start, page) {
+function renderPage(req, res, context, page) {
 
 	var routeName = context.navigator.getCurrentRoute().name;
 
@@ -213,69 +174,47 @@ function renderPage(req, res, context, start, page) {
 		lifecycleMethods = pageLifecycle();
 	}
 
-	lifecycleMethods.reduce((chain, func) => chain
+	let start = RLS().startTime;
+
+	return lifecycleMethods.reduce((chain, func) => chain
 		.then(() => func(req, res, context, start, page))
 		.then(() => {
 			timer.tick(func.name);
 			logger.time(`lifecycle.fromStart.${func.name}`, new Date - start);
-		})
-	).catch(err => {
-		logger.error("Error in renderPage chain", err)
-
-		// Register `finish` listener before ending response.
-		handleResponseComplete(req, res, context, start, page);
-
-		// Bummer.
-		res.status(500).end();
-	});
-
-	// TODO: we probably want a "we're not waiting any longer for this"
-	// timeout as well, and cancel the waiting deferreds
+		}), Q())
 }
 
 function rawResponseLifecycle () {
 	return [
-		Q(), // NOOP lead-in to prime the reduction
 		setHttpHeaders,
 		setContentType,
 		writeResponseData,
-		handleResponseComplete,
-		endResponse,
 	];
 }
 
 function fragmentLifecycle () {
 	return [
-		Q(), // NOOP lead-in to prime the reduction
 		setHttpHeaders,
 		writeDebugComments,
 		writeBody,
-		handleResponseComplete,
-		endResponse,
 	];
 }
 
 function dataBundleLifecycle () {
 	return [
-		Q(), // NOOP lead-in to prime the reduction
 		setDataBundleContentType,
 		writeDataBundle,
-		handleResponseComplete,
-		endResponse,
 	];
 }
 
 function pageLifecycle() {
 	return [
-		Q(), // This is just a NOOP lead-in to prime the reduction.
 		setHttpHeaders,
 		writeHeader,
 		startBody,
 		writeBody,
 		wrapUpLateArrivals,
 		closeBody,
-		handleResponseComplete,
-		endResponse,
 	];
 }
 
@@ -308,6 +247,8 @@ function writeHeader(req, res, context, start, pageObject) {
 	res.set('Transfer-Encoding', 'chunked');
 
 	res.write("<!DOCTYPE html><html><head>");
+
+	logger.debug("WRITE HEADER")
 
 	// note: these responses can currently come back out-of-order, as many are returning
 	// promises. scripts and stylesheets are guaranteed
@@ -661,6 +602,8 @@ function startBody(req, res, context, start, page) {
  * all the ReactElements have been written out.
  */
 function writeBody(req, res, context, start, page) {
+
+	logger.debug("write body")
 
 	// standardize to an array of EarlyPromises of ReactElements
 	var elementPromises = PageUtil.standardizeElements(page.getElements());
@@ -1020,7 +963,7 @@ function endResponse(req, res) {
 	return Q();
 }
 
-function logRequestStats(req, res, context, start){
+function logRequestStats(req, res, context){
 	var allRequests = ReactServerAgent.cache().getAllRequests()
 	,   notLoaded   = ReactServerAgent.cache().getLateRequests()
 	,   sock        = req.socket
@@ -1042,7 +985,7 @@ function logRequestStats(req, res, context, start){
 	logger.gauge("bytesRead", stash.bytesR, {hi: 1<<12});
 	logger.gauge("bytesWritten", stash.bytesW, {hi: 1<<18});
 
-	var time = new Date - start;
+	var time = new Date - RLS().startTime;
 
 	logger.time(`responseCode.${res.statusCode}`, time);
 	logger.time("totalRequestTime", time);

--- a/packages/react-server/core/server.js
+++ b/packages/react-server/core/server.js
@@ -1,4 +1,4 @@
 var common = require("./common.js");
-
-common.middleware = require("./renderMiddleware")
+common.renderMiddleware = require("./renderMiddleware");
+common.errorHandlingMiddleWare = require("./errorHandlingMiddleWare");
 module.exports = common;

--- a/packages/react-server/core/server.js
+++ b/packages/react-server/core/server.js
@@ -1,4 +1,4 @@
 var common = require("./common.js");
 common.renderMiddleware = require("./renderMiddleware");
-common.errorHandlingMiddleWare = require("./errorHandlingMiddleWare");
+common.errorHandlingMiddleware = require("./errorHandlingMiddleware");
 module.exports = common;

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -193,6 +193,8 @@ var PAGE_CHAIN_PROTOTYPE = {
 	setJsBelowTheFold  : makeSetter('jsBelowTheFold'),
 	getSplitJsLoad     : makeGetter('splitJsLoad'),
 	setSplitJsLoad     : makeSetter('splitJsLoad'),
+	getRedirectUrl     : makeGetter('redirectUrl'),
+	setRedirectUrl     : makeSetter('redirectUrl'),
 };
 
 // We log all method calls on the page chain for debugging purposes.


### PR DESCRIPTION
* Add `HttpError` class that extends the native error. This will handle 4xx, 3xx, etc.

* Promisify the navigator sequence, so that errors are passed down through the promise chain and handled in one place, rather than being handled haphazardly or swallowed.

https://github.com/redfin/react-server/issues/853

The react-server middleware is last in the middleware stack, so that a user can insert their own error handling middleware ahead of the default handler.

Example error messages:
![error_404](https://user-images.githubusercontent.com/2831712/27774032-30c354b4-5f3d-11e7-83c0-2c45d03994bd.png)

![internal_server_error](https://user-images.githubusercontent.com/2831712/27774076-554f0c00-5f3e-11e7-8b77-179301828954.png)

In production:
![error_404_prod](https://user-images.githubusercontent.com/2831712/27774077-5c4bf72a-5f3e-11e7-8210-6301947da043.png)


