### PR TITLE
Skip re-render on back nav in Safari

### DIFF
--- a/packages/react-server/core/ClientController.js
+++ b/packages/react-server/core/ClientController.js
@@ -751,6 +751,17 @@ class ClientController extends EventEmitter {
 	}
 
 	_navigateWithHistoryState({path, state, type, check}) {
+
+		// This is for browsers (Safari) which use a page cache for
+		// forward/back navigation. If we're coming back from a non-client
+		// transition then we'll get un-suspended with the current page still
+		// active, but we'll also receive a history navigation popstate event.
+		//
+		// If we receive a popstate event for the current page, ignore it.
+		//
+		if (path === this._previousPath) return;
+		this._previousPath = path;
+
 		const opts = (state||{}).reactServerFrame;
 
 		if (check && !opts) return; // Not our frame.


### PR DESCRIPTION
Webkit's page cache keeps a suspended page available for re-activation on
back/forward navigation. The history navigation API also fires a popstate
event, though, which triggers an unnecessary re-render. We can skip this.

About the page cache:
https://webkit.org/blog/427/webkit-page-cache-i-the-basics/