### PR TITLE
[generator-react-server] Reference the correct file for the yeoman generator in package.json

### DIFF
--- a/packages/generator-react-server/package.json
+++ b/packages/generator-react-server/package.json
@@ -11,7 +11,7 @@
   "files": [
     "generators"
   ],
-  "main": "generators/index.js",
+  "main": "generators/app/index.js",
   "keywords": [
     "react-server",
     "react",


### PR DESCRIPTION
Hi there!

Instead of using the globally installed yeoman generator for this project, we're using a local version with `yeoman-environment`. When using the environment directly, we `require` this package in order to get a reference to the generator itself.

Unfortunately, the reference to the main in the package.json points to a file that doesn't exist. Everything seems to be fixed by fixing this one line :)

Let me know if this has any other implications. I don't think it should have any implications to the globally installed generator but I could be wrong.