### PR TITLE
Reduce client logger overhead

### DIFF
--- a/packages/react-server/core/__bench__/loggingClient.js
+++ b/packages/react-server/core/__bench__/loggingClient.js
@@ -1,0 +1,50 @@
+import {Suite} from "benchmark";
+import logging from "../logging/client";
+
+const n = 1000;
+
+let enclosedDeferred;
+
+class NoopTransport {
+	constructor() {
+		this.name = 'noop';
+		this.level = 'info';
+	}
+
+	log(level, msg, meta, callback) {
+		if (meta === n || meta.ms === n) {
+			enclosedDeferred.resolve();
+		}
+		callback(null, true);
+	}
+}
+
+class NoopTimeTransport extends NoopTransport {
+	constructor() {
+		super();
+		this.level = 'fast';
+	}
+}
+
+const noTransportLogger   = logging.getLogger({name: "noTransports"});
+const noopTransportLogger = logging.getLogger({name: "noopTransport"});
+
+noopTransportLogger.add(NoopTransport)
+noopTransportLogger.timeLogger.add(NoopTimeTransport)
+
+function run(logger, method) {
+	return function(deferred) {
+		enclosedDeferred = deferred;
+		for (var i = 1; i <= n; i++) {
+			logger[method]("test", i);
+		}
+	}
+}
+
+new Suite()
+	.add("info no transports",  run(noTransportLogger,   'info'))
+	.add("info noop transport", run(noopTransportLogger, 'info'), { defer: true })
+	.add("time no transports",  run(noTransportLogger,   'time'))
+	.add("time noop transport", run(noopTransportLogger, 'time'), { defer: true })
+	.on('cycle', (v) => console.log(v.target.name + "\t" + v.target.stats.mean))
+	.run()

--- a/packages/react-server/core/logging/client.js
+++ b/packages/react-server/core/logging/client.js
@@ -70,12 +70,6 @@ var makeLogger = function(group, opts){
 		level: config.baseLevel,
 		log: function(level, msg, meta){
 
-			// We want an array of arguments to apply to
-			// `console.log` so we don't trail an `undefined` when
-			// `meta` isn't passed.
-			var args = [msg];
-			if (meta !== void 0) args.push(meta);
-
 			if (this.transports.length) {
 				this.transports.forEach(transport => {
 					if (config.levels[level] > config.levels[transport.level]) return;
@@ -84,6 +78,12 @@ var makeLogger = function(group, opts){
 			}
 
 			if (config.levels[level] > config.levels[this.level]) return;
+
+			// We want an array of arguments to apply to
+			// `console.log` so we don't trail an `undefined` when
+			// `meta` isn't passed.
+			var args = [msg];
+			if (meta !== void 0) args.push(meta);
 
 			clog(level).apply(
 				_console,

--- a/packages/react-server/core/logging/client.js
+++ b/packages/react-server/core/logging/client.js
@@ -76,10 +76,12 @@ var makeLogger = function(group, opts){
 			var args = [msg];
 			if (meta !== void 0) args.push(meta);
 
-			this.transports.forEach(transport => {
-				if (config.levels[level] > config.levels[transport.level]) return;
-				scheduleTransport([transport, level, msg, meta]);
-			});
+			if (this.transports.length) {
+				this.transports.forEach(transport => {
+					if (config.levels[level] > config.levels[transport.level]) return;
+					scheduleTransport([transport, level, msg, meta]);
+				});
+			}
 
 			if (config.levels[level] > config.levels[this.level]) return;
 

--- a/packages/react-server/core/logging/client.js
+++ b/packages/react-server/core/logging/client.js
@@ -49,12 +49,13 @@ function runTransports() {
 	transportQueue = [];
 	transportTimer = null;
 	for (var i = 0; i < batch.length; i++) {
-		batch[i]();
+		const [transport, level, msg, meta] = batch[i];
+		transport.log(level, msg, meta, noop);
 	}
 }
 
-function scheduleTransport(fn) {
-	transportQueue.push(fn);
+function scheduleTransport(tuple) {
+	transportQueue.push(tuple);
 	if (!transportTimer) {
 		transportTimer = setTimeout(runTransports, 0);
 	}
@@ -77,7 +78,7 @@ var makeLogger = function(group, opts){
 
 			this.transports.forEach(transport => {
 				if (config.levels[level] > config.levels[transport.level]) return;
-				scheduleTransport(transport.log.bind(transport, level, msg, meta, noop));
+				scheduleTransport([transport, level, msg, meta]);
 			});
 
 			if (config.levels[level] > config.levels[this.level]) return;


### PR DESCRIPTION
Small client-side performance improvement for sites that log a lot.

Added a benchmark to measure the impact.

Before:

```
info no transports      0.0030393327980000003
info noop transport     0.007346843629917184
time no transports      0.004063845286219832
time noop transport     0.008934361976376487
```

After:

```
info no transports      0.00004931556964542886
info noop transport     0.001289028179448941
time no transports      0.00010602540850444264
time noop transport     0.0011963334522868431
```