### PR TITLE
Add english as the default document language

### DIFF
--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -307,7 +307,7 @@ function writeHeader(req, res, context, start, pageObject) {
 	res.type('html');
 	res.set('Transfer-Encoding', 'chunked');
 
-	res.write("<!DOCTYPE html><html><head>");
+	res.write('<!DOCTYPE html><html lang="en"><head>');
 
 	// note: these responses can currently come back out-of-order, as many are returning
 	// promises. scripts and stylesheets are guaranteed


### PR DESCRIPTION
This helps screen readers use the correct pronunciation rules and to help automatic translation. I'd like to add support for specifying the document language so it isn't just english, but starting with English so there's something.