### PR TITLE
larger than expected bundle files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3892,11 +3892,11 @@
       "version": "file:packages/babel-plugin-react-server",
       "requires": {
         "@babel/types": "^7.0.0",
-        "react-server-module-tagger": "^1.0.0-alpha.0"
+        "react-server-module-tagger": "^1.0.0-alpha.1"
       },
       "dependencies": {
         "react-server-module-tagger": {
-          "version": "0.6.0",
+          "version": "1.0.0-alpha.1",
           "bundled": true
         }
       }
@@ -3909,18 +3909,19 @@
         "@babel/preset-env": "^7.0.0",
         "@babel/preset-react": "^7.0.0",
         "@babel/runtime": "^7.0.0",
-        "babel-plugin-react-server": "^1.0.0-alpha.0"
+        "babel-plugin-react-server": "^1.0.0-alpha.1"
       },
       "dependencies": {
         "babel-plugin-react-server": {
-          "version": "0.6.0",
+          "version": "1.0.0-alpha.1",
           "bundled": true,
           "requires": {
-            "react-server-module-tagger": "^0.6.0"
+            "@babel/types": "^7.0.0",
+            "react-server-module-tagger": "^1.0.0-alpha.1"
           }
         },
         "react-server-module-tagger": {
-          "version": "0.6.0",
+          "version": "1.0.0-alpha.1",
           "bundled": true
         }
       }
@@ -23430,7 +23431,7 @@
         "cookie-parser": "1.4.3",
         "eventemitter3": "^2.0.2",
         "express-state": "^1.4.0",
-        "flab": "^1.0.0-alpha.0",
+        "flab": "^1.0.0-alpha.1",
         "lodash": "^4.16.4",
         "mobile-detect": "^1.3.5",
         "q": "1.4.1",
@@ -23441,7 +23442,7 @@
       },
       "dependencies": {
         "flab": {
-          "version": "0.6.3",
+          "version": "1.0.0-alpha.1",
           "bundled": true
         }
       }
@@ -23476,7 +23477,7 @@
         "q": "1.4.1",
         "raw-loader": "^2.0.0",
         "react-hot-loader": "^4.8.2",
-        "react-server-core-middleware": "^1.0.0-alpha.0",
+        "react-server-core-middleware": "^1.0.0-alpha.1",
         "sass-loader": "^7.1.0",
         "style-loader": "^0.23.1",
         "terser-webpack-plugin": "^1.2.3",
@@ -23503,7 +23504,7 @@
           }
         },
         "react-server-core-middleware": {
-          "version": "0.6.0",
+          "version": "1.0.0-alpha.1",
           "bundled": true
         },
         "supports-color": {
@@ -23532,11 +23533,11 @@
         "gulp-foreach": "0.1.0",
         "gulp-plumber": "^1.1.0",
         "gulp-replace": "^0.5.4",
-        "react-server-module-tagger": "^1.0.0-alpha.0"
+        "react-server-module-tagger": "^1.0.0-alpha.1"
       },
       "dependencies": {
         "react-server-module-tagger": {
-          "version": "0.6.0",
+          "version": "1.0.0-alpha.1",
           "bundled": true
         }
       }

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -213,11 +213,15 @@ module.exports = {
 					return {
 						done: function(cb) {`);
 			if (isClient) {
-				// No need for require.ensure() here because we are already splitting code based on the routes by having
-				// multiple entry points.  Using require.ensure() or import() will create unnecessary bundles as well
-				// as confuse the browser because it will load some JS/CSS files via FLAB and some via Webpack's
-				// dynamic loader.  Best to just stick with the basic implementation.
-				routesOutput.push(`cb(unwrapEs6Module(require(${relativePathToPage})));`);
+				// Turns out, for now, we do need to keep require.ensure() here.  This should be migrated to
+				// use import() in the future, but there's an issue with Babel not recognizing import() without
+				// another plugin: https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import/#installation
+				// The JS/CSS files loaded by FLAB are the entrypoint/initial files.  Webpack's dynamic loader
+				// handles loading the other chunks.
+				routesOutput.push(`
+							require.ensure(${relativePathToPage}, function() {
+								cb(unwrapEs6Module(require(${relativePathToPage})));
+							});`);
 			} else {
 				routesOutput.push(`
 							try {

--- a/packages/react-server-integration-tests/src/__tests__/css/CssSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/css/CssSpec.js
@@ -10,7 +10,9 @@ describe("A CSS page", () => {
 
 	describe("can apply a css class", () => {
 		helper.testWithDocument("/css", (document) => {
-			expect(document.querySelector("head link[rel=stylesheet]").href).toMatch(/route0\.css/);
+			// The way Webpack is chunking the CSS files, the client transition might look for 0.css while
+			// the server side looks for route0.css
+			expect(document.querySelector("head link[rel=stylesheet]").href).toMatch(/(?:route)?0\.css/);
 		});
 	});
 
@@ -26,9 +28,11 @@ describe("A CSS page with assets", () => {
 
 	describe("can apply a css class", () => {
 		helper.testWithDocument("/cssWithAssets", (document) => {
-      // this test is really just to make sure that react-server-cli doesn't explode
-      // when compiling CSS that includes images and fonts.
-			expect(document.querySelector("head link[rel=stylesheet]").href).toMatch(/route0\.css/);
+			// this test is really just to make sure that react-server-cli doesn't explode
+			// when compiling CSS that includes images and fonts.
+			// The way Webpack is chunking the CSS files, the client transition might look for 0.css while
+			// the server side looks for route0.css
+			expect(document.querySelector("head link[rel=stylesheet]").href).toMatch(/(?:route)?0\.css/);
 		});
 	});
 


### PR DESCRIPTION
During the conversion to Webpack 4, the entrypoint `require.ensure()` statement was removed and this caused larger than normal bundle files to be created.  This should probably be refactored again in the future, but for now this restores the original functionality while we develop better Webpack 4 defaults.