### PR TITLE
Added nsp exceptions to generator-react-server

### DIFF
--- a/packages/generator-react-server/generators/app/index.js
+++ b/packages/generator-react-server/generators/app/index.js
@@ -45,6 +45,7 @@ module.exports = yeoman.Base.extend({
 			'_eslintrc',
 			'_gitignore',
 			'_reactserverrc',
+			'_nsprc',
 		].forEach(function (filename) {
 			var fn = filename.replace('_', '.');
 			_this.fs.copyTpl(

--- a/packages/generator-react-server/generators/app/templates/_nsprc
+++ b/packages/generator-react-server/generators/app/templates/_nsprc
@@ -1,0 +1,6 @@
+{
+	"exceptions": [
+		"https://nodesecurity.io/advisories/479",
+  		"https://nodesecurity.io/advisories/535"
+	]
+}


### PR DESCRIPTION
This PR adds some exceptions to `nsp` by specifying a `.nsprc` file described under https://github.com/nodesecurity/nsp#exceptions. This means the our build won't fail for the two nsp errors that we are currently seeing. 

The suppressed errors are https://nodesecurity.io/advisories/479 which seems to be a result of us using `superagent` 1.8.4. That in turn causes https://nodesecurity.io/advisories/535 since it imports `mime` 1.3.4. 
